### PR TITLE
Implement full game systems enhancements

### DIFF
--- a/content/genesis/scenes/scene_1.4.json
+++ b/content/genesis/scenes/scene_1.4.json
@@ -3,9 +3,140 @@
   "content_id": "genesis",
   "book_id": "book_1",
   "scene_id": "1.4",
-  "title": "Placeholder Scene",
-  "narration": "This is placeholder text for a scene that has not yet been written.",
-  "rounds": [],
-  "threshold_rewards": [],
-  "arrivals": []
+  "title": "Chromatic Vault",
+  "narration": "The corridor blooms into a prism chamber. Four color-coded conduits whirl, humming with ledger energy.",
+  "rounds": [
+    {
+      "round_id": "1.4-R1",
+      "description": "Stabilize the converging colors",
+      "actions": [
+        {
+          "id": "trace_gold",
+          "label": "Trace the Gold Flow",
+          "roll": { "kind": "phi_d20", "tags": ["insight", "integrity"] },
+          "outcomes": {
+            "crit_success": {
+              "effects": [ { "type": "xp", "value": 60 }, { "type": "flag", "id": "gold_understood", "value": true } ],
+              "narration": "You follow the golden arc to its anchor. Ledger whispers reward your precision."
+            },
+            "success": {
+              "effects": [ { "type": "xp", "value": 30 } ],
+              "narration": "Golden motes align, hinting at a secure path ahead."
+            },
+            "fail": {
+              "effects": [ { "type": "focus", "op": "-", "value": 1 } ],
+              "narration": "The flow slips from your fingers, leaving static on your gloves."
+            },
+            "crit_fail": {
+              "effects": [ { "type": "focus", "op": "-", "value": 2 } ],
+              "narration": "The gold flares. Numbers scramble across your vision."
+            }
+          }
+        },
+        {
+          "id": "steady_teal",
+          "label": "Steady the Teal Current",
+          "roll": { "kind": "phi_d20", "tags": ["harmony", "ritual"] },
+          "outcomes": {
+            "crit_success": {
+              "effects": [ { "type": "coins", "value": 120 }, { "type": "flag", "id": "teal_attuned", "value": true } ],
+              "narration": "You breathe with the current. Teal coils wrap your party in balanced light."
+            },
+            "success": {
+              "effects": [ { "type": "coins", "value": 60 } ],
+              "narration": "The current hums, smoothing microfractures along the walls."
+            },
+            "fail": {
+              "effects": [ { "type": "hp", "op": "-", "value": 1 } ],
+              "narration": "A teal wave catches you off guard, knocking you back a step."
+            },
+            "crit_fail": {
+              "effects": [ { "type": "hp", "op": "-", "value": 2 } ],
+              "narration": "The current pulses unpredictably and slams into the party."
+            }
+          }
+        },
+        {
+          "id": "sync_magenta",
+          "label": "Sync Magenta Signals",
+          "roll": { "kind": "phi_d20", "tags": ["gremlin", "rush"] },
+          "outcomes": {
+            "crit_success": {
+              "effects": [ { "type": "xp", "value": 45 }, { "type": "coins", "value": 45 } ],
+              "narration": "Gremlin beacons flash in rhythm with your gestures, cheering wildly."
+            },
+            "success": {
+              "effects": [ { "type": "xp", "value": 25 } ],
+              "narration": "The magenta line stabilizes just enough to keep the chamber calm."
+            },
+            "fail": {
+              "effects": [ { "type": "coins", "op": "-", "value": 10 } ],
+              "narration": "The line jitters and siphons a handful of coins."
+            },
+            "crit_fail": {
+              "effects": [ { "type": "coins", "op": "-", "value": 25 } ],
+              "narration": "Magenta sparks scatter your reserves before sputtering out."
+            }
+          },
+          "telemetry_tags": ["neutral"]
+        }
+      ]
+    },
+    {
+      "round_id": "1.4-R2",
+      "description": "Reconcile the chromatic ledger",
+      "actions": [
+        {
+          "id": "cross_reference",
+          "label": "Cross-reference color ledgers",
+          "roll": { "kind": "phi_d20", "tags": ["integrity", "ritual"] },
+          "outcomes": {
+            "crit_success": {
+              "effects": [ { "type": "xp", "value": 70 }, { "type": "flag", "id": "chromatic_balance", "value": true } ],
+              "narration": "You align the ledger entries. The room rings with satisfied consensus."
+            },
+            "success": {
+              "effects": [ { "type": "xp", "value": 35 } ],
+              "narration": "Numbers balance; the path forward gains clarity."
+            },
+            "fail": {
+              "effects": [ { "type": "focus", "op": "-", "value": 2 } ],
+              "narration": "Contradictory hues tangle your focus."
+            },
+            "crit_fail": {
+              "effects": [ { "type": "focus", "op": "-", "value": 3 } ],
+              "narration": "The ledgers reject your input, swirling into chaos."
+            }
+          }
+        },
+        {
+          "id": "gremlin_consult",
+          "label": "Consult chromatic gremlins",
+          "roll": { "kind": "phi_d20", "tags": ["gremlin", "harmony"] },
+          "outcomes": {
+            "crit_success": {
+              "effects": [ { "type": "coins", "value": 90 }, { "type": "flag", "id": "gremlin_trust", "value": true } ],
+              "narration": "Gremlins hand you color-coded notes and salute."
+            },
+            "success": {
+              "effects": [ { "type": "coins", "value": 40 } ],
+              "narration": "They exchange hints for a cut of your shine."
+            },
+            "fail": {
+              "effects": [ { "type": "coins", "op": "-", "value": 15 } ],
+              "narration": "The gremlins demand a toll for wasted time."
+            },
+            "crit_fail": {
+              "effects": [ { "type": "coins", "op": "-", "value": 35 } ],
+              "narration": "You get pranked with paint bombs."
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "threshold_rewards": [
+    { "sleight_gte": 4, "rewards": [ { "type": "coins", "value": 150 }, { "type": "xp", "value": 50 } ] }
+  ],
+  "arrivals": [ { "when": "else", "goto": "1.5" } ]
 }

--- a/content/genesis/scenes/scene_1.5.json
+++ b/content/genesis/scenes/scene_1.5.json
@@ -3,9 +3,67 @@
   "content_id": "genesis",
   "book_id": "book_1",
   "scene_id": "1.5",
-  "title": "Placeholder Scene",
-  "narration": "This is placeholder text for a scene that has not yet been written.",
-  "rounds": [],
-  "threshold_rewards": [],
-  "arrivals": []
+  "title": "Resonance Junction",
+  "narration": "A nexus of sonic corridors awaits. Resonant plates vibrate with every motion, measuring the party's sleight.",
+  "rounds": [
+    {
+      "round_id": "1.5-R1",
+      "description": "Calibrate resonance plates",
+      "actions": [
+        {
+          "id": "harmonic_alignment",
+          "label": "Perform harmonic alignment",
+          "roll": { "kind": "phi_d20", "tags": ["harmony", "integrity"] },
+          "outcomes": {
+            "crit_success": { "effects": [ { "type": "xp", "value": 70 }, { "type": "coins", "value": 60 } ], "narration": "The junction sings back, storing your cadence for future boosts." },
+            "success": { "effects": [ { "type": "xp", "value": 35 } ], "narration": "You settle the plates into a gentle oscillation." },
+            "fail": { "effects": [ { "type": "focus", "op": "-", "value": 2 } ], "narration": "Feedback rattles through the chamber." },
+            "crit_fail": { "effects": [ { "type": "focus", "op": "-", "value": 3 } ], "narration": "The plates shriek, forcing you to cover your ears." }
+          }
+        },
+        {
+          "id": "echo_mapping",
+          "label": "Map echo corridors",
+          "roll": { "kind": "phi_d20", "tags": ["insight", "ritual"] },
+          "outcomes": {
+            "crit_success": { "effects": [ { "type": "flag", "id": "echo_map", "value": true }, { "type": "xp", "value": 60 } ], "narration": "Holographic pathways appear, revealing shortcuts." },
+            "success": { "effects": [ { "type": "xp", "value": 30 } ], "narration": "Your sketches catch the major routes." },
+            "fail": { "effects": [ { "type": "coins", "op": "-", "value": 15 } ], "narration": "Echo bait costs you a few coins." },
+            "crit_fail": { "effects": [ { "type": "coins", "op": "-", "value": 35 } ], "narration": "Gremlin guides lead you astray on purpose." }
+          }
+        }
+      ]
+    },
+    {
+      "round_id": "1.5-R2",
+      "description": "Ride the resonance wave",
+      "actions": [
+        {
+          "id": "surf_signal",
+          "label": "Surf the signal",
+          "roll": { "kind": "phi_d20", "tags": ["rush", "gremlin"] },
+          "outcomes": {
+            "crit_success": { "effects": [ { "type": "xp", "value": 40 }, { "type": "coins", "value": 80 } ], "narration": "You glide across the plates, leaving cheering gremlins." },
+            "success": { "effects": [ { "type": "coins", "value": 40 } ], "narration": "The wave carries you toward the next junction." },
+            "fail": { "effects": [ { "type": "hp", "op": "-", "value": 1 } ], "narration": "You stumble, bruising a shin on the plates." },
+            "crit_fail": { "effects": [ { "type": "hp", "op": "-", "value": 2 } ], "narration": "You wipe out spectacularly; gremlins hand you a pity scarf." }
+          },
+          "telemetry_tags": ["neutral"]
+        },
+        {
+          "id": "seal_portal",
+          "label": "Seal a destabilized portal",
+          "roll": { "kind": "phi_d20", "tags": ["integrity", "insight"] },
+          "outcomes": {
+            "crit_success": { "effects": [ { "type": "flag", "id": "portal_sealed", "value": true }, { "type": "xp", "value": 55 } ], "narration": "The portal locks in place with a satisfied chime." },
+            "success": { "effects": [ { "type": "xp", "value": 25 } ], "narration": "You reinforce the edges with stabilizing glyphs." },
+            "fail": { "effects": [ { "type": "focus", "op": "-", "value": 1 } ], "narration": "The seal resists, draining your focus." },
+            "crit_fail": { "effects": [ { "type": "focus", "op": "-", "value": 2 } ], "narration": "The portal snaps back and erupts with static." }
+          }
+        }
+      ]
+    }
+  ],
+  "threshold_rewards": [ { "sleight_gte": 5, "rewards": [ { "type": "coins", "value": 180 }, { "type": "xp", "value": 60 } ] } ],
+  "arrivals": [ { "when": "else", "goto": "1.6" } ]
 }

--- a/content/genesis/scenes/scene_1.6.json
+++ b/content/genesis/scenes/scene_1.6.json
@@ -3,9 +3,67 @@
   "content_id": "genesis",
   "book_id": "book_1",
   "scene_id": "1.6",
-  "title": "Placeholder Scene",
-  "narration": "This is placeholder text for a scene that has not yet been written.",
-  "rounds": [],
-  "threshold_rewards": [],
-  "arrivals": []
+  "title": "Gremlin Summit",
+  "narration": "A council of gremlin captains convenes around a floating ledger. They debate who should steer the next expedition.",
+  "rounds": [
+    {
+      "round_id": "1.6-R1",
+      "description": "Negotiate with captains",
+      "actions": [
+        {
+          "id": "champion_dev",
+          "label": "Champion the Dev Wizard",
+          "roll": { "kind": "phi_d20", "tags": ["insight", "integrity"] },
+          "outcomes": {
+            "crit_success": { "effects": [ { "type": "xp", "value": 80 }, { "type": "flag", "id": "captain_support", "value": "dev" } ], "narration": "They nod, impressed by your logic diagrams." },
+            "success": { "effects": [ { "type": "xp", "value": 40 } ], "narration": "You secure tentative support." },
+            "fail": { "effects": [ { "type": "focus", "op": "-", "value": 1 } ], "narration": "They counter with questions that fray your focus." },
+            "crit_fail": { "effects": [ { "type": "focus", "op": "-", "value": 3 } ], "narration": "Your argument glitches; they laugh kindly." }
+          }
+        },
+        {
+          "id": "back_trade",
+          "label": "Back the Trader captain",
+          "roll": { "kind": "phi_d20", "tags": ["trader", "gremlin"] },
+          "outcomes": {
+            "crit_success": { "effects": [ { "type": "coins", "value": 120 }, { "type": "flag", "id": "captain_support", "value": "trader" } ], "narration": "You structure a fair split; they clink ledgers in approval." },
+            "success": { "effects": [ { "type": "coins", "value": 60 } ], "narration": "Profitable numbers sway the room." },
+            "fail": { "effects": [ { "type": "coins", "op": "-", "value": 20 } ], "narration": "You cover a short-term deficit to keep the peace." },
+            "crit_fail": { "effects": [ { "type": "coins", "op": "-", "value": 40 } ], "narration": "Your math slips; they dock you for the trouble." }
+          },
+          "telemetry_tags": ["neutral"]
+        }
+      ]
+    },
+    {
+      "round_id": "1.6-R2",
+      "description": "Seal the alliance",
+      "actions": [
+        {
+          "id": "write_manifesto",
+          "label": "Draft a joint manifesto",
+          "roll": { "kind": "phi_d20", "tags": ["integrity", "ritual"] },
+          "outcomes": {
+            "crit_success": { "effects": [ { "type": "xp", "value": 75 }, { "type": "flag", "id": "gremlin_manifesto", "value": true } ], "narration": "The captains sign and stamp the parchment." },
+            "success": { "effects": [ { "type": "xp", "value": 30 } ], "narration": "You compile principles that keep the room unified." },
+            "fail": { "effects": [ { "type": "focus", "op": "-", "value": 1 } ], "narration": "Draft revisions wear you down." },
+            "crit_fail": { "effects": [ { "type": "focus", "op": "-", "value": 2 } ], "narration": "Arguments erupt over clause wording." }
+          }
+        },
+        {
+          "id": "gift_charm",
+          "label": "Offer gremlin charms",
+          "roll": { "kind": "phi_d20", "tags": ["gremlin", "harmony"] },
+          "outcomes": {
+            "crit_success": { "effects": [ { "type": "item", "id": "trinket_gremlin_charm" }, { "type": "coins", "value": 90 } ], "narration": "The captains adorn themselves with your gifts." },
+            "success": { "effects": [ { "type": "coins", "value": 45 } ], "narration": "They appreciate the gesture and pass around snacks." },
+            "fail": { "effects": [ { "type": "coins", "op": "-", "value": 15 } ], "narration": "Your charms fall apart mid-handshake." },
+            "crit_fail": { "effects": [ { "type": "coins", "op": "-", "value": 35 } ], "narration": "The charms explode in confetti; cleanup fees apply." }
+          }
+        }
+      ]
+    }
+  ],
+  "threshold_rewards": [ { "sleight_gte": 6, "rewards": [ { "type": "coins", "value": 200 }, { "type": "xp", "value": 70 } ] } ],
+  "arrivals": [ { "when": "else", "goto": "1.7" } ]
 }

--- a/content/genesis/scenes/scene_1.7.json
+++ b/content/genesis/scenes/scene_1.7.json
@@ -3,9 +3,67 @@
   "content_id": "genesis",
   "book_id": "book_1",
   "scene_id": "1.7",
-  "title": "Placeholder Scene",
-  "narration": "This is placeholder text for a scene that has not yet been written.",
-  "rounds": [],
-  "threshold_rewards": [],
-  "arrivals": []
+  "title": "Ledger Heart",
+  "narration": "You reach the vault's heart. A colossal gear of light records every choice made so far.",
+  "rounds": [
+    {
+      "round_id": "1.7-R1",
+      "description": "Present your ledger",
+      "actions": [
+        {
+          "id": "test_integrity",
+          "label": "Test integrity pathways",
+          "roll": { "kind": "phi_d20", "tags": ["integrity", "insight"] },
+          "outcomes": {
+            "crit_success": { "effects": [ { "type": "xp", "value": 90 }, { "type": "coins", "value": 120 } ], "narration": "The gear brightens, acknowledging your precise account." },
+            "success": { "effects": [ { "type": "xp", "value": 40 } ], "narration": "Your ledger holds. The heart rotates calmly." },
+            "fail": { "effects": [ { "type": "focus", "op": "-", "value": 2 } ], "narration": "Inconsistencies glare back at you." },
+            "crit_fail": { "effects": [ { "type": "focus", "op": "-", "value": 3 } ], "narration": "The heart stalls; adjustments required." }
+          }
+        },
+        {
+          "id": "offer_manifest",
+          "label": "Offer the manifest",
+          "roll": { "kind": "phi_d20", "tags": ["harmony", "ritual"] },
+          "outcomes": {
+            "crit_success": { "effects": [ { "type": "flag", "id": "ledger_honored", "value": true }, { "type": "xp", "value": 80 } ], "narration": "The heart etches your manifest along its rim." },
+            "success": { "effects": [ { "type": "xp", "value": 30 } ], "narration": "Your pledge resonates, granting a gentle boon." },
+            "fail": { "effects": [ { "type": "hp", "op": "-", "value": 1 } ], "narration": "The heart questions your pledge and taps your vitality." },
+            "crit_fail": { "effects": [ { "type": "hp", "op": "-", "value": 2 } ], "narration": "A backlash of light scorches your hands." }
+          },
+          "telemetry_tags": ["neutral"]
+        }
+      ]
+    },
+    {
+      "round_id": "1.7-R2",
+      "description": "Claim the heart's blessing",
+      "actions": [
+        {
+          "id": "sync_party",
+          "label": "Sync party heartbeat",
+          "roll": { "kind": "phi_d20", "tags": ["harmony", "gremlin"] },
+          "outcomes": {
+            "crit_success": { "effects": [ { "type": "xp", "value": 100 }, { "type": "coins", "value": 150 } ], "narration": "Everyone's heartbeat aligns with the vault—an unforgettable moment." },
+            "success": { "effects": [ { "type": "coins", "value": 60 } ], "narration": "You feel collectively empowered." },
+            "fail": { "effects": [ { "type": "focus", "op": "-", "value": 2 } ], "narration": "You miss a beat, wobbling slightly." },
+            "crit_fail": { "effects": [ { "type": "focus", "op": "-", "value": 3 } ], "narration": "The gear squeals; you scramble to stay upright." }
+          }
+        },
+        {
+          "id": "activate_reward",
+          "label": "Activate threshold reward",
+          "roll": { "kind": "phi_d20", "tags": ["integrity", "ritual"] },
+          "outcomes": {
+            "crit_success": { "effects": [ { "type": "item", "id": "reward_heartglyph" }, { "type": "xp", "value": 90 } ], "narration": "A Heartglyph materializes, pulsing with promise." },
+            "success": { "effects": [ { "type": "xp", "value": 45 } ], "narration": "The heart offers a moderate boon." },
+            "fail": { "effects": [ { "type": "coins", "op": "-", "value": 25 } ], "narration": "You pay into the ledger for another attempt later." },
+            "crit_fail": { "effects": [ { "type": "coins", "op": "-", "value": 60 } ], "narration": "The heart rejects your request and debits your account." }
+          }
+        }
+      ]
+    }
+  ],
+  "threshold_rewards": [ { "sleight_gte": 7, "rewards": [ { "type": "coins", "value": 250 }, { "type": "xp", "value": 120 } ] } ],
+  "arrivals": [ { "when": "else", "goto": "2.1" } ]
 }

--- a/content/seasons/christmas2025/manifest.json
+++ b/content/seasons/christmas2025/manifest.json
@@ -1,0 +1,8 @@
+{
+  "content_id": "seasons/christmas2025",
+  "version": "2025.1",
+  "book_name": "Room 6 — Frost Signal",
+  "description": "A limited-time hunt through crystalline corridors.",
+  "scenes": ["6.1"],
+  "schema_version": "1.0"
+}

--- a/content/seasons/christmas2025/scenes/scene_6.1.json
+++ b/content/seasons/christmas2025/scenes/scene_6.1.json
@@ -1,0 +1,258 @@
+{
+  "schema_version": "1.0",
+  "content_id": "seasons/christmas2025",
+  "book_id": "room6",
+  "scene_id": "6.1",
+  "title": "Frost Signal Arrival",
+  "narration": "Crystalline branches hang over Room 6. Gremlins drag strings of frosted lights while the vault hums a resonant carol.",
+  "rounds": [
+    {
+      "round_id": "6.1-R1",
+      "description": "First survey of the frost signal",
+      "actions": [
+        {
+          "id": "inspect_runes",
+          "label": "Inspect frozen runes",
+          "roll": { "kind": "phi_d20", "tags": ["insight", "ritual"] },
+          "outcomes": {
+            "crit_success": {
+              "effects": [
+                { "type": "xp", "value": 40 },
+                { "type": "flag", "id": "frost_runes", "value": true }
+              ],
+              "narration": "You decipher the frost glyphs and note their harmonic cadence."
+            },
+            "success": {
+              "effects": [
+                { "type": "xp", "value": 20 }
+              ],
+              "narration": "The glyphs glow softly, revealing a calming pattern."
+            },
+            "fail": {
+              "effects": [
+                { "type": "focus", "op": "-", "value": 1 }
+              ],
+              "narration": "Your breath fogs the rune and the pattern slips away."
+            },
+            "crit_fail": {
+              "effects": [
+                { "type": "focus", "op": "-", "value": 2 }
+              ],
+              "narration": "The rune flashes and a shard of chill nicks your focus."
+            }
+          }
+        },
+        {
+          "id": "join_carol",
+          "label": "Join gremlin carol",
+          "roll": { "kind": "phi_d20", "tags": ["harmony", "gremlin"] },
+          "outcomes": {
+            "crit_success": {
+              "effects": [
+                { "type": "coins", "value": 75 },
+                { "type": "flag", "id": "carol_spirit", "value": true }
+              ],
+              "narration": "You lead the chorus, gremlins tossing silver petals at your feet."
+            },
+            "success": {
+              "effects": [
+                { "type": "coins", "value": 40 }
+              ],
+              "narration": "The gremlins echo your rhythm and the vault warms a fraction."
+            },
+            "fail": {
+              "effects": [
+                { "type": "hp", "op": "-", "value": 1 }
+              ],
+              "narration": "A gremlin misfires a bell and it bonks your shoulder."
+            },
+            "crit_fail": {
+              "effects": [
+                { "type": "hp", "op": "-", "value": 2 }
+              ],
+              "narration": "Your voice cracks and the choir dissolves into chaotic laughter."
+            }
+          }
+        },
+        {
+          "id": "stoke_braziers",
+          "label": "Stoke crystalline braziers",
+          "roll": { "kind": "phi_d20", "tags": ["rush", "integrity"] },
+          "outcomes": {
+            "crit_success": {
+              "effects": [
+                { "type": "coins", "value": 60 },
+                { "type": "xp", "value": 20 }
+              ],
+              "narration": "Heat ripples along the walls and hidden mosaics blink awake."
+            },
+            "success": {
+              "effects": [
+                { "type": "coins", "value": 30 }
+              ],
+              "narration": "The braziers shimmer, keeping the frost at bay."
+            },
+            "fail": {
+              "effects": [
+                { "type": "hp", "op": "-", "value": 1 }
+              ],
+              "narration": "Sparks lick your gloves as the brazier sputters."
+            },
+            "crit_fail": {
+              "effects": [
+                { "type": "hp", "op": "-", "value": 3 }
+              ],
+              "narration": "A shard pops loose and skitters down your arm."
+            }
+          }
+        },
+        {
+          "id": "trade_tokens",
+          "label": "Trade frost tokens",
+          "roll": { "kind": "phi_d20", "tags": ["trader", "gremlin"] },
+          "outcomes": {
+            "crit_success": {
+              "effects": [
+                { "type": "coins", "value": 120 }
+              ],
+              "narration": "The gremlins hand you a pouch of minted frost credits."
+            },
+            "success": {
+              "effects": [
+                { "type": "coins", "value": 55 }
+              ],
+              "narration": "You swap trinkets for a tidy stack of coins."
+            },
+            "fail": {
+              "effects": [
+                { "type": "coins", "op": "-", "value": 10 }
+              ],
+              "narration": "A gremlin pockets a shiny and shrugs innocently."
+            },
+            "crit_fail": {
+              "effects": [
+                { "type": "coins", "op": "-", "value": 25 }
+              ],
+              "narration": "The trade stalls and your tokens melt uselessly."
+            }
+          },
+          "telemetry_tags": ["neutral"]
+        }
+      ]
+    },
+    {
+      "round_id": "6.1-R2",
+      "description": "Redirect the signal",
+      "actions": [
+        {
+          "id": "align_prisms",
+          "label": "Align frost prisms",
+          "roll": { "kind": "phi_d20", "tags": ["insight", "integrity"] },
+          "outcomes": {
+            "crit_success": {
+              "effects": [
+                { "type": "xp", "value": 60 },
+                { "type": "flag", "id": "prism_harmony", "value": true }
+              ],
+              "narration": "Prisms snap into a precise lattice and the vault applauds with resonant bells."
+            },
+            "success": {
+              "effects": [
+                { "type": "xp", "value": 30 }
+              ],
+              "narration": "You nudge the prisms and the beam stabilizes."
+            },
+            "fail": {
+              "effects": [
+                { "type": "focus", "op": "-", "value": 2 }
+              ],
+              "narration": "Reflections blur, leaving a headache of light."
+            },
+            "crit_fail": {
+              "effects": [
+                { "type": "focus", "op": "-", "value": 3 }
+              ],
+              "narration": "Prisms scatter and a shard of light briefly blinds you."
+            }
+          }
+        },
+        {
+          "id": "harness_aura",
+          "label": "Harness aurora",
+          "roll": { "kind": "phi_d20", "tags": ["harmony", "ritual"] },
+          "outcomes": {
+            "crit_success": {
+              "effects": [
+                { "type": "xp", "value": 45 },
+                { "type": "coins", "value": 80 }
+              ],
+              "narration": "You bottle the aurora and the party gains a luminous aura."
+            },
+            "success": {
+              "effects": [
+                { "type": "coins", "value": 40 }
+              ],
+              "narration": "Threads of light wrap around your party like scarves."
+            },
+            "fail": {
+              "effects": [
+                { "type": "hp", "op": "-", "value": 1 }
+              ],
+              "narration": "Static zaps your hand and the aurora flickers away."
+            },
+            "crit_fail": {
+              "effects": [
+                { "type": "hp", "op": "-", "value": 2 }
+              ],
+              "narration": "The aurora recoils and leaves frostbite kisses." 
+            }
+          }
+        },
+        {
+          "id": "gift_ledger",
+          "label": "Offer ledger gift",
+          "roll": { "kind": "phi_d20", "tags": ["integrity", "trader"] },
+          "outcomes": {
+            "crit_success": {
+              "effects": [
+                { "type": "item", "id": "gift_frostsigil" },
+                { "type": "xp", "value": 30 }
+              ],
+              "narration": "The vault returns a Frost Sigil to wear proudly."
+            },
+            "success": {
+              "effects": [
+                { "type": "coins", "value": 50 }
+              ],
+              "narration": "Your offering impresses the watchers."
+            },
+            "fail": {
+              "effects": [
+                { "type": "coins", "op": "-", "value": 15 }
+              ],
+              "narration": "The gift cracks and slides into a drain."
+            },
+            "crit_fail": {
+              "effects": [
+                { "type": "coins", "op": "-", "value": 30 }
+              ],
+              "narration": "Gremlins giggle and abscond with your satchel."
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "threshold_rewards": [
+    {
+      "sleight_gte": 4,
+      "rewards": [
+        { "type": "coins", "value": 120 },
+        { "type": "xp", "value": 50 }
+      ]
+    }
+  ],
+  "arrivals": [
+    { "when": "else", "goto": "6.1" }
+  ]
+}

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,90 +1,357 @@
-import { Client, GatewayIntentBits, Partials, Events, ChannelType, ActionRowBuilder, ButtonBuilder, ButtonStyle, TextChannel, SlashCommandBuilder, REST, Routes, ButtonInteraction } from 'discord.js';
+import {
+  Client,
+  GatewayIntentBits,
+  Partials,
+  Events,
+  ChannelType,
+  TextChannel,
+  SlashCommandBuilder,
+  SlashCommandUserOption,
+  SlashCommandIntegerOption,
+  REST,
+  Routes,
+  ButtonInteraction,
+  StringSelectMenuInteraction,
+  Message,
+  Interaction,
+} from 'discord.js';
 import { CFG } from './config.js';
 import db from './persistence/db.js';
-import { startRun } from './engine/orchestrator.js';
-import { renderScene, onButton, showShop } from './ui/ui.js';
+import { onButton, showShop, onSelectMenu, syncPinnedUi } from './ui/ui.js';
+import {
+  showRoleSelection,
+  getCurrentRole,
+  startRoleBasedRun,
+  joinGameWithRole,
+  showUserGames,
+  getUserActiveRuns,
+  getRoleById,
+} from './ui/roles.js';
+import { claimWeeklyReward } from './ui/shop.js';
+import { renderEquipment } from './ui/equipment.js';
+import { attemptSelfReboot, attemptAllyRevive } from './ui/recovery.js';
+import { startMinigame, handleMinigameButton } from './ui/minigames.js';
+import { listSeasons, startSeasonalRun } from './ui/seasonal.js';
+import { listCraftables, craftItem } from './ui/crafting.js';
+import { queueForMatch, listActiveMatches, recordPvPAction, concludeMatch } from './pvp/duels.js';
+import { processAfkTimeouts } from './engine/orchestrator.js';
+import { guildHasLicense, featureEnabled } from './persistence/licensing.js';
+import { getGuildSettings } from './persistence/settings.js';
 
 export const client = new Client({
   intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent, GatewayIntentBits.GuildMembers],
-  partials: [Partials.Message, Partials.Channel]
+  partials: [Partials.Message, Partials.Channel],
 });
 
 (globalThis as any)._client = client;
 
-client.once(Events.ClientReady, async (c)=>{
-  console.log(`Logged in as ${c.user.tag}`);
+function scheduleDecay(messagePromise: Promise<any>) {
+  messagePromise
+    .then((msg) => {
+      if (!msg) return;
+      setTimeout(() => {
+        msg.delete().catch(() => {});
+      }, 45 * 60 * 1000);
+    })
+    .catch(() => {});
+}
+
+function ensureFeatureAccess(message: Message, feature: string) {
+  const guildId = message.guild?.id ?? null;
+  if (!guildId) {
+    return true;
+  }
+  if (!guildHasLicense(guildId)) {
+    scheduleDecay(
+      message.reply({
+        content: '❌ This server is not licensed for LedgerLegends. Contact the bot owner to activate a subscription.',
+      })
+    );
+    return false;
+  }
+  if (!featureEnabled(guildId, feature)) {
+    scheduleDecay(message.reply({ content: '❌ This feature is not enabled for this server.' }));
+    return false;
+  }
+  return true;
+}
+
+client.once(Events.ClientReady, async (c: Client<true>) => {
+  const tag = c.user?.tag ?? 'unknown user';
+  console.log(`Logged in as ${tag}`);
   await registerSlash();
+  setInterval(async () => {
+    const events = processAfkTimeouts();
+    for (const evt of events) {
+      try {
+        const channel = await client.channels.fetch(evt.channel_id);
+        if (channel && channel.isTextBased()) {
+          if (evt.message) {
+            await (channel as TextChannel).send({ content: evt.message });
+          }
+          if (evt.refresh) {
+            await syncPinnedUi(channel as TextChannel, evt.run_id);
+          }
+        }
+      } catch (err) {
+        console.error('Failed to broadcast AFK timeout', err);
+      }
+    }
+  }, 60_000);
 });
 
-client.on(Events.MessageCreate, async (m)=>{
+client.on(Events.MessageCreate, async (m: Message) => {
   if (m.author.bot) return;
   const lc = m.content.trim().toLowerCase();
-  // ensure profile
   const exists = db.prepare('SELECT 1 FROM users WHERE user_id=?').get(m.author.id);
-  if (!exists){
+  if (!exists) {
     db.prepare('INSERT INTO users (user_id, discord_id, created_at) VALUES (?,?,?)').run(m.author.id, m.author.id, Date.now());
     db.prepare('INSERT INTO profiles (user_id, coins, gems) VALUES (?, ?, ?)').run(m.author.id, 0, 0);
   }
 
-  // GM/GN ritual
-  if (lc === 'gm' || lc === 'gn'){
+  if (lc === 'gm' || lc === 'gn') {
+    if (!ensureFeatureAccess(m, 'campaign')) return;
     const prof = db.prepare('SELECT * FROM profiles WHERE user_id=?').get(m.author.id);
     const now = Date.now();
-    const last = lc==='gm' ? (prof?.last_gm_ts||0) : (prof?.last_gn_ts||0);
+    const last = lc === 'gm' ? prof?.last_gm_ts ?? 0 : prof?.last_gn_ts ?? 0;
     const delta = now - last;
-    const can = delta >= 4*60*60*1000;
-    const claims = db.prepare(`SELECT COUNT(*) c FROM events WHERE user_id=? AND type='ritual.claim' AND ts > ?`).get(m.author.id, now-24*60*60*1000).c;
-    if (can && claims < 2){
-      db.prepare('UPDATE profiles SET coins=coins+?, xp=xp+?, '+(lc==='gm'?'last_gm_ts=?':'last_gn_ts=?')+' WHERE user_id=?')
-        .run(25, 1, now, m.author.id);
+    const can = delta >= 4 * 60 * 60 * 1000;
+    const claims = db
+      .prepare(`SELECT COUNT(*) c FROM events WHERE user_id=? AND type='ritual.claim' AND ts > ?`)
+      .get(m.author.id, now - 24 * 60 * 60 * 1000).c;
+    if (can && claims < 2) {
+      const settings = getGuildSettings(m.guild?.id);
+      const coinsAward = lc === 'gm' ? settings.gm_reward : settings.gn_reward;
+      const xpAward = settings.xp_reward;
+      const column = lc === 'gm' ? 'last_gm_ts' : 'last_gn_ts';
+      db.prepare(
+        `UPDATE profiles SET coins=coins+?, xp=xp+?, ${column}=? WHERE user_id=?`
+      ).run(coinsAward, xpAward, now, m.author.id);
       db.prepare('INSERT INTO events (event_id, run_id, user_id, type, payload_json, ts) VALUES (?,?,?,?,?,?)')
-        .run(`${m.id}`, '', m.author.id, 'ritual.claim', JSON.stringify({kind:lc}), now);
-      await m.reply({ content:`☀️ **${lc.toUpperCase()}!** You earned +25 Coins, +1 XP.` });
+        .run(`${m.id}`, '', m.author.id, 'ritual.claim', JSON.stringify({ kind: lc }), now);
+      await m.reply({
+        content: `☀️ **${lc.toUpperCase()}!** You earned +${coinsAward.toLocaleString()} Coins, +${xpAward} XP.`,
+      });
     } else {
-      await m.reply({ content:`(Ritual on cooldown or max 2/day reached.)` });
+      scheduleDecay(m.reply({ content: '(Ritual on cooldown or max 2/day reached.)' }));
+    }
+    return;
+  }
+
+  if (lc === '!role') {
+    const view = await showRoleSelection(m.author.id);
+    await m.reply(view);
+    return;
+  }
+
+  if (lc === '!games') {
+    scheduleDecay(m.reply({ content: showUserGames(m.author.id) }));
+    return;
+  }
+
+  if (lc === '!resume') {
+    if (!ensureFeatureAccess(m, 'campaign')) return;
+    const runs = getUserActiveRuns(m.author.id);
+    if (runs.length === 0) {
+      await m.reply({ content: '❌ No active games to resume.' });
+      return;
+    }
+    if (!m.guild || m.channel.type !== ChannelType.GuildText) return;
+    const latest = runs[0];
+    await syncPinnedUi(m.channel as TextChannel, latest.run_id);
+    await m.reply({ content: `▶️ Resumed Scene ${latest.current_scene_id} (${latest.round_id}).` });
+    return;
+  }
+
+  if (lc === '!weekly') {
+    if (!ensureFeatureAccess(m, 'shop')) return;
+    const reward = claimWeeklyReward(m.author.id);
+    if (!reward.success) {
+      scheduleDecay(m.reply({ content: '❌ Weekly reward already claimed.' }));
+    } else {
+      await m.reply({ content: `📅 Weekly reward claimed! +${reward.amount?.toLocaleString()} coins (streak ${reward.streak}).` });
+    }
+    return;
+  }
+
+  if (lc === '!loadout') {
+    if (!ensureFeatureAccess(m, 'campaign')) return;
+    const view = await renderEquipment(m.author.id);
+    await m.reply(view);
+    return;
+  }
+
+  if (lc === '!crafts') {
+    if (!ensureFeatureAccess(m, 'shop')) return;
+    const lines = listCraftables().map((c) => `${c.id} — ${c.costFragments} fragments`).join('\n');
+    scheduleDecay(m.reply({ content: `🛠️ Available recipes:\n${lines}` }));
+    return;
+  }
+
+  if (lc.startsWith('!craft ')) {
+    if (!ensureFeatureAccess(m, 'shop')) return;
+    const parts = m.content.trim().split(/\s+/);
+    const recipeId = parts[1];
+    const res = craftItem(m.author.id, recipeId);
+    scheduleDecay(m.reply({ content: res.message }));
+    return;
+  }
+
+  if (lc === '!reboot') {
+    if (!ensureFeatureAccess(m, 'campaign')) return;
+    const res = attemptSelfReboot(m.author.id);
+    scheduleDecay(m.reply({ content: res.message }));
+    return;
+  }
+
+  if (lc.startsWith('!revive')) {
+    if (!ensureFeatureAccess(m, 'campaign')) return;
+    const target = m.mentions.users.first();
+    if (!target) {
+      scheduleDecay(m.reply({ content: '❌ Mention a user to revive.' }));
+      return;
+    }
+    const res = attemptAllyRevive(m.author.id, target.id);
+    await m.reply({ content: res.message });
+    return;
+  }
+
+  if (lc.startsWith('!minigame')) {
+    if (!ensureFeatureAccess(m, 'minigames')) return;
+    const parts = m.content.trim().split(/\s+/);
+    const type = (parts[1] as any) || 'memory';
+    const { embed, row } = startMinigame(m.author.id, type);
+    await m.reply({ embeds: [embed], components: [row] });
+    return;
+  }
+
+  if (lc.startsWith('!season')) {
+    if (!ensureFeatureAccess(m, 'seasonal')) return;
+    const parts = m.content.trim().split(/\s+/);
+    if (!parts[1]) {
+      const seasons = listSeasons();
+      const lines = seasons.map((s) => `${s.id} (${s.version}) — ${s.description}`).join('\n');
+      scheduleDecay(m.reply({ content: lines || 'No seasons loaded.' }));
+      return;
+    }
+    if (parts[1] === 'start' && parts[2]) {
+      if (m.channel.type !== ChannelType.GuildText) return;
+      try {
+        const run_id = startSeasonalRun(m.author.id, m.guild!.id, (m.channel as TextChannel).id, parts[2]);
+        await syncPinnedUi(m.channel as TextChannel, run_id);
+        await m.reply({ content: `🎄 Seasonal run started: ${parts[2]}` });
+      } catch (err: any) {
+        scheduleDecay(m.reply({ content: `❌ ${err.message ?? 'Failed to start season.'}` }));
+      }
+      return;
     }
   }
 
-  // quick start
-  if (lc === '!start'){
+  if (lc.startsWith('!pvp')) {
+    if (!ensureFeatureAccess(m, 'pvp')) return;
+    const parts = m.content.trim().split(/\s+/);
+    const sub = parts[1] ?? 'queue';
+    if (sub === 'queue') {
+      const mode = (parts[2] as any) || '1v1';
+      const res = queueForMatch(m.author.id, mode);
+      scheduleDecay(m.reply({ content: res.message }));
+      return;
+    }
+    if (sub === 'matches') {
+      const matches = listActiveMatches();
+      const lines = matches.map((match) => `${match.matchId}: ${match.participants.join(', ')} ${JSON.stringify(match.scores)}`).join('\n');
+      scheduleDecay(m.reply({ content: lines || 'No active matches.' }));
+      return;
+    }
+    if (sub === 'report' && parts[2] && parts[3]) {
+      const res = recordPvPAction(parts[2], m.author.id, parts[3] as any);
+      scheduleDecay(m.reply({ content: res.message }));
+      return;
+    }
+    if (sub === 'conclude' && parts[2]) {
+      const res = concludeMatch(parts[2]);
+      scheduleDecay(m.reply({ content: res.success ? `Match ${parts[2]} complete. Winner <@${res.winner}>` : 'Unable to conclude.' }));
+      return;
+    }
+  }
+
+  if (lc === '!tutorial') {
+    if (!ensureFeatureAccess(m, 'campaign')) return;
+    const currentRole = getCurrentRole(m.author.id);
+    if (!currentRole?.selected_role) {
+      const view = await showRoleSelection(m.author.id, true);
+      await m.reply({ content: '❌ Please select a role first.', ...view });
+      return;
+    }
+    if (!m.guild || m.channel.type !== ChannelType.GuildText) return;
+    const run_id = startRoleBasedRun(m.author.id, currentRole.selected_role, '1.1', {
+      is_tutorial: true,
+      guild_id: m.guild.id,
+      channel_id: (m.channel as TextChannel).id,
+    });
+    await syncPinnedUi(m.channel as TextChannel, run_id);
+    const roleInfo = getRoleById(currentRole.selected_role);
+    await m.reply({ content: `🔄 Tutorial restarted as ${roleInfo?.emoji ?? '🎭'} ${roleInfo?.name ?? 'Adventurer'}!` });
+    return;
+  }
+
+  if (lc.startsWith('!start')) {
+    if (!ensureFeatureAccess(m, 'campaign')) return;
     if (m.channel.type !== ChannelType.GuildText) return;
-    const run_id = startRun(m.guild!.id, m.channelId, [m.author.id]);
-    const payload = await renderScene(run_id);
-    await (m.channel as TextChannel).send(payload);
-    const shopRow = new ActionRowBuilder<ButtonBuilder>()
-      .addComponents(new ButtonBuilder().setCustomId('shop:open:genesis').setLabel('Open Shop').setStyle(ButtonStyle.Primary));
-    await (m.channel as TextChannel).send({ content:'Open the shop:', components:[shopRow] });
+    const parts = m.content.trim().split(/\s+/);
+    const sceneId = parts[1] ?? '1.1';
+    const join = joinGameWithRole(m.author.id, sceneId, m.guild!.id, (m.channel as TextChannel).id);
+    if (!join.success) {
+      const view = await showRoleSelection(m.author.id);
+      await m.reply({ content: join.message, ...view });
+      return;
+    }
+    await syncPinnedUi(m.channel as TextChannel, join.run_id!);
+    await m.reply({ content: join.message });
+    return;
   }
 });
 
-client.on(Events.InteractionCreate, async (i)=>{
-  if (i.isButton()){
-    if (i.customId.startsWith('shop:open')) return showShop(i as ButtonInteraction);
-    if (i.customId.startsWith('act:') || i.customId.startsWith('shop:')) return onButton(i as ButtonInteraction);
+client.on(Events.InteractionCreate, async (i: Interaction) => {
+  if (i.isButton()) {
+    if (i.customId === 'shop:open') return showShop(i as ButtonInteraction);
+    if (i.customId.startsWith('minigame:')) return handleMinigameButton(i as ButtonInteraction);
+    return onButton(i as ButtonInteraction);
   }
-  if (i.isChatInputCommand()){
-    if (i.commandName === 'admin_gems_grant'){
-      if (i.user.id !== CFG.ownerId) return i.reply({ ephemeral:true, content:'Not allowed' });
+  if (i.isStringSelectMenu()) {
+    return onSelectMenu(i as StringSelectMenuInteraction);
+  }
+  if (i.isChatInputCommand()) {
+    if (i.commandName === 'admin_gems_grant') {
+      if (i.user.id !== CFG.ownerId) return i.reply({ ephemeral: true, content: 'Not allowed' });
       const who = i.options.getUser('user', true);
       const amt = i.options.getInteger('amount', true);
       db.prepare('UPDATE profiles SET gems=gems+? WHERE user_id=?').run(amt, who.id);
       db.prepare('INSERT INTO economy_ledger (txn_id,user_id,kind,amount,reason,meta_json,ts) VALUES (?,?,?,?,?,?,?)')
         .run(`txn_${Date.now()}`, who.id, 'gem_grant', amt, 'admin_grant', '{}', Date.now());
-      return i.reply({ ephemeral:true, content:`Granted ${amt} Gems to ${who.tag}` });
+      return i.reply({ ephemeral: true, content: `Granted ${amt} Gems to ${who.tag}` });
     }
   }
 });
 
-async function registerSlash(){
-  const rest = new REST({version: '10'}).setToken(CFG.token);
+async function registerSlash() {
+  const rest = new REST({ version: '10' }).setToken(CFG.token);
   const body = [
-    new SlashCommandBuilder().setName('admin_gems_grant').setDescription('Grant Gems to a user (owner only)')
-      .addUserOption(o=>o.setName('user').setDescription('User').setRequired(true))
-      .addIntegerOption(o=>o.setName('amount').setDescription('Amount').setRequired(true))
-      .toJSON()
+    new SlashCommandBuilder()
+      .setName('admin_gems_grant')
+      .setDescription('Grant Gems to a user (owner only)')
+      .addUserOption((o: SlashCommandUserOption) =>
+        o.setName('user').setDescription('User').setRequired(true)
+      )
+      .addIntegerOption((o: SlashCommandIntegerOption) =>
+        o.setName('amount').setDescription('Amount').setRequired(true)
+      )
+      .toJSON(),
   ];
   try {
     await rest.put(Routes.applicationCommands(CFG.clientId), { body });
     console.log('Slash commands registered.');
-  } catch (e){ console.error(e); }
+  } catch (e) {
+    console.error(e);
+  }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,26 @@ export const CFG = {
   dbPath: process.env.DATABASE_PATH || './data/bot.db',
   botName: process.env.BOT_NAME || 'LedgerLegends',
   contentRoot: './content',
+  dashboardPort: Number(process.env.DASHBOARD_PORT || 0),
+  dashboardClientId: process.env.DASHBOARD_CLIENT_ID || '',
+  dashboardClientSecret: process.env.DASHBOARD_CLIENT_SECRET || '',
+  dashboardRedirectUri: process.env.DASHBOARD_REDIRECT_URI || '',
+  dashboardSessionSecret: process.env.DASHBOARD_SESSION_SECRET || '',
+  dashboardBaseUrl: process.env.DASHBOARD_BASE_URL || '',
+  homeGuildId: process.env.HOME_GUILD_ID || '',
+  allowedGuilds: (process.env.ALLOWED_GUILD_IDS || '')
+    .split(',')
+    .map((g) => g.trim())
+    .filter(Boolean),
+  gemWebhookSecret: process.env.GEM_WEBHOOK_SECRET || '',
 };
 
 if (!CFG.token) throw new Error('Missing DISCORD_TOKEN in .env');
+
+if (CFG.dashboardPort && !CFG.dashboardSessionSecret) {
+  throw new Error('Missing DASHBOARD_SESSION_SECRET for dashboard authentication');
+}
+
+if (CFG.dashboardPort && (!CFG.dashboardClientId || !CFG.dashboardClientSecret || !CFG.dashboardRedirectUri)) {
+  throw new Error('Dashboard OAuth configuration incomplete. Set DASHBOARD_CLIENT_ID, DASHBOARD_CLIENT_SECRET, and DASHBOARD_REDIRECT_URI.');
+}

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -1,0 +1,551 @@
+import * as http from 'node:http';
+import url from 'node:url';
+import crypto from 'node:crypto';
+import { CFG } from '../config.js';
+import db from '../persistence/db.js';
+import { getGuildSettings, upsertGuildSettings } from '../persistence/settings.js';
+import { listLicenses, upsertLicense, setFeatureFlag } from '../persistence/licensing.js';
+import { listGemOrders, recordGemPurchase, verifyWebhookSignature, GemPurchasePayload } from '../payments/gems.js';
+import { loadManifest } from '../content/contentLoader.js';
+
+interface DiscordGuildSummary {
+  id: string;
+  name: string;
+  permissions: string;
+}
+
+interface DashboardUser {
+  id: string;
+  username: string;
+  discriminator: string;
+  avatar?: string | null;
+  guilds: DiscordGuildSummary[];
+  accessibleGuilds: string[];
+}
+
+interface SessionRecord {
+  id: string;
+  user?: DashboardUser;
+  state?: string;
+  expiresAt: number;
+}
+
+const sessions = new Map<string, SessionRecord>();
+const SESSION_COOKIE = 'ledger_session';
+const SESSION_TTL = 1000 * 60 * 60 * 8; // 8 hours
+const MANAGE_GUILD = BigInt(1 << 5);
+
+function now() {
+  return Date.now();
+}
+
+function parseCookies(header?: string) {
+  const result: Record<string, string> = {};
+  if (!header) return result;
+  const parts = header.split(';');
+  for (const part of parts) {
+    const [k, v] = part.trim().split('=');
+    if (k && v) result[k] = decodeURIComponent(v);
+  }
+  return result;
+}
+
+function createSession(res: http.ServerResponse): SessionRecord {
+  const id = crypto.randomBytes(18).toString('hex');
+  const record: SessionRecord = { id, expiresAt: now() + SESSION_TTL };
+  sessions.set(id, record);
+  res.setHeader('Set-Cookie', `${SESSION_COOKIE}=${id}; HttpOnly; Path=/; Max-Age=${SESSION_TTL / 1000}; SameSite=Lax`);
+  return record;
+}
+
+function getSession(req: http.IncomingMessage, res: http.ServerResponse): SessionRecord {
+  const cookies = parseCookies(req.headers.cookie);
+  const sid = cookies[SESSION_COOKIE];
+  if (sid) {
+    const record = sessions.get(sid);
+    if (record && record.expiresAt > now()) {
+      record.expiresAt = now() + SESSION_TTL;
+      return record;
+    }
+    sessions.delete(sid);
+  }
+  return createSession(res);
+}
+
+function destroySession(res: http.ServerResponse, session: SessionRecord) {
+  sessions.delete(session.id);
+  res.setHeader('Set-Cookie', `${SESSION_COOKIE}=; HttpOnly; Path=/; Max-Age=0; SameSite=Lax`);
+}
+
+function hasManageGuild(permissions: string | number): boolean {
+  try {
+    const value = typeof permissions === 'string' ? BigInt(permissions) : BigInt(permissions);
+    return (value & MANAGE_GUILD) === MANAGE_GUILD;
+  } catch {
+    return false;
+  }
+}
+
+function isOwner(user?: DashboardUser) {
+  return Boolean(user && CFG.ownerId && user.id === CFG.ownerId);
+}
+
+function canManageGuild(user: DashboardUser, guild_id: string) {
+  if (isOwner(user)) return true;
+  return user.accessibleGuilds.includes(guild_id);
+}
+
+function guildLabel(user: DashboardUser, guild_id: string) {
+  const match = user.guilds.find((g) => g.id === guild_id);
+  if (match) return `${match.name} (${guild_id})`;
+  if (guild_id === CFG.homeGuildId) return `Home Guild (${guild_id})`;
+  return guild_id;
+}
+
+function htmlEscape(value: string) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function sendHtml(res: http.ServerResponse, status: number, body: string) {
+  res.writeHead(status, { 'Content-Type': 'text/html; charset=utf-8' });
+  res.end(body);
+}
+
+function sendJson(res: http.ServerResponse, status: number, payload: any) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(payload));
+}
+
+function redirect(res: http.ServerResponse, location: string) {
+  res.writeHead(302, { Location: location });
+  res.end();
+}
+
+async function readBody(req: http.IncomingMessage): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
+
+function renderDashboard(user: DashboardUser) {
+  const licenses = listLicenses();
+  const licenseMap = new Map(licenses.map((lic) => [lic.guild_id, lic]));
+  const manifest = loadManifest('genesis');
+  const orders = isOwner(user) ? listGemOrders(20) : [];
+  const guildIds = Array.from(new Set(user.accessibleGuilds));
+
+  const economyRows = guildIds
+    .map((guild_id) => {
+      const settings = getGuildSettings(guild_id);
+      const tier = licenseMap.get(guild_id)?.tier ?? '—';
+      return `<tr><td>${htmlEscape(guildLabel(user, guild_id))}</td><td>${tier}</td><td>${settings.gm_reward}</td><td>${settings.gn_reward}</td><td>${settings.xp_reward}</td><td>${settings.difficulty_bias}</td></tr>`;
+    })
+    .join('');
+
+  const guildOptions = guildIds
+    .map((guild_id) => `<option value="${guild_id}">${htmlEscape(guildLabel(user, guild_id))}</option>`)
+    .join('');
+
+  const licenseRows = licenses
+    .map((lic) => {
+      const expires = lic.expires_at ? new Date(lic.expires_at).toISOString() : '—';
+      return `<tr><td>${lic.guild_id}</td><td>${lic.tier ?? '—'}</td><td>${htmlEscape(lic.features_json ?? '[]')}</td><td>${expires}</td></tr>`;
+    })
+    .join('');
+
+  const ordersRows = orders
+    .map(
+      (order: any) =>
+        `<tr><td>${order.order_id}</td><td>${order.user_id}</td><td>${order.network}</td><td>${order.tx_id}</td><td>${order.gems}</td><td>${new Date(order.created_at).toLocaleString()}</td></tr>`
+    )
+    .join('');
+
+  const manifestSummary = manifest
+    ? `<p><strong>${htmlEscape(manifest.book_name ?? 'Genesis')}</strong> • Version ${htmlEscape(manifest.version ?? '1.0.0')} • Scenes: ${manifest.scenes?.length ?? 0}</p>`
+    : '<p>No manifest loaded.</p>';
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>LedgerLegends Dashboard</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 2rem; background: #111827; color: #f9fafb; }
+    a { color: #93c5fd; }
+    table { width: 100%; border-collapse: collapse; margin-bottom: 1.5rem; }
+    th, td { border: 1px solid #374151; padding: 0.5rem; text-align: left; }
+    th { background: #1f2937; }
+    section { margin-bottom: 2rem; padding: 1rem; background: #1f2937; border-radius: 0.75rem; }
+    input, select, textarea { width: 100%; padding: 0.5rem; margin-top: 0.25rem; margin-bottom: 0.75rem; border-radius: 0.5rem; border: 1px solid #4b5563; background: #111827; color: #f9fafb; }
+    button { padding: 0.6rem 1.2rem; border-radius: 0.5rem; border: none; background: #2563eb; color: white; cursor: pointer; }
+    button:hover { background: #1d4ed8; }
+    form.inline { display: flex; gap: 1rem; flex-wrap: wrap; align-items: flex-end; }
+    form.inline label { flex: 1 1 12rem; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>LedgerLegends Control Panel</h1>
+    <p>Logged in as <strong>${htmlEscape(`${user.username}#${user.discriminator}`)}</strong>. <a href="/logout">Log out</a></p>
+  </header>
+
+  <section>
+    <h2>Economy Snapshot</h2>
+    <table>
+      <thead><tr><th>Guild</th><th>Tier</th><th>GM Reward</th><th>GN Reward</th><th>XP Reward</th><th>Difficulty Bias</th></tr></thead>
+      <tbody>${economyRows || '<tr><td colspan="6">No guilds accessible.</td></tr>'}</tbody>
+    </table>
+    <form method="POST" action="/economy">
+      <label>Guild
+        <select name="guild_id" required>${guildOptions}</select>
+      </label>
+      <label>GM Reward (coins)
+        <input name="gm_reward" type="number" value="25" min="0" step="1" />
+      </label>
+      <label>GN Reward (coins)
+        <input name="gn_reward" type="number" value="25" min="0" step="1" />
+      </label>
+      <label>XP Reward
+        <input name="xp_reward" type="number" value="1" min="0" step="1" />
+      </label>
+      <label>Difficulty Bias (-3 .. +3)
+        <input name="difficulty_bias" type="number" value="0" min="-3" max="3" step="1" />
+      </label>
+      <button type="submit">Save Economy Settings</button>
+    </form>
+  </section>
+
+  <section>
+    <h2>Feature Flags</h2>
+    <form method="POST" action="/features" class="inline">
+      <label>Guild
+        <select name="guild_id" required>${guildOptions}</select>
+      </label>
+      <label>Feature Key
+        <input name="feature" placeholder="seasonal" required />
+      </label>
+      <label>Enabled
+        <select name="enabled"><option value="true">Enabled</option><option value="false">Disabled</option></select>
+      </label>
+      <button type="submit">Update Feature Flag</button>
+    </form>
+  </section>
+
+  ${isOwner(user) ? `<section>
+    <h2>Licenses</h2>
+    <table>
+      <thead><tr><th>Guild</th><th>Tier</th><th>Features JSON</th><th>Expires</th></tr></thead>
+      <tbody>${licenseRows || '<tr><td colspan="4">No licenses recorded.</td></tr>'}</tbody>
+    </table>
+    <form method="POST" action="/licenses">
+      <label>Guild ID
+        <input name="guild_id" required />
+      </label>
+      <label>Tier
+        <input name="tier" placeholder="pro" />
+      </label>
+      <label>Features (comma separated)
+        <input name="features" placeholder="campaign,shop,seasonal" />
+      </label>
+      <label>Expires At (ISO timestamp)
+        <input name="expires_at" placeholder="2026-01-01T00:00:00Z" />
+      </label>
+      <button type="submit">Upsert License</button>
+    </form>
+  </section>` : ''}
+
+  ${isOwner(user) ? `<section>
+    <h2>Shop Configuration</h2>
+    <form method="POST" action="/shop/packs">
+      <label>Pack ID
+        <input name="pack_id" required />
+      </label>
+      <label>Rotation Tag
+        <input name="rotation_tag" placeholder="weekly" />
+      </label>
+      <label>Definition JSON
+        <textarea name="definition_json" rows="6" placeholder='{"name":"Genesis Pack","cost":1000}'></textarea>
+      </label>
+      <button type="submit">Save Pack Definition</button>
+    </form>
+    <form method="POST" action="/shop/rotation">
+      <label>Packs JSON
+        <textarea name="packs_json" rows="4" placeholder='[{"id":"genesis","weight":1}]'></textarea>
+      </label>
+      <label>Items JSON
+        <textarea name="items_json" rows="4" placeholder='[]'></textarea>
+      </label>
+      <button type="submit">Publish Rotation</button>
+    </form>
+  </section>` : ''}
+
+  ${isOwner(user) ? `<section>
+    <h2>Gem Purchase Orders</h2>
+    <table>
+      <thead><tr><th>Order</th><th>User</th><th>Network</th><th>Transaction</th><th>Gems</th><th>Created</th></tr></thead>
+      <tbody>${ordersRows || '<tr><td colspan="6">No orders recorded.</td></tr>'}</tbody>
+    </table>
+  </section>` : ''}
+
+  <section>
+    <h2>Content Overview</h2>
+    ${manifestSummary}
+  </section>
+</body>
+</html>`;
+}
+
+async function handleOAuth(session: SessionRecord, code: string) {
+  const tokenResponse = await fetch('https://discord.com/api/oauth2/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: CFG.dashboardClientId,
+      client_secret: CFG.dashboardClientSecret,
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: CFG.dashboardRedirectUri,
+    }),
+  });
+  if (!tokenResponse.ok) {
+    const text = await tokenResponse.text();
+    throw new Error(`Token exchange failed: ${text}`);
+  }
+  const token = (await tokenResponse.json()) as { access_token: string; token_type: string };
+  const headers = { Authorization: `${token.token_type} ${token.access_token}` };
+  const userResponse = await fetch('https://discord.com/api/users/@me', { headers });
+  const guildResponse = await fetch('https://discord.com/api/users/@me/guilds', { headers });
+  if (!userResponse.ok || !guildResponse.ok) {
+    throw new Error('Failed to fetch user profile');
+  }
+  const userJson = (await userResponse.json()) as {
+    id: string;
+    username: string;
+    discriminator: string;
+    avatar?: string | null;
+  };
+  const guildsJson = (await guildResponse.json()) as any[];
+  const manageable: DiscordGuildSummary[] = Array.isArray(guildsJson)
+    ? guildsJson
+        .filter((g) => hasManageGuild(g.permissions))
+        .map((g) => ({ id: g.id, name: g.name, permissions: g.permissions }))
+    : [];
+  const accessible = new Set<string>(manageable.map((g) => g.id));
+  if (CFG.homeGuildId) accessible.add(CFG.homeGuildId);
+  CFG.allowedGuilds.forEach((g) => accessible.add(g));
+  if (userJson.id === CFG.ownerId) {
+    listLicenses().forEach((lic) => accessible.add(lic.guild_id));
+  }
+  session.user = {
+    id: userJson.id,
+    username: userJson.username,
+    discriminator: userJson.discriminator,
+    avatar: userJson.avatar,
+    guilds: manageable,
+    accessibleGuilds: Array.from(accessible),
+  };
+}
+
+export function startDashboardServer(port: number) {
+  if (!port) return;
+  const base = CFG.dashboardBaseUrl || `http://localhost:${port}`;
+
+  const server = http.createServer(async (req: http.IncomingMessage, res: http.ServerResponse) => {
+    const session = getSession(req, res);
+    const parsedUrl = req.url ? new url.URL(req.url, base) : new url.URL('/', base);
+    const path = parsedUrl.pathname;
+
+    try {
+      if (path === '/health') {
+        return sendJson(res, 200, { ok: true });
+      }
+
+      if (path === '/webhooks/gems' && req.method === 'POST') {
+        if (!CFG.gemWebhookSecret) {
+          return sendJson(res, 503, { error: 'Gems webhook disabled' });
+        }
+        const raw = await readBody(req);
+        const signature = req.headers['x-ledger-signature'] as string | undefined;
+        if (!verifyWebhookSignature(raw, signature)) {
+          return sendJson(res, 401, { error: 'Invalid signature' });
+        }
+        try {
+          const payload = JSON.parse(raw) as GemPurchasePayload;
+          const result = recordGemPurchase(payload);
+          return sendJson(res, 200, { ok: true, result });
+        } catch (err) {
+          return sendJson(res, 400, { error: 'Malformed payload' });
+        }
+      }
+
+      if (path === '/login') {
+        session.state = crypto.randomBytes(16).toString('hex');
+        const authorize = new url.URL('https://discord.com/api/oauth2/authorize');
+        authorize.searchParams.set('client_id', CFG.dashboardClientId);
+        authorize.searchParams.set('redirect_uri', CFG.dashboardRedirectUri);
+        authorize.searchParams.set('response_type', 'code');
+        authorize.searchParams.set('scope', 'identify guilds');
+        authorize.searchParams.set('state', session.state ?? '');
+        return redirect(res, authorize.toString());
+      }
+
+      if (path === '/oauth/callback') {
+        const state = parsedUrl.searchParams.get('state');
+        const code = parsedUrl.searchParams.get('code');
+        if (!state || state !== session.state || !code) {
+          return sendHtml(res, 400, '<h1>OAuth state mismatch</h1>');
+        }
+        session.state = undefined;
+        try {
+          await handleOAuth(session, code);
+          return redirect(res, '/');
+        } catch (err) {
+          console.error('OAuth callback failed', err);
+          return sendHtml(res, 500, '<h1>OAuth failure</h1>');
+        }
+      }
+
+      if (path === '/logout') {
+        destroySession(res, session);
+        return redirect(res, '/login');
+      }
+
+      if (!session.user) {
+        return redirect(res, '/login');
+      }
+
+      const user = session.user;
+
+      if (path === '/' && req.method === 'GET') {
+        return sendHtml(res, 200, renderDashboard(user));
+      }
+
+      if (path === '/economy' && req.method === 'POST') {
+        const body = await readBody(req);
+        const params = new url.URLSearchParams(body);
+        const guild_id = params.get('guild_id') || '';
+        if (!guild_id || !canManageGuild(user, guild_id)) {
+          return sendHtml(res, 403, '<h1>Forbidden</h1>');
+        }
+        const gm = Number(params.get('gm_reward') ?? 25);
+        const gn = Number(params.get('gn_reward') ?? 25);
+        const xp = Number(params.get('xp_reward') ?? 1);
+        const bias = Number(params.get('difficulty_bias') ?? 0);
+        upsertGuildSettings(guild_id, {
+          gm_reward: Number.isFinite(gm) ? gm : 25,
+          gn_reward: Number.isFinite(gn) ? gn : 25,
+          xp_reward: Number.isFinite(xp) ? xp : 1,
+          difficulty_bias: Math.max(-3, Math.min(3, Number.isFinite(bias) ? bias : 0)),
+        });
+        return redirect(res, '/');
+      }
+
+      if (path === '/features' && req.method === 'POST') {
+        const body = await readBody(req);
+        const params = new url.URLSearchParams(body);
+        const guild_id = params.get('guild_id') || '';
+        const feature = params.get('feature') || '';
+        if (!guild_id || !feature || !canManageGuild(user, guild_id)) {
+          return sendHtml(res, 403, '<h1>Forbidden</h1>');
+        }
+        const toggle = (params.get('enabled') || '').toLowerCase();
+        const enabled = toggle === 'true' || toggle === '1' || toggle === 'enabled' || toggle === 'on';
+        setFeatureFlag(guild_id, feature, enabled);
+        return redirect(res, '/');
+      }
+
+      if (path === '/licenses' && req.method === 'POST') {
+        if (!isOwner(user)) {
+          return sendHtml(res, 403, '<h1>Owner only</h1>');
+        }
+        const body = await readBody(req);
+        const params = new url.URLSearchParams(body);
+        const guild_id = params.get('guild_id') || '';
+        if (!guild_id) {
+          return sendHtml(res, 400, '<h1>Missing guild</h1>');
+        }
+        const tier = params.get('tier') || undefined;
+        const features = (params.get('features') || '')
+          .split(',')
+          .map((f: string) => f.trim())
+          .filter(Boolean);
+        const expires = params.get('expires_at');
+        const expiresAt = expires ? Date.parse(expires) : undefined;
+        upsertLicense({
+          guild_id,
+          tier,
+          features_json: JSON.stringify(features),
+          expires_at: Number.isFinite(expiresAt) ? expiresAt : null,
+        });
+        return redirect(res, '/');
+      }
+
+      if (path === '/shop/packs' && req.method === 'POST') {
+        if (!isOwner(user)) {
+          return sendHtml(res, 403, '<h1>Owner only</h1>');
+        }
+        const body = await readBody(req);
+        const params = new url.URLSearchParams(body);
+        const pack_id = params.get('pack_id') || '';
+        if (!pack_id) {
+          return sendHtml(res, 400, '<h1>Missing pack id</h1>');
+        }
+        const definition = params.get('definition_json') || '{}';
+        const rotation_tag = params.get('rotation_tag') || null;
+        try {
+          const parsed = definition ? JSON.parse(definition) : {};
+          db.prepare(
+            `INSERT INTO shop_packs (pack_id, definition_json, rotation_tag, updated_at)
+             VALUES (?,?,?,?)
+             ON CONFLICT(pack_id) DO UPDATE SET definition_json=excluded.definition_json, rotation_tag=excluded.rotation_tag, updated_at=excluded.updated_at`
+          ).run(pack_id, JSON.stringify(parsed), rotation_tag, now());
+          return redirect(res, '/');
+        } catch {
+          return sendHtml(res, 400, '<h1>Invalid JSON payload</h1>');
+        }
+      }
+
+      if (path === '/shop/rotation' && req.method === 'POST') {
+        if (!isOwner(user)) {
+          return sendHtml(res, 403, '<h1>Owner only</h1>');
+        }
+        const body = await readBody(req);
+        const params = new url.URLSearchParams(body);
+        try {
+          const packs = params.get('packs_json') ? JSON.parse(params.get('packs_json') as string) : [];
+          const items = params.get('items_json') ? JSON.parse(params.get('items_json') as string) : [];
+          db.prepare(
+            `INSERT INTO shop_rotations (rotation_id, active_from, active_to, packs_json, items_json)
+             VALUES (?,?,?,?,?)`
+          ).run(`rot_${now()}`, now(), now(), JSON.stringify(packs), JSON.stringify(items));
+          return redirect(res, '/');
+        } catch {
+          return sendHtml(res, 400, '<h1>Invalid rotation JSON</h1>');
+        }
+      }
+
+      if (path === '/api/orders' && req.method === 'GET') {
+        if (!isOwner(user)) {
+          return sendJson(res, 403, { error: 'Owner only' });
+        }
+        return sendJson(res, 200, { orders: listGemOrders(100) });
+      }
+
+      return sendHtml(res, 404, '<h1>Not Found</h1>');
+    } catch (err) {
+      console.error('Dashboard request failed', err);
+      return sendHtml(res, 500, '<h1>Server Error</h1>');
+    }
+  });
+
+  server.listen(port, () => {
+    console.log(`[dashboard] listening on ${port}`);
+  });
+}

--- a/src/engine/difficulty.ts
+++ b/src/engine/difficulty.ts
@@ -1,13 +1,29 @@
 export type Tier = 'normal'|'tough'|'epic'|'mythic';
 
-export function computeHiddenTier(avgLevel: number, avgPower: number, debuffBias=0): {tier:Tier, dcOffset:number} {
-  const phi = 1.618;
-  const scale = (avgLevel + avgPower/100) / 10 / phi - debuffBias*0.2;
+export function computeHiddenTier(avgLevel: number, avgPower: number, debuffBias = 0, manualBias = 0): {
+  tier: Tier;
+  dcOffset: number;
+} {
+  const normalizedLevel = avgLevel / 5; // level 5 feels like mid-game
+  const normalizedPower = avgPower / 120; // roughly 0-2 range for gear
+  const totalBias = manualBias * 0.5; // admin adjustment -3..+3 => -1.5..1.5
+  const penalty = debuffBias * 0.6;
+  const score = normalizedLevel + normalizedPower + totalBias - penalty;
+
   let tier: Tier = 'normal';
   let dc = 0;
-  if (scale > 1.2) { tier='tough'; dc=+2; }
-  if (scale > 2.0) { tier='epic'; dc=+5; }
-  if (scale > 2.8) { tier='mythic'; dc=+7; }
+  if (score >= 1.4) {
+    tier = 'tough';
+    dc = 2;
+  }
+  if (score >= 2.2) {
+    tier = 'epic';
+    dc = 5;
+  }
+  if (score >= 3.0) {
+    tier = 'mythic';
+    dc = 7;
+  }
   return { tier, dcOffset: dc };
 }
 

--- a/src/engine/orchestrator.ts
+++ b/src/engine/orchestrator.ts
@@ -2,80 +2,429 @@ import { nanoid } from 'nanoid';
 import db from '../persistence/db.js';
 import { loadScene, loadManifest } from '../content/contentLoader.js';
 import { phiD20, pickOutcome, applyEffects } from './rules.js';
-import { thresholdRewards } from './rewards.js';
+import { thresholdRewards, groupBonusAllSurvive, loneSurvivor } from './rewards.js';
 import { computeHiddenTier, flavorForTier } from './difficulty.js';
+import { calculatePartyDifficultyInputs } from './partyStrength.js';
 import { SceneDef } from '../models.js';
+import {
+  equipmentAdvantageState,
+  loadoutSleightBonus,
+  neutralizesCritFail,
+  shouldRerollFails,
+  tickDurability,
+  EquipmentSlot,
+  hasCoinLossProtection,
+  fragmentsBoost,
+} from '../ui/equipment.js';
+import { randomCompliment } from '../ui/compliments.js';
+import { getGuildSettings } from '../persistence/settings.js';
 
-export function startRun(guild_id:string, channel_id:string, party_ids:string[], content_id='genesis', scene_id='1.1'){
+const TURN_TIMEOUT_MS = 24 * 60 * 60 * 1000;
+
+function prepareTurnOrder(party_ids: string[]) {
+  const deduped = Array.from(new Set(party_ids));
+  return deduped.length ? deduped : [...party_ids];
+}
+
+export function startRun(
+  guild_id: string,
+  channel_id: string,
+  party_ids: string[],
+  content_id = 'genesis',
+  scene_id = '1.1'
+) {
   const manifest = loadManifest(content_id);
   const run_id = `run_${nanoid(8)}`;
   const rng_seed = nanoid(12);
   const flags = {};
   const now = Date.now();
+  const turnOrder = prepareTurnOrder(party_ids);
+  const active = turnOrder[0] ?? null;
   db.prepare(`INSERT INTO runs (run_id,guild_id,channel_id,party_id,content_id,content_version,scene_id,round_id,micro_ix,rng_seed,flags_json,sleight_score,created_at,updated_at)
   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)`)
-    .run(run_id, guild_id, channel_id, party_ids.sort().join(','), content_id, manifest.version, scene_id, '1.1-R1', 1, rng_seed, JSON.stringify(flags), 0, now, now);
+    .run(
+      run_id,
+      guild_id,
+      channel_id,
+      party_ids.sort().join(','),
+      content_id,
+      manifest.version,
+      scene_id,
+      '1.1-R1',
+      1,
+      rng_seed,
+      JSON.stringify(flags),
+      0,
+      now,
+      now
+    );
+  db.prepare('UPDATE runs SET turn_order_json=?, active_user_id=?, turn_expires_at=? WHERE run_id=?')
+    .run(JSON.stringify(turnOrder), active, active ? now + TURN_TIMEOUT_MS : null, run_id);
+  db.prepare('UPDATE runs SET ui_channel_id=? WHERE run_id=?').run(channel_id, run_id);
   return run_id;
 }
 
-export function getRun(run_id:string){
+export function getRun(run_id: string) {
   return db.prepare('SELECT * FROM runs WHERE run_id=?').get(run_id);
 }
 
-export function saveRun(run:any){
-  db.prepare(`UPDATE runs SET scene_id=?, round_id=?, micro_ix=?, flags_json=?, sleight_score=?, updated_at=? WHERE run_id=?`)
-    .run(run.scene_id, run.round_id, run.micro_ix, run.flags_json, run.sleight_score, Date.now(), run.run_id);
+export function saveRun(run: any) {
+  db.prepare(
+    `UPDATE runs SET scene_id=?, round_id=?, micro_ix=?, flags_json=?, sleight_score=?, sleight_history_json=?, active_user_id=?, turn_order_json=?, turn_expires_at=?, afk_tracker_json=?, updated_at=? WHERE run_id=?`
+  )
+    .run(
+      run.scene_id,
+      run.round_id,
+      run.micro_ix,
+      run.flags_json,
+      run.sleight_score,
+      run.sleight_history_json ?? '[]',
+      run.active_user_id ?? null,
+      run.turn_order_json ?? '[]',
+      run.turn_expires_at ?? null,
+      run.afk_tracker_json ?? '{}',
+      Date.now(),
+      run.run_id
+    );
 }
 
-export function sceneState(run:any): SceneDef {
+export function sceneState(run: any): SceneDef {
   return loadScene(run.content_id, run.scene_id);
 }
 
-export function handleAction(run_id:string, user_id:string, action_id:string){
+type CommitState = {
+  hp: Record<string, number>;
+  focus: Record<string, number>;
+  flags: Record<string, any>;
+  _coins: Record<string, number>;
+  _xp: Record<string, number>;
+  _fragments: Record<string, number>;
+  _items: Record<string, string[]>;
+  _buffs: Record<string, string[]>;
+  _debuffs: Record<string, string[]>;
+  _gems: Record<string, number>;
+};
+
+function commitState(user_id: string, state: CommitState) {
+  if (state.hp[user_id] !== undefined || state.focus[user_id] !== undefined) {
+    const prof = db
+      .prepare('SELECT hp, hp_max, focus, focus_max FROM profiles WHERE user_id=?')
+      .get(user_id) as { hp: number; hp_max: number; focus: number; focus_max: number } | undefined;
+    const hpMax = prof?.hp_max ?? 20;
+    const focusMax = prof?.focus_max ?? 10;
+    const hp = Math.max(0, Math.min(state.hp[user_id] ?? prof?.hp ?? 20, hpMax));
+    const focus = Math.max(0, Math.min(state.focus[user_id] ?? prof?.focus ?? 10, focusMax));
+    const downed_at = hp <= 0 ? Date.now() : null;
+    db.prepare('UPDATE profiles SET hp=?, focus=?, downed_at=? WHERE user_id=?')
+      .run(hp, focus, downed_at, user_id);
+  }
+
+  if (state._coins[user_id]) {
+    const delta = state._coins[user_id];
+    if (delta < 0 && hasCoinLossProtection(user_id)) {
+      // Prevent dipping below zero when protection is active.
+      const current = db.prepare('SELECT coins FROM profiles WHERE user_id=?').get(user_id) as { coins: number } | undefined;
+      const protectedDelta = Math.max(-(current?.coins ?? 0), delta);
+      db.prepare('UPDATE profiles SET coins=coins+? WHERE user_id=?').run(protectedDelta, user_id);
+    } else {
+      db.prepare('UPDATE profiles SET coins=coins+? WHERE user_id=?').run(delta, user_id);
+    }
+  }
+
+  if (state._xp[user_id]) {
+    db.prepare('UPDATE profiles SET xp=xp+? WHERE user_id=?').run(state._xp[user_id], user_id);
+  }
+
+  if (state._fragments[user_id]) {
+    const bonus = fragmentsBoost(user_id);
+    const total = (state._fragments[user_id] ?? 0) + bonus;
+    db.prepare('UPDATE profiles SET fragments=fragments+? WHERE user_id=?').run(total, user_id);
+  }
+
+  if (state._gems[user_id]) {
+    db.prepare('UPDATE profiles SET gems=gems+? WHERE user_id=?').run(state._gems[user_id], user_id);
+  }
+
+  if (state._items[user_id]?.length) {
+    const stmt = db.prepare(
+      'INSERT INTO inventories (user_id,item_id,kind,rarity,qty,meta_json) VALUES (?,?,?,?,?,?) ON CONFLICT(user_id,item_id) DO UPDATE SET qty=qty+excluded.qty'
+    );
+    for (const id of state._items[user_id]) {
+      stmt.run(user_id, id, 'reward', 'unknown', 1, '{}');
+    }
+  }
+}
+
+function appendSleightHistory(run: any, entry: any) {
+  const history: any[] = JSON.parse(run.sleight_history_json || '[]');
+  history.push(entry);
+  run.sleight_history_json = JSON.stringify(history.slice(-50));
+}
+
+function advanceTurn(run: any, { skipActiveCheck = false } = {}) {
+  const order: string[] = JSON.parse(run.turn_order_json || '[]');
+  if (!order.length) return;
+  let currentIndex = order.indexOf(run.active_user_id ?? order[0]);
+  if (currentIndex === -1) currentIndex = 0;
+  let nextIndex = (currentIndex + 1) % order.length;
+  let loops = order.length;
+  while (loops-- > 0) {
+    const candidate = order[nextIndex];
+    if (!candidate) break;
+    const prof = db
+      .prepare('SELECT downed_at FROM profiles WHERE user_id=?')
+      .get(candidate) as { downed_at?: number } | undefined;
+    if (!prof?.downed_at) {
+      run.active_user_id = candidate;
+      run.turn_expires_at = Date.now() + TURN_TIMEOUT_MS;
+      saveRun(run);
+      return;
+    }
+    nextIndex = (nextIndex + 1) % order.length;
+  }
+  if (skipActiveCheck) {
+    run.active_user_id = order[currentIndex];
+    run.turn_expires_at = Date.now() + TURN_TIMEOUT_MS;
+    saveRun(run);
+  }
+}
+
+function applyThresholdRewards(run: any, user_id: string, scene: SceneDef, state: CommitState) {
+  const rewards = thresholdRewards(run.sleight_score, scene.threshold_rewards);
+  if (rewards?.length) {
+    applyEffects(rewards, state as any, user_id);
+    commitState(user_id, state);
+  }
+
+  const party = (run.party_id as string)?.split(',').filter(Boolean) ?? [];
+  if (!party.length) return;
+  const downed = party.filter((p) => {
+    const prof = db.prepare('SELECT downed_at FROM profiles WHERE user_id=?').get(p) as { downed_at?: number } | undefined;
+    return Boolean(prof?.downed_at);
+  });
+  if (downed.length === 0) {
+    const bonus = groupBonusAllSurvive();
+    applyEffects(bonus, state as any, user_id);
+    commitState(user_id, state);
+  } else if (downed.length === party.length - 1) {
+    const survivor = party.find((p) => !downed.includes(p));
+    if (survivor) {
+      const bonus = loneSurvivor();
+      applyEffects(bonus, state as any, survivor);
+      commitState(survivor, state);
+    }
+  }
+}
+
+export function handleAction(
+  run_id: string,
+  user_id: string,
+  action_id: string,
+  opts: { forcedKind?: 'crit_success' | 'success' | 'fail' | 'crit_fail'; autop?: boolean; reason?: string } = {}
+) {
   const run = getRun(run_id);
+  if (!run) throw new Error('Run not found');
   const scene = loadScene(run.content_id, run.scene_id);
-  const round = scene.rounds.find((r:any) => r.round_id === run.round_id);
+  const round = scene.rounds.find((r: any) => r.round_id === run.round_id);
   if (!round) throw new Error('Round not found');
-  const act = round.actions.find((a:any) => a.id === action_id);
+  const act = round.actions.find((a: any) => a.id === action_id);
   if (!act) throw new Error('Action not found');
 
-  // Hidden difficulty snapshot (toy avg levels)
-  const avgLevel = 10, avgPower = 1200, debuff = 0;
-  const { dcOffset, tier } = computeHiddenTier(avgLevel, avgPower, debuff);
-  const roll = act.roll ? phiD20(13, dcOffset) : { kind:'success', roll: 20, dc:13 } as any;
+  if (run.active_user_id && run.active_user_id !== user_id && !opts.autop) {
+    throw new Error('It is not your turn.');
+  }
+
+  const prof = db
+    .prepare('SELECT hp, focus, downed_at FROM profiles WHERE user_id=?')
+    .get(user_id) as { hp: number; focus: number; downed_at?: number } | undefined;
+  if (prof?.downed_at && !opts.autop) {
+    throw new Error('You are downed! Use a reboot or wait for a revive.');
+  }
+
+  const tags: string[] = act.roll?.tags ?? [];
+  const { advantage, disadvantage, dcShift, dcOffset, focusBonus, hpBonus } = equipmentAdvantageState(user_id, tags);
+  const difficultyInputs = calculatePartyDifficultyInputs(run);
+  const settings = getGuildSettings(run.guild_id);
+  const { dcOffset: hiddenOffset, tier } = computeHiddenTier(
+    difficultyInputs.avgLevel,
+    difficultyInputs.avgPower,
+    difficultyInputs.debuffBias,
+    settings.difficulty_bias
+  );
+  db.prepare(
+    'INSERT INTO difficulty_snapshots (run_id, scene_id, snapshot_ts, tier, dc_offset, inputs_json) VALUES (?,?,?,?,?,?)'
+  ).run(
+    run_id,
+    run.scene_id,
+    Date.now(),
+    tier,
+    hiddenOffset,
+    JSON.stringify({
+      avgLevel: difficultyInputs.avgLevel,
+      avgPower: difficultyInputs.avgPower,
+      debuffBias: difficultyInputs.debuffBias,
+      bias: settings.difficulty_bias,
+      members: difficultyInputs.members,
+    })
+  );
+
+  const baseDc = 13 + dcShift;
+  const totalOffset = hiddenOffset + dcOffset;
+  let roll = act.roll
+    ? phiD20(baseDc, totalOffset)
+    : ({ kind: 'success', roll: 20, dc: baseDc + totalOffset } as any);
+
+  if (act.roll) {
+    if (advantage && !disadvantage) {
+      const contender = phiD20(baseDc, totalOffset);
+      roll = contender.roll >= roll.roll ? contender : roll;
+    } else if (disadvantage && !advantage) {
+      const contender = phiD20(baseDc, totalOffset);
+      roll = contender.roll <= roll.roll ? contender : roll;
+    }
+  }
+
+  if (opts.forcedKind) {
+    roll = { kind: opts.forcedKind, roll: 0, dc: baseDc + totalOffset } as any;
+  }
+
+  if (roll.kind === 'crit_fail' && neutralizesCritFail(user_id)) {
+    roll = { ...roll, kind: 'fail' };
+  }
+
+  const rerollAllowed = shouldRerollFails(user_id) && (roll.kind === 'fail' || roll.kind === 'crit_fail') && !opts.autop;
+  if (rerollAllowed) {
+    const contender = phiD20(baseDc, totalOffset);
+    if (contender.roll > roll.roll) {
+      roll = contender;
+    }
+  }
 
   const outcome = pickOutcome(act.outcomes, roll.kind as any);
-  const state = {
-    hp: {}, focus: {}, flags: JSON.parse(run.flags_json||'{}'),
-    _coins:{}, _xp:{}, _fragments:{}, _items:{}, _buffs:{}, _debuffs:{}, _gems:{}
+  const state: CommitState = {
+    hp: { [user_id]: prof?.hp ?? 20 },
+    focus: { [user_id]: prof?.focus ?? 10 },
+    flags: JSON.parse(run.flags_json || '{}'),
+    _coins: {},
+    _xp: {},
+    _fragments: {},
+    _items: {},
+    _buffs: {},
+    _debuffs: {},
+    _gems: {},
   };
-  const summary = applyEffects(outcome.effects||[], state, user_id);
 
-  const newFlags = { ...(JSON.parse(run.flags_json||'{}')), ...(state.flags||{}) };
+  if (focusBonus) {
+    state.focus[user_id] = (state.focus[user_id] ?? prof?.focus ?? 10) + focusBonus;
+  }
+  if (hpBonus && (state.hp[user_id] ?? 0) > 0) {
+    state.hp[user_id] = (state.hp[user_id] ?? prof?.hp ?? 20) + hpBonus;
+  }
+
+  const summary = applyEffects(outcome.effects || [], state as any, user_id);
+  commitState(user_id, state);
+
+  const newFlags = { ...(JSON.parse(run.flags_json || '{}')), ...(state.flags || {}) };
   run.flags_json = JSON.stringify(newFlags);
 
-  if (roll.kind === 'crit_success') run.sleight_score += 2;
-  else if (roll.kind === 'success') run.sleight_score += 1;
-  else if (roll.kind === 'crit_fail') run.sleight_score -= 1;
+  let sleightDelta = 0;
+  if (roll.kind === 'crit_success') sleightDelta = 2;
+  else if (roll.kind === 'success') sleightDelta = 1;
+  else if (roll.kind === 'crit_fail') sleightDelta = -1;
+  sleightDelta += loadoutSleightBonus(user_id, roll.kind);
+  run.sleight_score += sleightDelta;
+  appendSleightHistory(run, { user_id, delta: sleightDelta, reason: roll.kind, ts: Date.now() });
 
-  const rounds = scene.rounds.map(r=>r.round_id);
+  const rounds = scene.rounds.map((r: any) => r.round_id);
   const idx = rounds.indexOf(run.round_id);
-  if (idx < rounds.length - 1){
-    run.round_id = rounds[idx+1];
+  let completedScene = false;
+  if (idx < rounds.length - 1) {
+    run.round_id = rounds[idx + 1];
   } else {
-    const rewards = thresholdRewards(run.sleight_score, scene.threshold_rewards);
-    applyEffects(rewards, state, user_id);
-    const arr = scene.arrivals||[];
-    let next = arr.find(a => a.when.startsWith('flags') && (newFlags as any)[a.when.split('.')[1]])?.goto || arr.find(a=>a.when==='else')?.goto || '2B';
-    run.scene_id = (''+next).replace(/^\s*→?\s*/,'').replace(/^Scene\s*/,'').replace(/^2([A-D])$/,(m,p)=> ({A:'2.1',B:'2.1',C:'2.1',D:'2.1'}[p] ));
+    completedScene = true;
+    applyThresholdRewards(run, user_id, scene, state);
+    const arr = scene.arrivals || [];
+    const next =
+      arr.find((a) => a.when.startsWith('flags') && (newFlags as any)[a.when.split('.')[1]])?.goto ||
+      arr.find((a) => a.when === 'else')?.goto ||
+      '2B';
+    const sceneMap: Record<'A' | 'B' | 'C' | 'D', string> = { A: '2.1', B: '2.1', C: '2.1', D: '2.1' };
+    run.scene_id = ('' + next)
+      .replace(/^\s*→?\s*/, '')
+      .replace(/^Scene\s*/, '')
+      .replace(/^2([A-D])$/, (m, p: 'A' | 'B' | 'C' | 'D') => sceneMap[p]);
     run.round_id = `${run.scene_id}-R1`;
     run.micro_ix += 1;
     run.sleight_score = 0;
   }
 
-  db.prepare(`INSERT INTO events (event_id, run_id, user_id, type, payload_json, ts) VALUES (?,?,?,?,?,?)`)
-    .run(`${run_id}:${Date.now()}`, run_id, user_id, 'scene.choice', JSON.stringify({ action_id, roll, outcome, summary, tierFlavor: flavorForTier(tier) }), Date.now());
+  const tracker = JSON.parse(run.afk_tracker_json || '{}');
+  tracker[user_id] = 0;
+  run.afk_tracker_json = JSON.stringify(tracker);
 
+  tickDurability(user_id, ['weapon', 'armor', 'helm', 'trinket', 'deck'] as EquipmentSlot[], 1);
+
+  const compliment = roll.kind === 'crit_success' || roll.kind === 'success' ? randomCompliment() : undefined;
+
+  db.prepare('INSERT INTO events (event_id, run_id, user_id, type, payload_json, ts) VALUES (?,?,?,?,?,?)')
+    .run(
+      `${run_id}:${Date.now()}`,
+      run_id,
+      user_id,
+      opts.autop ? 'scene.force_choice' : 'scene.choice',
+      JSON.stringify({
+        action_id,
+        roll,
+        outcome,
+        summary,
+        compliment,
+        tierFlavor: flavorForTier(tier),
+        reason: opts.reason,
+      }),
+      Date.now()
+    );
+
+  advanceTurn(run, { skipActiveCheck: completedScene });
   saveRun(run);
-  return { roll, outcome, summary, tier };
+  db.prepare('UPDATE user_runs SET scene_id=?, updated_at=? WHERE run_id=? AND user_id=?')
+    .run(run.scene_id, Date.now(), run_id, user_id);
+  return { roll, outcome, summary, tier, compliment, completedScene };
+}
+
+export function processAfkTimeouts(now = Date.now()) {
+  const timedOut = db
+    .prepare('SELECT * FROM runs WHERE turn_expires_at IS NOT NULL AND turn_expires_at <= ?')
+    .all(now) as any[];
+  const events: { run_id: string; user_id: string; action_id: string; message: string; channel_id: string; refresh?: boolean }[] = [];
+  for (const run of timedOut) {
+    if (!run.active_user_id) continue;
+    const scene = loadScene(run.content_id, run.scene_id);
+    const round = scene.rounds.find((r: any) => r.round_id === run.round_id);
+    if (!round) continue;
+    const fallback =
+      round.actions.find((a: any) => a.telemetry_tags?.includes('neutral')) || round.actions[0];
+    if (!fallback) continue;
+    try {
+      handleAction(run.run_id, run.active_user_id, fallback.id, {
+        forcedKind: 'fail',
+        autop: true,
+        reason: 'timeout',
+      });
+      const tracker = JSON.parse(run.afk_tracker_json || '{}');
+      tracker[run.active_user_id] = (tracker[run.active_user_id] ?? 0) + 1;
+      run.afk_tracker_json = JSON.stringify(tracker);
+      saveRun(run);
+      events.push({
+        run_id: run.run_id,
+        user_id: run.active_user_id,
+        action_id: fallback.id,
+        message: `⏱️ Forced a neutral outcome for <@${run.active_user_id}> (timeout).`,
+        channel_id: run.channel_id,
+        refresh: true,
+      });
+    } catch (err) {
+      console.error('Failed to resolve timeout', err);
+    }
+  }
+  return events;
 }

--- a/src/engine/partyStrength.ts
+++ b/src/engine/partyStrength.ts
@@ -1,0 +1,78 @@
+import db from '../persistence/db.js';
+import { aggregateBonus } from '../ui/equipment.js';
+
+export interface PartyDifficultyInputs {
+  avgLevel: number;
+  avgPower: number;
+  debuffBias: number;
+  members: {
+    user_id: string;
+    level: number;
+    equipmentPower: number;
+    hpRatio: number;
+    focusRatio: number;
+    downed: boolean;
+  }[];
+}
+
+function equipmentPowerScore(user_id: string) {
+  const agg = aggregateBonus(user_id);
+  let score = 0;
+  score += Math.abs(agg.dcOffset) * 40;
+  score += Math.abs(agg.dcShift) * 25;
+  score += agg.focusBonus * 15;
+  score += agg.hpBonus * 6;
+  score += agg.sleightBonus * 20;
+  if (agg.rerollFail) score += 35;
+  if (agg.neutralizeCritFail) score += 30;
+  if (agg.fragmentsBoost) score += agg.fragmentsBoost * 5;
+  if (agg.preventsCoinLoss) score += 10;
+  score += agg.advantageTags.length * 6;
+  score -= agg.disadvantageTags.length * 4;
+  return score;
+}
+
+export function calculatePartyDifficultyInputs(run: any): PartyDifficultyInputs {
+  const party = (run.party_id as string)?.split(',').filter(Boolean) ?? [];
+  if (party.length === 0) {
+    return { avgLevel: 1, avgPower: 0, debuffBias: 0, members: [] };
+  }
+  const members: PartyDifficultyInputs['members'] = [];
+  let levelSum = 0;
+  let powerSum = 0;
+  let debuffSum = 0;
+  for (const user_id of party) {
+    const profile = db
+      .prepare('SELECT level, hp, hp_max, focus, focus_max, downed_at FROM profiles WHERE user_id=?')
+      .get(user_id) as { level?: number; hp?: number; hp_max?: number; focus?: number; focus_max?: number; downed_at?: number } | undefined;
+    const level = profile?.level && profile.level > 0 ? profile.level : 1;
+    const hpMax = profile?.hp_max && profile.hp_max > 0 ? profile.hp_max : 20;
+    const focusMax = profile?.focus_max && profile.focus_max > 0 ? profile.focus_max : 10;
+    const hpRatio = Math.max(0, Math.min(1, (profile?.hp ?? hpMax) / hpMax));
+    const focusRatio = Math.max(0, Math.min(1, (profile?.focus ?? focusMax) / focusMax));
+    const downed = Boolean(profile?.downed_at);
+    const eqPower = equipmentPowerScore(user_id);
+
+    let debuff = 0;
+    if (hpRatio < 0.6) {
+      debuff += (0.6 - hpRatio) * 4;
+    }
+    if (focusRatio < 0.6) {
+      debuff += (0.6 - focusRatio) * 4;
+    }
+    if (downed) {
+      debuff += 3;
+    }
+
+    members.push({ user_id, level, equipmentPower: eqPower, hpRatio, focusRatio, downed });
+    levelSum += level;
+    powerSum += eqPower;
+    debuffSum += debuff;
+  }
+  return {
+    avgLevel: levelSum / party.length,
+    avgPower: powerSum / party.length,
+    debuffBias: debuffSum / party.length,
+    members,
+  };
+}

--- a/src/engine/rules.ts
+++ b/src/engine/rules.ts
@@ -15,13 +15,13 @@ export function applyEffects(effects: Effect[], state: any, userId: string){
     switch (e.type) {
       case 'hp': {
         const d = (e.op === '-') ? -(e.value as number) : (e.value as number);
-        state.hp[userId] = Math.max(0, (state.hp[userId]||20) + d);
+        state.hp[userId] = Math.max(0, (state.hp[userId] ?? 20) + d);
         summary.push(`HP ${d>=0?'+':''}${d}`);
         break;
       }
       case 'focus': {
         const d = (e.op === '-') ? -(e.value as number) : (e.value as number);
-        state.focus[userId] = Math.max(0, (state.focus[userId]||10) + d);
+        state.focus[userId] = Math.max(0, (state.focus[userId] ?? 10) + d);
         summary.push(`Focus ${d>=0?'+':''}${d}`);
         break;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
 import { client } from './bot.js';
 import { CFG } from './config.js';
+import { startDashboardServer } from './dashboard/server.js';
+
+startDashboardServer(CFG.dashboardPort);
 client.login(CFG.token);

--- a/src/payments/gems.ts
+++ b/src/payments/gems.ts
@@ -1,0 +1,88 @@
+import crypto from 'node:crypto';
+import db from '../persistence/db.js';
+import { CFG } from '../config.js';
+
+export interface GemPurchasePayload {
+  order_id: string;
+  user_id: string;
+  network: string;
+  tx_id: string;
+  amount: number;
+  gems: number;
+  metadata?: Record<string, any>;
+}
+
+export function verifyWebhookSignature(rawBody: string, signature?: string | null) {
+  if (!CFG.gemWebhookSecret) return false;
+  if (!signature) return false;
+  const expected = crypto
+    .createHmac('sha256', CFG.gemWebhookSecret)
+    .update(rawBody)
+    .digest('hex');
+  try {
+    return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
+  } catch {
+    return false;
+  }
+}
+
+export function recordGemPurchase(payload: GemPurchasePayload) {
+  const now = Date.now();
+  const existing = db
+    .prepare('SELECT status FROM gem_orders WHERE order_id=?')
+    .get(payload.order_id) as { status?: string } | undefined;
+  if (existing?.status === 'processed') {
+    return { alreadyProcessed: true };
+  }
+
+  db.prepare(
+    `INSERT INTO gem_orders (order_id, user_id, network, tx_id, amount, gems, status, meta_json, created_at, updated_at)
+     VALUES (?,?,?,?,?,?,?,?,?,?)
+     ON CONFLICT(order_id) DO UPDATE SET
+       user_id=excluded.user_id,
+       network=excluded.network,
+       tx_id=excluded.tx_id,
+       amount=excluded.amount,
+       gems=excluded.gems,
+       status=excluded.status,
+       meta_json=excluded.meta_json,
+       updated_at=excluded.updated_at`
+  ).run(
+    payload.order_id,
+    payload.user_id,
+    payload.network,
+    payload.tx_id,
+    payload.amount,
+    payload.gems,
+    'processed',
+    JSON.stringify(payload.metadata ?? {}),
+    now,
+    now
+  );
+
+  const userExists = db.prepare('SELECT 1 FROM users WHERE user_id=?').get(payload.user_id);
+  if (!userExists) {
+    db.prepare('INSERT INTO users (user_id, discord_id, created_at) VALUES (?,?,?)').run(payload.user_id, payload.user_id, now);
+    db.prepare('INSERT INTO profiles (user_id, coins, gems) VALUES (?,?,?)').run(payload.user_id, 0, 0);
+  }
+
+  db.prepare('UPDATE profiles SET gems=gems+? WHERE user_id=?').run(payload.gems, payload.user_id);
+  db.prepare(
+    'INSERT INTO economy_ledger (txn_id, user_id, kind, amount, reason, meta_json, ts) VALUES (?,?,?,?,?,?,?)'
+  ).run(
+    `gem_${payload.order_id}`,
+    payload.user_id,
+    'gem_purchase',
+    payload.gems,
+    payload.network,
+    JSON.stringify({ tx: payload.tx_id, amount: payload.amount }),
+    now
+  );
+  return { processed: true };
+}
+
+export function listGemOrders(limit = 100) {
+  return db
+    .prepare('SELECT * FROM gem_orders ORDER BY created_at DESC LIMIT ?')
+    .all(limit);
+}

--- a/src/persistence/licensing.ts
+++ b/src/persistence/licensing.ts
@@ -1,0 +1,89 @@
+import { CFG } from '../config.js';
+import db from './db.js';
+
+export interface LicenseRecord {
+  guild_id: string;
+  tier?: string;
+  features_json?: string;
+  expires_at?: number | null;
+}
+
+function parseFeatures(json?: string | null): string[] {
+  if (!json) return [];
+  try {
+    const parsed = JSON.parse(json);
+    if (Array.isArray(parsed)) {
+      return parsed.map((f) => `${f}`);
+    }
+    if (parsed && typeof parsed === 'object') {
+      return Object.keys(parsed).filter((key) => parsed[key]);
+    }
+  } catch (err) {
+    console.warn('Failed to parse license features', err);
+  }
+  return [];
+}
+
+export function guildHasLicense(guild_id?: string | null): boolean {
+  if (!guild_id) return true; // direct messages
+  if (CFG.homeGuildId && guild_id === CFG.homeGuildId) return true;
+  if (CFG.allowedGuilds.includes(guild_id)) return true;
+  const row = db
+    .prepare('SELECT tier, expires_at FROM licenses WHERE guild_id=?')
+    .get(guild_id) as { tier?: string; expires_at?: number } | undefined;
+  if (!row) return false;
+  if (row.expires_at && row.expires_at < Date.now()) return false;
+  return true;
+}
+
+export function licenseFeatures(guild_id?: string | null): string[] {
+  if (!guild_id) return [];
+  if (CFG.homeGuildId && guild_id === CFG.homeGuildId) {
+    return ['campaign', 'shop', 'seasonal', 'pvp', 'minigames', 'gems'];
+  }
+  const row = db
+    .prepare('SELECT features_json FROM licenses WHERE guild_id=?')
+    .get(guild_id) as { features_json?: string } | undefined;
+  const features = parseFeatures(row?.features_json);
+  return features;
+}
+
+export function featureEnabled(guild_id: string | null | undefined, feature: string): boolean {
+  if (!guild_id) return true;
+  if (CFG.homeGuildId && guild_id === CFG.homeGuildId) return true;
+  if (CFG.allowedGuilds.includes(guild_id)) return true;
+  const override = db
+    .prepare('SELECT enabled FROM feature_flags WHERE guild_id=? AND feature=?')
+    .get(guild_id, feature) as { enabled?: number } | undefined;
+  if (override) {
+    return Boolean(override.enabled);
+  }
+  const features = licenseFeatures(guild_id);
+  if (features.length === 0) return false;
+  return features.includes(feature);
+}
+
+export function upsertLicense(record: LicenseRecord) {
+  db.prepare(
+    `INSERT INTO licenses (guild_id, tier, features_json, expires_at)
+     VALUES (?,?,?,?)
+     ON CONFLICT(guild_id) DO UPDATE SET
+       tier=excluded.tier,
+       features_json=excluded.features_json,
+       expires_at=excluded.expires_at`
+  ).run(record.guild_id, record.tier ?? null, record.features_json ?? null, record.expires_at ?? null);
+}
+
+export function setFeatureFlag(guild_id: string, feature: string, enabled: boolean) {
+  db.prepare(
+    `INSERT INTO feature_flags (guild_id, feature, enabled, updated_at)
+     VALUES (?,?,?,?)
+     ON CONFLICT(guild_id, feature) DO UPDATE SET enabled=excluded.enabled, updated_at=excluded.updated_at`
+  ).run(guild_id, feature, enabled ? 1 : 0, Date.now());
+}
+
+export function listLicenses(): LicenseRecord[] {
+  return db
+    .prepare('SELECT guild_id, tier, features_json, expires_at FROM licenses ORDER BY guild_id')
+    .all() as LicenseRecord[];
+}

--- a/src/persistence/schema.sql
+++ b/src/persistence/schema.sql
@@ -10,12 +10,20 @@ CREATE TABLE IF NOT EXISTS profiles (
   level INTEGER DEFAULT 1,
   xp INTEGER DEFAULT 0,
   hp INTEGER DEFAULT 20,
+  hp_max INTEGER DEFAULT 20,
   focus INTEGER DEFAULT 10,
+  focus_max INTEGER DEFAULT 10,
   flags_json TEXT DEFAULT '{}',
   last_gm_ts INTEGER,
   last_gn_ts INTEGER,
   coins INTEGER DEFAULT 0,
   gems INTEGER DEFAULT 0,
+  fragments INTEGER DEFAULT 0,
+  last_weekly_claim INTEGER,
+  weekly_streak INTEGER DEFAULT 0,
+  selected_role TEXT,
+  downed_at INTEGER,
+  loadout_hash TEXT,
   CHECK (level >= 1),
   FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
 );
@@ -44,8 +52,61 @@ CREATE TABLE IF NOT EXISTS runs (
   rng_seed TEXT,
   flags_json TEXT,
   sleight_score INTEGER DEFAULT 0,
+  sleight_history_json TEXT DEFAULT '[]',
+  active_user_id TEXT,
+  turn_order_json TEXT,
+  turn_expires_at INTEGER,
+  afk_tracker_json TEXT DEFAULT '{}',
+  ui_message_id TEXT,
+  ui_channel_id TEXT,
   created_at INTEGER,
   updated_at INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS equipment_loadouts (
+  user_id TEXT,
+  slot TEXT,
+  item_id TEXT,
+  durability INTEGER DEFAULT 100,
+  max_durability INTEGER DEFAULT 100,
+  set_key TEXT,
+  equipped_at INTEGER,
+  PRIMARY KEY(user_id, slot),
+  FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS seasonal_badges (
+  user_id TEXT,
+  season_id TEXT,
+  version TEXT,
+  earned_at INTEGER,
+  PRIMARY KEY(user_id, season_id, version)
+);
+
+CREATE TABLE IF NOT EXISTS minigame_scores (
+  user_id TEXT,
+  minigame_id TEXT,
+  best_score INTEGER,
+  last_played INTEGER,
+  PRIMARY KEY(user_id, minigame_id)
+);
+
+CREATE TABLE IF NOT EXISTS shop_rotations (
+  rotation_id TEXT PRIMARY KEY,
+  active_from INTEGER,
+  active_to INTEGER,
+  packs_json TEXT,
+  items_json TEXT
+);
+
+CREATE TABLE IF NOT EXISTS pvp_matches (
+  match_id TEXT PRIMARY KEY,
+  kind TEXT,
+  status TEXT,
+  participants_json TEXT,
+  created_at INTEGER,
+  updated_at INTEGER,
+  result_json TEXT
 );
 
 CREATE TABLE IF NOT EXISTS difficulty_snapshots (
@@ -84,6 +145,19 @@ CREATE TABLE IF NOT EXISTS pity (
   PRIMARY KEY(user_id, pack_id)
 );
 
+CREATE TABLE IF NOT EXISTS user_runs (
+  user_id TEXT,
+  run_id TEXT,
+  role_id TEXT,
+  scene_id TEXT,
+  status TEXT DEFAULT 'active',
+  created_at INTEGER,
+  updated_at INTEGER,
+  PRIMARY KEY(user_id, run_id),
+  FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
+  FOREIGN KEY (run_id) REFERENCES runs(run_id) ON DELETE CASCADE
+);
+
 CREATE TABLE IF NOT EXISTS licenses (
   guild_id TEXT PRIMARY KEY,
   tier TEXT,
@@ -91,5 +165,53 @@ CREATE TABLE IF NOT EXISTS licenses (
   expires_at INTEGER
 );
 
+CREATE TABLE IF NOT EXISTS guild_settings (
+  guild_id TEXT PRIMARY KEY,
+  gm_reward INTEGER DEFAULT 25,
+  gn_reward INTEGER DEFAULT 25,
+  xp_reward INTEGER DEFAULT 1,
+  difficulty_bias INTEGER DEFAULT 0,
+  created_at INTEGER,
+  updated_at INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS feature_flags (
+  guild_id TEXT,
+  feature TEXT,
+  enabled INTEGER DEFAULT 1,
+  updated_at INTEGER,
+  PRIMARY KEY(guild_id, feature)
+);
+
+CREATE TABLE IF NOT EXISTS content_overrides (
+  guild_id TEXT,
+  content_id TEXT,
+  scene_id TEXT,
+  override_json TEXT,
+  updated_at INTEGER,
+  PRIMARY KEY(guild_id, content_id, scene_id)
+);
+
+CREATE TABLE IF NOT EXISTS shop_packs (
+  pack_id TEXT PRIMARY KEY,
+  definition_json TEXT,
+  rotation_tag TEXT,
+  updated_at INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS gem_orders (
+  order_id TEXT PRIMARY KEY,
+  user_id TEXT,
+  network TEXT,
+  tx_id TEXT,
+  amount INTEGER,
+  gems INTEGER,
+  status TEXT,
+  meta_json TEXT,
+  created_at INTEGER,
+  updated_at INTEGER
+);
+
 CREATE INDEX IF NOT EXISTS idx_events_run ON events(run_id);
 CREATE INDEX IF NOT EXISTS idx_runs_guild ON runs(guild_id);
+CREATE INDEX IF NOT EXISTS idx_user_runs_status ON user_runs(user_id, status);

--- a/src/persistence/settings.ts
+++ b/src/persistence/settings.ts
@@ -1,0 +1,66 @@
+import db from './db.js';
+
+export interface GuildSettings {
+  guild_id: string;
+  gm_reward: number;
+  gn_reward: number;
+  xp_reward: number;
+  difficulty_bias: number;
+}
+
+const DEFAULT_SETTINGS: GuildSettings = {
+  guild_id: 'global',
+  gm_reward: 25,
+  gn_reward: 25,
+  xp_reward: 1,
+  difficulty_bias: 0,
+};
+
+export function getGuildSettings(guild_id?: string | null): GuildSettings {
+  if (!guild_id) {
+    return { ...DEFAULT_SETTINGS, guild_id: 'global' };
+  }
+  const row = db
+    .prepare(
+      'SELECT guild_id, gm_reward, gn_reward, xp_reward, difficulty_bias FROM guild_settings WHERE guild_id=?'
+    )
+    .get(guild_id) as GuildSettings | undefined;
+  if (!row) {
+    return { ...DEFAULT_SETTINGS, guild_id };
+  }
+  return {
+    guild_id,
+    gm_reward: row.gm_reward ?? DEFAULT_SETTINGS.gm_reward,
+    gn_reward: row.gn_reward ?? DEFAULT_SETTINGS.gn_reward,
+    xp_reward: row.xp_reward ?? DEFAULT_SETTINGS.xp_reward,
+    difficulty_bias: row.difficulty_bias ?? DEFAULT_SETTINGS.difficulty_bias,
+  };
+}
+
+export function upsertGuildSettings(guild_id: string, settings: Partial<GuildSettings>) {
+  const now = Date.now();
+  const current = getGuildSettings(guild_id);
+  const merged: GuildSettings = {
+    ...current,
+    ...settings,
+    guild_id,
+  };
+  const existingRow = db
+    .prepare('SELECT created_at FROM guild_settings WHERE guild_id=?')
+    .get(guild_id) as { created_at?: number } | undefined;
+  const createdAt = existingRow?.created_at ?? now;
+  db.prepare(
+    `INSERT INTO guild_settings (guild_id, gm_reward, gn_reward, xp_reward, difficulty_bias, created_at, updated_at)
+     VALUES (?,?,?,?,?,?,?)
+     ON CONFLICT(guild_id) DO UPDATE SET
+       gm_reward=excluded.gm_reward,
+       gn_reward=excluded.gn_reward,
+       xp_reward=excluded.xp_reward,
+       difficulty_bias=excluded.difficulty_bias,
+       updated_at=excluded.updated_at`
+  ).run(guild_id, merged.gm_reward, merged.gn_reward, merged.xp_reward, merged.difficulty_bias, createdAt, now);
+}
+
+export function deleteGuildSettings(guild_id: string) {
+  db.prepare('DELETE FROM guild_settings WHERE guild_id=?').run(guild_id);
+}

--- a/src/pvp/duels.ts
+++ b/src/pvp/duels.ts
@@ -1,0 +1,92 @@
+import { nanoid } from 'nanoid';
+import db from '../persistence/db.js';
+
+type PvPMode = '1v1' | '2v2';
+
+interface MatchState {
+  matchId: string;
+  mode: PvPMode;
+  participants: string[];
+  turnIndex: number;
+  scores: Record<string, number>;
+  createdAt: number;
+}
+
+const queue: Record<PvPMode, string[]> = {
+  '1v1': [],
+  '2v2': [],
+};
+
+const activeMatches = new Map<string, MatchState>();
+
+function storeMatch(state: MatchState) {
+  db.prepare(
+    `INSERT OR REPLACE INTO pvp_matches (match_id,kind,status,participants_json,created_at,updated_at,result_json)
+     VALUES (?,?,?,?,?,?,?)`
+  ).run(
+    state.matchId,
+    state.mode,
+    'active',
+    JSON.stringify(state.participants),
+    state.createdAt,
+    Date.now(),
+    '{}'
+  );
+}
+
+export function queueForMatch(user_id: string, mode: PvPMode = '1v1') {
+  const list = queue[mode];
+  if (list.includes(user_id)) {
+    return { message: 'Already in queue.' };
+  }
+  list.push(user_id);
+  if ((mode === '1v1' && list.length >= 2) || (mode === '2v2' && list.length >= 4)) {
+    const players = mode === '1v1' ? list.splice(0, 2) : list.splice(0, 4);
+    const matchId = `pvp_${nanoid(6)}`;
+    const state: MatchState = {
+      matchId,
+      mode,
+      participants: players,
+      turnIndex: 0,
+      scores: Object.fromEntries(players.map((p) => [p, 0])),
+      createdAt: Date.now(),
+    };
+    activeMatches.set(matchId, state);
+    storeMatch(state);
+    return { message: `Match ${matchId} ready: ${players.map((p) => `<@${p}>`).join(' vs ')}`, matchId };
+  }
+  return { message: `Queued for ${mode}. Waiting for more challengers.` };
+}
+
+export function recordPvPAction(matchId: string, user_id: string, result: 'win' | 'loss' | 'draw') {
+  const match = activeMatches.get(matchId);
+  if (!match) return { success: false, message: 'Match not active.' };
+  if (!match.participants.includes(user_id)) {
+    return { success: false, message: 'You are not part of this match.' };
+  }
+  if (result === 'win') match.scores[user_id] += 1;
+  if (result === 'loss') match.scores[user_id] -= 1;
+  match.turnIndex = (match.turnIndex + 1) % match.participants.length;
+  storeMatch(match);
+  return { success: true, message: `Score updated for ${matchId}.` };
+}
+
+export function concludeMatch(matchId: string) {
+  const match = activeMatches.get(matchId);
+  if (!match) return { success: false };
+  const sorted = Object.entries(match.scores).sort((a, b) => b[1] - a[1]);
+  const winner = sorted[0]?.[0];
+  db.prepare('UPDATE pvp_matches SET status=?, updated_at=?, result_json=? WHERE match_id=?')
+    .run('completed', Date.now(), JSON.stringify({ scores: match.scores, winner }), matchId);
+  activeMatches.delete(matchId);
+  return { success: true, winner };
+}
+
+export function listActiveMatches() {
+  return Array.from(activeMatches.values()).map((m) => ({
+    matchId: m.matchId,
+    mode: m.mode,
+    participants: m.participants,
+    scores: m.scores,
+  }));
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,223 @@
+declare module 'fs-extra';
+
+declare module 'better-sqlite3' {
+  export default class Database {
+    constructor(path: string);
+    prepare(query: string): any;
+    transaction<T extends (...args: any[]) => any>(fn: T): T;
+    pragma(statement: string): any;
+    exec(sql: string): void;
+  }
+}
+
+declare module 'fast-deep-equal' {
+  const equal: (a: unknown, b: unknown) => boolean;
+  export default equal;
+}
+
+declare module 'nanoid' {
+  export function nanoid(size?: number): string;
+}
+
+declare module 'discord.js' {
+  export type Snowflake = string;
+
+  export class Client<Ready extends boolean = boolean> {
+    constructor(options?: any);
+    once(event: string, listener: (...args: any[]) => void): this;
+    on(event: string, listener: (...args: any[]) => void): this;
+    login(token: string): Promise<string>;
+    channels: any;
+    user: { tag: string } | null;
+    [key: string]: any;
+  }
+
+  export const GatewayIntentBits: Record<string, number>;
+  export const Partials: Record<string, number>;
+  export const Events: Record<string, string>;
+  export const ChannelType: Record<string, number>;
+
+  export class EmbedBuilder {
+    constructor(data?: any);
+    setTitle(title: string): this;
+    setDescription(description: string): this;
+    setColor(color: number): this;
+    addFields(...fields: { name: string; value: string; inline?: boolean }[]): this;
+    setFooter(footer: { text: string }): this;
+    [key: string]: any;
+  }
+
+  export class ButtonBuilder {
+    constructor();
+    setCustomId(id: string): this;
+    setLabel(label: string): this;
+    setEmoji(emoji: string): this;
+    setStyle(style: ButtonStyle): this;
+    [key: string]: any;
+  }
+
+  export class StringSelectMenuBuilder {
+    constructor();
+    setCustomId(id: string): this;
+    setPlaceholder(text: string): this;
+    addOptions(options: { label: string; value: string; description?: string; emoji?: string }[] | { label: string; value: string; description?: string; emoji?: string }): this;
+    [key: string]: any;
+  }
+
+  export class ActionRowBuilder<T = any> {
+    constructor();
+    addComponents(...components: (T | T[])[]): this;
+    [key: string]: any;
+  }
+
+  export enum ButtonStyle {
+    Primary,
+    Secondary,
+    Success,
+    Danger
+  }
+
+  export class TextChannel {
+    id: string;
+    send(options: any): Promise<any>;
+    type: number;
+    [key: string]: any;
+  }
+
+  export class REST {
+    constructor(options?: any);
+    setToken(token: string): this;
+    put(route: string, options: any): Promise<any>;
+    [key: string]: any;
+  }
+
+  export const Routes: Record<string, (...args: any[]) => string>;
+
+  export class SlashCommandBuilder {
+    setName(name: string): this;
+    setDescription(description: string): this;
+    addUserOption(fn: (option: SlashCommandUserOption) => SlashCommandUserOption): this;
+    addIntegerOption(fn: (option: SlashCommandIntegerOption) => SlashCommandIntegerOption): this;
+    toJSON(): any;
+  }
+
+  export class SlashCommandUserOption {
+    setName(name: string): this;
+    setDescription(description: string): this;
+    setRequired(required: boolean): this;
+    [key: string]: any;
+  }
+
+  export class SlashCommandIntegerOption {
+    setName(name: string): this;
+    setDescription(description: string): this;
+    setRequired(required: boolean): this;
+    [key: string]: any;
+  }
+
+  export class Interaction {
+    user: { id: Snowflake; tag?: string };
+    reply(options: any): Promise<any>;
+    isButton(): this is ButtonInteraction;
+    isStringSelectMenu(): this is StringSelectMenuInteraction;
+    isChatInputCommand(): boolean;
+    commandName: string;
+    options: any;
+    [key: string]: any;
+  }
+
+  export class ButtonInteraction extends Interaction {
+    customId: string;
+    update(options: any): Promise<any>;
+    deferReply(options?: any): Promise<any>;
+    editReply(options: any): Promise<any>;
+    message: any;
+    channel: any;
+  }
+
+  export class StringSelectMenuInteraction extends Interaction {
+    customId: string;
+    values: string[];
+    update(options: any): Promise<any>;
+    deferReply(options?: any): Promise<any>;
+    editReply(options: any): Promise<any>;
+    message: any;
+    channel: any;
+  }
+
+  export class Message {
+    id: string;
+    author: { id: Snowflake; bot: boolean };
+    content: string;
+    channel: any;
+    reply(options: any): Promise<Message>;
+    delete(): Promise<void>;
+    mentions: any;
+    [key: string]: any;
+  }
+}
+
+declare module 'node:path' {
+  const path: any;
+  export default path;
+}
+
+declare module 'node:crypto' {
+  const crypto: any;
+  export default crypto;
+}
+
+declare module 'node:http' {
+  export type IncomingMessage = any;
+  export type ServerResponse = any;
+  export type RequestListener = (req: IncomingMessage, res: ServerResponse) => void;
+  export function createServer(listener: RequestListener): any;
+  const http: {
+    createServer: typeof createServer;
+  };
+  export default http;
+}
+
+declare module 'node:url' {
+  export class URLSearchParams {
+    constructor(init?: any);
+    append(name: string, value: string): void;
+    toString(): string;
+    get(name: string): string | null;
+    set(name: string, value: string): void;
+    entries(): IterableIterator<[string, string]>;
+  }
+  export class URL {
+    constructor(input: string, base?: string);
+    toString(): string;
+    searchParams: URLSearchParams;
+    pathname: string;
+  }
+  const url: {
+    URLSearchParams: typeof URLSearchParams;
+    URL: typeof URL;
+  };
+  export default url;
+}
+
+declare module 'fs' {
+  const fs: any;
+  export default fs;
+}
+
+declare module 'path' {
+  const path: any;
+  export default path;
+}
+
+declare const process: {
+  env: Record<string, string | undefined>;
+  argv: string[];
+  exit(code?: number): void;
+};
+
+type Buffer = any;
+declare const Buffer: {
+  from(input: any, encoding?: any): Buffer;
+  concat(list: Buffer[]): Buffer;
+};

--- a/src/ui/backpacks.ts
+++ b/src/ui/backpacks.ts
@@ -2,55 +2,131 @@ import db from '../persistence/db.js';
 import { loadDropTable } from '../content/contentLoader.js';
 import { nanoid } from 'nanoid';
 
-function weightedPick(weights:Record<string,number>){
-  const total = Object.values(weights).reduce((a,b)=>a+b,0);
-  let r = Math.random()*total;
-  for (const [rarity, w] of Object.entries(weights)){
-    if ((r-=w) <= 0) return rarity;
+type RarityWeights = Record<string, number>;
+
+interface OpenPackOptions {
+  skipCost?: boolean;
+  spendAmountOverride?: number;
+  packIdOverride?: string;
+}
+
+function weightedPick(weights: RarityWeights): string {
+  const total = Object.values(weights).reduce((a, b) => a + b, 0);
+  let r = Math.random() * total;
+  for (const [rarity, weight] of Object.entries(weights)) {
+    r -= weight;
+    if (r <= 0) return rarity;
   }
   return Object.keys(weights)[0];
 }
 
-function pityAdjustedRarity(user_id:string, pack_id:string, weights:Record<string,number>, rare_after=10, epic_after=30){
-  const row = db.prepare('SELECT opened, last_rarity FROM pity WHERE user_id=? AND pack_id=?').get(user_id, pack_id);
-  const opened = row?.opened || 0;
-  // Guarantee rare+ after rare_after opens, epic+ after epic_after
-  if (opened >= epic_after) return 'epic';
-  if (opened >= rare_after) return 'rare';
+function pityAdjustedRarity(
+  opened: number,
+  weights: RarityWeights,
+  rareAfter = 10,
+  epicAfter = 30
+): string {
+  if (opened >= epicAfter) return 'epic';
+  if (opened >= rareAfter) return 'rare';
   return weightedPick(weights);
 }
 
-export function openPack(user_id:string, pack_id='Genesis'){
-  const dt = loadDropTable('packs_genesis.json');
-  if (dt.pack_id !== pack_id) throw new Error('Unknown pack');
-  const costCoins = dt.cost.coins||0;
-  const prof = db.prepare('SELECT coins FROM profiles WHERE user_id=?').get(user_id);
-  if ((prof?.coins||0) < costCoins) throw new Error('Not enough coins');
+const PACK_FILES: Record<string, string> = {
+  Genesis: 'packs_genesis.json',
+};
 
-  db.prepare('UPDATE profiles SET coins=coins-? WHERE user_id=?').run(costCoins, user_id);
+const FRAGMENT_VALUES: Record<string, number> = {
+  common: 5,
+  uncommon: 10,
+  rare: 25,
+  epic: 40,
+  legendary: 60,
+  mythic: 100,
+};
 
-  const pity = db.prepare('SELECT opened, last_rarity FROM pity WHERE user_id=? AND pack_id=?').get(user_id, pack_id) || {opened:0,last_rarity:null};
-  const rarity = pityAdjustedRarity(user_id, pack_id, dt.weights, dt.pity?.rare_after||10, dt.pity?.epic_after||30);
-  const pool = dt.pools[rarity] || [];
-  const pick = pool[Math.floor(Math.random()*pool.length)] || {kind:'cosmetic', id:'cosmetic_confetti', rarity};
+export function openPack(user_id: string, packIdentifier = 'Genesis', options: OpenPackOptions = {}) {
+  const isFile = packIdentifier.endsWith('.json');
+  const pack_id = options.packIdOverride ?? (isFile ? 'Genesis' : packIdentifier);
+  const tableFile = isFile ? packIdentifier : PACK_FILES[packIdentifier] ?? 'packs_genesis.json';
+  const dt = loadDropTable(tableFile);
 
-  const txn_id = `txn_${nanoid(8)}`;
-  db.prepare('INSERT INTO economy_ledger (txn_id,user_id,kind,amount,reason,meta_json,ts) VALUES (?,?,?,?,?,?,?)')
-    .run(txn_id, user_id, 'pack_open', costCoins, 'coins_spent', JSON.stringify({pack_id}), Date.now());
+  const costCoins = dt.cost.coins ?? 0;
+  const spendAmount = options.spendAmountOverride ?? costCoins;
 
-  db.prepare('INSERT INTO inventories (user_id,item_id,kind,rarity,qty,meta_json) VALUES (?,?,?,?,?,?) ON CONFLICT(user_id,item_id) DO UPDATE SET qty=qty+1')
-    .run(user_id, pick.id, pick.kind, rarity, 1, '{}');
+  if (!options.skipCost && costCoins > 0) {
+    const prof = db
+      .prepare('SELECT coins FROM profiles WHERE user_id=?')
+      .get(user_id) as { coins?: number } | undefined;
+    if ((prof?.coins ?? 0) < costCoins) throw new Error('Not enough coins');
+    db.prepare('UPDATE profiles SET coins=coins-? WHERE user_id=?').run(costCoins, user_id);
+  }
 
-  db.prepare('INSERT INTO economy_ledger (txn_id,user_id,kind,amount,reason,meta_json,ts) VALUES (?,?,?,?,?,?,?)')
-    .run(`txn_${nanoid(8)}`, user_id, 'drop_grant', 1, 'pack_drop', JSON.stringify({pack_id, rarity, id: pick.id}), Date.now());
+  const pityRow = db
+    .prepare('SELECT opened, last_rarity FROM pity WHERE user_id=? AND pack_id=?')
+    .get(user_id, pack_id) as { opened?: number; last_rarity?: string } | undefined;
 
-  // update pity
-  const opened = (pity.opened||0) + 1
-  let newOpened = opened;
-  if ((dt.pity?.epic_after && opened >= dt.pity.epic_after) or (dt.pity?.rare_after and opened >= dt.pity.rare_after)):
-      pass
-  db.prepare('INSERT INTO pity (user_id, pack_id, opened, last_rarity) VALUES (?,?,?,?) ON CONFLICT(user_id,pack_id) DO UPDATE SET opened=opened+1, last_rarity=?')
-    .run(user_id, pack_id, opened, rarity, rarity);
+  const rarity = pityAdjustedRarity(
+    pityRow?.opened ?? 0,
+    dt.weights,
+    dt.pity?.rare_after,
+    dt.pity?.epic_after
+  );
+  const pool = dt.pools[rarity] ?? [];
+  const pick =
+    pool[Math.floor(Math.random() * pool.length)] ?? ({
+      kind: 'cosmetic',
+      id: 'cosmetic_confetti',
+      rarity,
+    } as { kind: string; id: string; rarity?: string });
 
-  return { rarity, drop: pick };
+  if (spendAmount > 0) {
+    db.prepare(
+      'INSERT INTO economy_ledger (txn_id,user_id,kind,amount,reason,meta_json,ts) VALUES (?,?,?,?,?,?,?)'
+    ).run(
+      `txn_${nanoid(8)}`,
+      user_id,
+      'pack_open',
+      spendAmount,
+      'coins_spent',
+      JSON.stringify({ pack_id }),
+      Date.now()
+    );
+  }
+
+  const existing = db
+    .prepare('SELECT qty FROM inventories WHERE user_id=? AND item_id=?')
+    .get(user_id, pick.id) as { qty?: number } | undefined;
+
+  let duplicate = false;
+  if (existing?.qty) {
+    duplicate = true;
+    const fragments = FRAGMENT_VALUES[rarity] ?? 5;
+    db.prepare('UPDATE profiles SET fragments=fragments+? WHERE user_id=?').run(fragments, user_id);
+  } else {
+    db.prepare(
+      'INSERT INTO inventories (user_id,item_id,kind,rarity,qty,meta_json) VALUES (?,?,?,?,?,?) ON CONFLICT(user_id,item_id) DO UPDATE SET qty=qty+excluded.qty'
+    ).run(user_id, pick.id, pick.kind, rarity, 1, '{}');
+  }
+
+  db.prepare(
+    'INSERT INTO economy_ledger (txn_id,user_id,kind,amount,reason,meta_json,ts) VALUES (?,?,?,?,?,?,?)'
+  ).run(
+    `txn_${nanoid(8)}`,
+    user_id,
+    'drop_grant',
+    1,
+    'pack_drop',
+    JSON.stringify({ pack_id, rarity, id: pick.id }),
+    Date.now()
+  );
+
+  const newOpened = (pityRow?.opened ?? 0) + 1;
+
+  db.prepare(
+    `INSERT INTO pity (user_id, pack_id, opened, last_rarity)
+     VALUES (?,?,?,?)
+     ON CONFLICT(user_id,pack_id) DO UPDATE SET opened=excluded.opened, last_rarity=excluded.last_rarity`
+  ).run(user_id, pack_id, newOpened, rarity);
+
+  return { rarity, drop: pick, duplicate };
 }

--- a/src/ui/compliments.ts
+++ b/src/ui/compliments.ts
@@ -1,0 +1,16 @@
+import { loadCompliments } from '../content/contentLoader.js';
+
+let cache: string[] | null = null;
+
+export function randomCompliment(): string {
+  if (!cache) {
+    try {
+      cache = loadCompliments().lines;
+    } catch (err) {
+      cache = ['The Vault hums softly.'];
+    }
+  }
+  if (!cache?.length) return 'The Vault hums softly.';
+  const idx = Math.floor(Math.random() * cache.length);
+  return cache[idx];
+}

--- a/src/ui/crafting.ts
+++ b/src/ui/crafting.ts
@@ -1,0 +1,37 @@
+import db from '../persistence/db.js';
+
+interface CraftRecipe {
+  costFragments: number;
+  description: string;
+  rarity: string;
+}
+
+const CRAFT_RECIPES: Record<string, CraftRecipe> = {
+  wp_liquidity_spear: { costFragments: 120, description: 'Forge the iconic spear of flow.', rarity: 'epic' },
+  gear_ledger_plate: { costFragments: 80, description: 'Assemble protective Ledger Plate armor.', rarity: 'uncommon' },
+  helm_oracle_hood: { costFragments: 90, description: 'Weave an Oracle Hood for insight checks.', rarity: 'rare' },
+  trinket_ledger_amulet: { costFragments: 70, description: 'Infuse a Ledger Amulet to boost focus.', rarity: 'rare' },
+  gift_frostsigil: { costFragments: 50, description: 'Craft the seasonal Frost Sigil cosmetic.', rarity: 'rare' },
+};
+
+export function listCraftables() {
+  return Object.entries(CRAFT_RECIPES).map(([id, recipe]) => ({ id, ...recipe }));
+}
+
+export function craftItem(user_id: string, item_id: string) {
+  const recipe = CRAFT_RECIPES[item_id];
+  if (!recipe) {
+    return { success: false, message: '❌ Unknown recipe.' };
+  }
+  const prof = db
+    .prepare('SELECT fragments FROM profiles WHERE user_id=?')
+    .get(user_id) as { fragments?: number } | undefined;
+  if ((prof?.fragments ?? 0) < recipe.costFragments) {
+    return { success: false, message: `❌ Need ${recipe.costFragments} fragments.` };
+  }
+  db.prepare('UPDATE profiles SET fragments=fragments-? WHERE user_id=?').run(recipe.costFragments, user_id);
+  db.prepare(
+    'INSERT INTO inventories (user_id,item_id,kind,rarity,qty,meta_json) VALUES (?,?,?,?,?,?) ON CONFLICT(user_id,item_id) DO UPDATE SET qty=qty+1'
+  ).run(user_id, item_id, 'crafted', recipe.rarity, 1, JSON.stringify({ crafted_at: Date.now() }));
+  return { success: true, message: `🛠️ Crafted ${item_id} for ${recipe.costFragments} fragments!` };
+}

--- a/src/ui/equipment.ts
+++ b/src/ui/equipment.ts
@@ -1,0 +1,413 @@
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonInteraction,
+  ButtonStyle,
+  EmbedBuilder,
+  StringSelectMenuBuilder,
+  StringSelectMenuInteraction,
+} from 'discord.js';
+import db from '../persistence/db.js';
+
+export type EquipmentSlot = 'weapon' | 'armor' | 'helm' | 'trinket' | 'deck';
+
+interface EquipmentBonus {
+  dcShift?: number;
+  dcOffset?: number;
+  advantageTags?: string[];
+  disadvantageTags?: string[];
+  focusBonus?: number;
+  hpBonus?: number;
+  sleightBonus?: number;
+  rerollFail?: boolean;
+  neutralizeCritFail?: boolean;
+  fragmentsBoost?: number;
+  preventsCoinLoss?: boolean;
+}
+
+interface EquipmentDefinition {
+  id: string;
+  slot: EquipmentSlot;
+  name: string;
+  rarity: string;
+  emoji: string;
+  description: string;
+  setKey?: string;
+  bonuses: EquipmentBonus;
+}
+
+const EQUIPMENT_REGISTRY: Record<string, EquipmentDefinition> = {
+  wp_liquidity_spear: {
+    id: 'wp_liquidity_spear',
+    slot: 'weapon',
+    name: 'Liquidity Spear',
+    rarity: 'epic',
+    emoji: '⚔️',
+    description: 'A spear that flows through gaps in consensus. Grants advantage on rush and momentum tags.',
+    setKey: 'liquidity',
+    bonuses: {
+      dcOffset: -1,
+      advantageTags: ['rush', 'momentum', 'gremlin'],
+      sleightBonus: 1,
+    },
+  },
+  gear_ledger_plate: {
+    id: 'gear_ledger_plate',
+    slot: 'armor',
+    name: 'Ledger Plate',
+    rarity: 'uncommon',
+    emoji: '🛡️',
+    description: 'Heavy plating that remembers every promise. Flat HP protection and mitigates critical failures.',
+    setKey: 'audit',
+    bonuses: {
+      hpBonus: 5,
+      neutralizeCritFail: true,
+    },
+  },
+  trinket_hardware_wallet: {
+    id: 'trinket_hardware_wallet',
+    slot: 'trinket',
+    name: 'Hardware Wallet',
+    rarity: 'uncommon',
+    emoji: '💾',
+    description: 'Cold storage that laughs at rugs. Protects coins and adds fragments when duplicates drop.',
+    setKey: 'audit',
+    bonuses: {
+      preventsCoinLoss: true,
+      fragmentsBoost: 2,
+    },
+  },
+  trinket_ledger_amulet: {
+    id: 'trinket_ledger_amulet',
+    slot: 'trinket',
+    name: 'Ledger Amulet',
+    rarity: 'rare',
+    emoji: '📿',
+    description: 'A faint hum tracks collective focus. Adds focus each scene and eases ritual tags.',
+    setKey: 'harmony',
+    bonuses: {
+      focusBonus: 2,
+      dcShift: -1,
+      advantageTags: ['ritual', 'insight'],
+    },
+  },
+  helm_oracle_hood: {
+    id: 'helm_oracle_hood',
+    slot: 'helm',
+    name: 'Oracle Hood',
+    rarity: 'rare',
+    emoji: '🪬',
+    description: 'Threads of foresight align probabilities. Lowers DC for insight and puzzle actions.',
+    setKey: 'harmony',
+    bonuses: {
+      dcOffset: -2,
+      advantageTags: ['insight', 'puzzle'],
+    },
+  },
+  helm_forked_crown: {
+    id: 'helm_forked_crown',
+    slot: 'helm',
+    name: 'Forked Crown',
+    rarity: 'epic',
+    emoji: '👑',
+    description: 'Splits perception, doubling possible paths. Grants a reroll on fails each scene.',
+    setKey: 'liquidity',
+    bonuses: {
+      rerollFail: true,
+    },
+  },
+};
+
+const EQUIPMENT_SETS: Record<
+  string,
+  { label: string; threshold: number; description: string; bonus: EquipmentBonus }
+> = {
+  audit: {
+    label: 'Audit Set',
+    threshold: 2,
+    description: 'Integrity sharpened—small DC reduction on integrity tags.',
+    bonus: {
+      dcOffset: -1,
+      advantageTags: ['integrity'],
+    },
+  },
+  liquidity: {
+    label: 'Flow State Set',
+    threshold: 2,
+    description: 'Momentum builds, granting sleight bonuses on crit successes.',
+    bonus: {
+      sleightBonus: 1,
+    },
+  },
+  harmony: {
+    label: 'Harmony Set',
+    threshold: 2,
+    description: 'Attunement to the Vault adds focus recovery on successes.',
+    bonus: {
+      focusBonus: 1,
+    },
+  },
+};
+
+export interface EquippedItem {
+  slot: EquipmentSlot;
+  definition: EquipmentDefinition;
+  durability: number;
+  max_durability: number;
+}
+
+export function equippedLoadout(user_id: string): EquippedItem[] {
+  const rows = db
+    .prepare(
+      'SELECT slot, item_id, durability, max_durability FROM equipment_loadouts WHERE user_id=?'
+    )
+    .all(user_id) as { slot: EquipmentSlot; item_id: string; durability: number; max_durability: number }[];
+  return rows
+    .map((row) => {
+      const def = EQUIPMENT_REGISTRY[row.item_id];
+      if (!def) return undefined;
+      return { slot: row.slot, definition: def, durability: row.durability, max_durability: row.max_durability };
+    })
+    .filter((v): v is EquippedItem => Boolean(v));
+}
+
+export function equipmentBonuses(user_id: string): EquipmentBonus[] {
+  const equipped = equippedLoadout(user_id);
+  const bonuses: EquipmentBonus[] = [];
+  const setCounts: Record<string, number> = {};
+  for (const item of equipped) {
+    bonuses.push(item.definition.bonuses);
+    if (item.definition.setKey) {
+      setCounts[item.definition.setKey] = (setCounts[item.definition.setKey] ?? 0) + 1;
+    }
+  }
+  for (const [setKey, count] of Object.entries(setCounts)) {
+    const set = EQUIPMENT_SETS[setKey];
+    if (set && count >= set.threshold) {
+      bonuses.push(set.bonus);
+    }
+  }
+  return bonuses;
+}
+
+interface AggregatedBonusTotals {
+  dcShift: number;
+  dcOffset: number;
+  focusBonus: number;
+  hpBonus: number;
+  sleightBonus: number;
+  rerollFail: boolean;
+  neutralizeCritFail: boolean;
+  fragmentsBoost: number;
+  preventsCoinLoss: boolean;
+  advantageTags: string[];
+  disadvantageTags: string[];
+}
+
+export function aggregateBonus(user_id: string) {
+  const bonuses = equipmentBonuses(user_id);
+  return bonuses.reduce<AggregatedBonusTotals>((acc, bonus) => {
+    if (bonus.dcShift) acc.dcShift += bonus.dcShift;
+    if (bonus.dcOffset) acc.dcOffset += bonus.dcOffset;
+    if (bonus.focusBonus) acc.focusBonus += bonus.focusBonus;
+    if (bonus.hpBonus) acc.hpBonus += bonus.hpBonus;
+    if (bonus.sleightBonus) acc.sleightBonus += bonus.sleightBonus;
+    if (bonus.rerollFail) acc.rerollFail = true;
+    if (bonus.neutralizeCritFail) acc.neutralizeCritFail = true;
+    if (bonus.fragmentsBoost) acc.fragmentsBoost += bonus.fragmentsBoost;
+    if (bonus.preventsCoinLoss) acc.preventsCoinLoss = true;
+    const adv = bonus.advantageTags ?? [];
+    const disadv = bonus.disadvantageTags ?? [];
+    acc.advantageTags = [...new Set([...acc.advantageTags, ...adv])];
+    acc.disadvantageTags = [...new Set([...acc.disadvantageTags, ...disadv])];
+    return acc;
+  }, {
+    dcShift: 0,
+    dcOffset: 0,
+    focusBonus: 0,
+    hpBonus: 0,
+    sleightBonus: 0,
+    rerollFail: false,
+    neutralizeCritFail: false,
+    fragmentsBoost: 0,
+    preventsCoinLoss: false,
+    advantageTags: [],
+    disadvantageTags: [],
+  });
+}
+
+export function ensureLoadoutDurability(user_id: string) {
+  const equipped = equippedLoadout(user_id);
+  for (const item of equipped) {
+    if (item.durability <= 0) {
+      db.prepare('DELETE FROM equipment_loadouts WHERE user_id=? AND slot=?').run(user_id, item.slot);
+    }
+  }
+}
+
+export function tickDurability(user_id: string, slots: EquipmentSlot[], amount = 1) {
+  const stmt = db.prepare(
+    'UPDATE equipment_loadouts SET durability = MAX(0, durability-?) WHERE user_id=? AND slot=?'
+  );
+  for (const slot of slots) {
+    stmt.run(amount, user_id, slot);
+  }
+  ensureLoadoutDurability(user_id);
+}
+
+function inventoryItemsForSlot(user_id: string, slot: EquipmentSlot) {
+  const defs = Object.values(EQUIPMENT_REGISTRY).filter((d) => d.slot === slot);
+  if (defs.length === 0) return [];
+  const stmt = db.prepare('SELECT qty FROM inventories WHERE user_id=? AND item_id=?');
+  return defs
+    .filter((def) => (stmt.get(user_id, def.id) as { qty?: number } | undefined)?.qty ?? 0 > 0)
+    .map((def) => def);
+}
+
+export function equipItem(user_id: string, item_id: string) {
+  const def = EQUIPMENT_REGISTRY[item_id];
+  if (!def) throw new Error('Unknown equipment item');
+  const owned = db
+    .prepare('SELECT qty FROM inventories WHERE user_id=? AND item_id=?')
+    .get(user_id, item_id) as { qty?: number } | undefined;
+  if ((owned?.qty ?? 0) <= 0) throw new Error('You do not own that item.');
+
+  db.prepare('INSERT OR REPLACE INTO equipment_loadouts (user_id, slot, item_id, durability, max_durability, set_key, equipped_at) VALUES (?,?,?,?,?,?,?)')
+    .run(user_id, def.slot, def.id, 100, 100, def.setKey ?? null, Date.now());
+  db.prepare('UPDATE profiles SET loadout_hash=? WHERE user_id=?').run(`${Date.now()}`, user_id);
+}
+
+export function unequipSlot(user_id: string, slot: EquipmentSlot) {
+  db.prepare('DELETE FROM equipment_loadouts WHERE user_id=? AND slot=?').run(user_id, slot);
+  db.prepare('UPDATE profiles SET loadout_hash=? WHERE user_id=?').run(`${Date.now()}`, user_id);
+}
+
+export async function renderEquipment(user_id: string) {
+  const embed = new EmbedBuilder()
+    .setTitle('⚙️ Loadout')
+    .setColor(0x8bd3ff)
+    .setDescription('Equip weapons, armor, helms, trinkets, and decks to gain passive bonuses. Durability decreases with use.');
+
+  const equipped = equippedLoadout(user_id);
+  if (equipped.length === 0) {
+    embed.addFields({ name: 'Current Equipment', value: 'Nothing equipped yet.', inline: false });
+  } else {
+    for (const slot of ['weapon', 'armor', 'helm', 'trinket', 'deck'] as EquipmentSlot[]) {
+      const eq = equipped.find((e) => e.slot === slot);
+      if (!eq) {
+        embed.addFields({ name: slot.toUpperCase(), value: '_empty_', inline: true });
+        continue;
+      }
+      const pct = Math.round((eq.durability / eq.max_durability) * 100);
+      embed.addFields({
+        name: `${slot.toUpperCase()} — ${eq.definition.emoji} ${eq.definition.name}`,
+        value: `${eq.definition.description}\nDurability: ${pct}%`,
+        inline: true,
+      });
+    }
+  }
+
+  const rows: ActionRowBuilder<any>[] = [];
+  const slotSelect = new StringSelectMenuBuilder()
+    .setCustomId('equipment:slot')
+    .setPlaceholder('Choose a slot to equip...')
+    .addOptions(
+      ['weapon', 'armor', 'helm', 'trinket', 'deck'].map((slot) => ({
+        label: slot.toUpperCase(),
+        value: slot,
+      }))
+    );
+  rows.push(new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(slotSelect));
+
+  const unequipRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder().setCustomId('equipment:unequip:weapon').setLabel('Unequip Weapon').setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder().setCustomId('equipment:unequip:armor').setLabel('Unequip Armor').setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder().setCustomId('equipment:unequip:helm').setLabel('Unequip Helm').setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder().setCustomId('equipment:unequip:trinket').setLabel('Unequip Trinket').setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder().setCustomId('equipment:unequip:deck').setLabel('Unequip Deck').setStyle(ButtonStyle.Secondary)
+  );
+  rows.push(unequipRow);
+
+  return { embeds: [embed], components: rows };
+}
+
+export async function handleEquipmentSelect(i: StringSelectMenuInteraction) {
+  const slot = i.values[0] as EquipmentSlot;
+  const options = inventoryItemsForSlot(i.user.id, slot);
+  if (options.length === 0) {
+    await i.update({ content: '❌ No equipment available for that slot.', components: [], embeds: [] });
+    return;
+  }
+  const select = new StringSelectMenuBuilder()
+    .setCustomId(`equipment:equip:${slot}`)
+    .setPlaceholder(`Equip ${slot.toUpperCase()} item...`)
+    .addOptions(
+      options.map((opt) => ({
+        label: opt.name,
+        description: opt.description.slice(0, 90),
+        value: opt.id,
+        emoji: opt.emoji,
+      }))
+    );
+  await i.update({
+    content: 'Select the item you want to equip.',
+    components: [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select)],
+    embeds: [],
+  });
+}
+
+export async function handleEquipmentEquip(i: StringSelectMenuInteraction) {
+  const [, , slot] = i.customId.split(':');
+  const itemId = i.values[0];
+  try {
+    equipItem(i.user.id, itemId);
+    const view = await renderEquipment(i.user.id);
+    await i.update({ content: `✅ Equipped ${EQUIPMENT_REGISTRY[itemId]?.name ?? itemId}.`, ...view });
+  } catch (err: any) {
+    await i.update({ content: `❌ ${err.message ?? 'Unable to equip item.'}` });
+  }
+}
+
+export async function handleEquipmentButton(i: ButtonInteraction) {
+  const [, action, slot] = i.customId.split(':');
+  if (action === 'unequip' && slot) {
+    unequipSlot(i.user.id, slot as EquipmentSlot);
+    const view = await renderEquipment(i.user.id);
+    await i.update({ content: `Slot ${slot.toUpperCase()} unequipped.`, ...view });
+    return;
+  }
+  const view = await renderEquipment(i.user.id);
+  await i.update(view);
+}
+
+export function hasCoinLossProtection(user_id: string) {
+  return aggregateBonus(user_id).preventsCoinLoss;
+}
+
+export function fragmentsBoost(user_id: string) {
+  return aggregateBonus(user_id).fragmentsBoost;
+}
+
+export function loadoutSleightBonus(user_id: string, outcomeKind: string) {
+  const agg = aggregateBonus(user_id);
+  if (agg.sleightBonus && (outcomeKind === 'crit_success' || outcomeKind === 'success')) {
+    return agg.sleightBonus;
+  }
+  return 0;
+}
+
+export function shouldRerollFails(user_id: string) {
+  return aggregateBonus(user_id).rerollFail;
+}
+
+export function neutralizesCritFail(user_id: string) {
+  return aggregateBonus(user_id).neutralizeCritFail;
+}
+
+export function equipmentAdvantageState(user_id: string, tags: string[] = []) {
+  const agg = aggregateBonus(user_id);
+  const advantage = agg.advantageTags.some((tag) => tags.includes(tag));
+  const disadvantage = agg.disadvantageTags.some((tag) => tags.includes(tag));
+  return { advantage, disadvantage, dcShift: agg.dcShift, dcOffset: agg.dcOffset, focusBonus: agg.focusBonus, hpBonus: agg.hpBonus };
+}
+

--- a/src/ui/minigames.ts
+++ b/src/ui/minigames.ts
@@ -1,0 +1,159 @@
+import { ActionRowBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle, EmbedBuilder } from 'discord.js';
+import { nanoid } from 'nanoid';
+import db from '../persistence/db.js';
+
+type MinigameType = 'memory' | 'reaction' | 'cipher' | 'gambit';
+
+interface MinigameSession {
+  id: string;
+  type: MinigameType;
+  userId: string;
+  state: any;
+  createdAt: number;
+}
+
+const sessions = new Map<string, MinigameSession>();
+
+function storeScore(userId: string, type: MinigameType, score: number) {
+  const row = db
+    .prepare('SELECT best_score FROM minigame_scores WHERE user_id=? AND minigame_id=?')
+    .get(userId, type) as { best_score?: number } | undefined;
+  const best = Math.max(score, row?.best_score ?? 0);
+  db.prepare(
+    `INSERT INTO minigame_scores (user_id,minigame_id,best_score,last_played)
+     VALUES (?,?,?,?)
+     ON CONFLICT(user_id,minigame_id) DO UPDATE SET best_score=excluded.best_score, last_played=excluded.last_played`
+  ).run(userId, type, best, Date.now());
+}
+
+export function startMinigame(userId: string, type: MinigameType) {
+  const sessionId = nanoid(10);
+  let embed: EmbedBuilder;
+  let row: ActionRowBuilder<ButtonBuilder>;
+  let state: any = {};
+
+  if (type === 'memory') {
+    const choices = ['🔴', '🟢', '🔵', '🟡', '🟣'];
+    const sequence = Array.from({ length: 4 }, () => choices[Math.floor(Math.random() * choices.length)]);
+    state.sequence = sequence;
+    state.progress = 0;
+    embed = new EmbedBuilder()
+      .setTitle('🧠 Memory Runes')
+      .setDescription(`Memorize this sequence, then repeat it by pressing the buttons: ${sequence.join(' ')}`)
+      .setColor(0xf0c987);
+    row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      ...choices.map((emoji) =>
+        new ButtonBuilder().setCustomId(`minigame:memory:${sessionId}:${emoji}`).setLabel(emoji).setStyle(ButtonStyle.Secondary)
+      )
+    );
+  } else if (type === 'reaction') {
+    state.started = Date.now();
+    embed = new EmbedBuilder()
+      .setTitle('⚡ Reaction Sparks')
+      .setDescription('Wait for the prompt, then tap GO as fast as possible!')
+      .setColor(0xf97316);
+    row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder().setCustomId(`minigame:reaction:${sessionId}:go`).setLabel('GO!').setStyle(ButtonStyle.Primary)
+    );
+  } else if (type === 'cipher') {
+    const words = [
+      ['vault', 'A ancient system hums.'],
+      ['ledger', 'Blocks align silently.'],
+      ['gremlin', 'Mischief in the vents.'],
+    ];
+    const pick = words[Math.floor(Math.random() * words.length)];
+    const hint = pick[1];
+    const answer = pick[0];
+    const scrambled = answer
+      .split('')
+      .sort(() => Math.random() - 0.5)
+      .join('');
+    state.answer = answer;
+    state.guesses = 0;
+    embed = new EmbedBuilder()
+      .setTitle('🔐 Cipher Nibbles')
+      .setDescription(`Unscramble the word: **${scrambled}**\nHint: ${hint}`)
+      .setFooter({ text: 'Use the buttons to guess.' })
+      .setColor(0x22c55e);
+    row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      ...answer.split('').map((letter, idx) =>
+        new ButtonBuilder()
+          .setCustomId(`minigame:cipher:${sessionId}:${letter}:${idx}`)
+          .setLabel(letter.toUpperCase())
+          .setStyle(ButtonStyle.Secondary)
+      )
+    );
+    state.progress = '';
+  } else {
+    state.pick = Math.floor(Math.random() * 3);
+    embed = new EmbedBuilder()
+      .setTitle('🎲 Gremlin Gambits')
+      .setDescription('Pick the cup hiding the ledger chip!')
+      .setColor(0x8b5cf6);
+    row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      ...[0, 1, 2].map((idx) =>
+        new ButtonBuilder()
+          .setCustomId(`minigame:gambit:${sessionId}:${idx}`)
+          .setLabel(`Cup ${idx + 1}`)
+          .setStyle(ButtonStyle.Secondary)
+      )
+    );
+  }
+
+  sessions.set(sessionId, { id: sessionId, type, userId, state, createdAt: Date.now() });
+  return { sessionId, embed, row };
+}
+
+export async function handleMinigameButton(i: ButtonInteraction) {
+  const [, type, sessionId, payload] = i.customId.split(':');
+  const session = sessions.get(sessionId);
+  if (!session || session.userId !== i.user.id) {
+    await i.reply({ ephemeral: true, content: '❌ Session expired.' });
+    return;
+  }
+  if (type === 'memory') {
+    const expected = session.state.sequence[session.state.progress];
+    if (payload === expected) {
+      session.state.progress += 1;
+      if (session.state.progress >= session.state.sequence.length) {
+        storeScore(i.user.id, 'memory', session.state.sequence.length);
+        sessions.delete(sessionId);
+        await i.update({ content: '✅ Perfect recall! Sleight score increased by 1.', components: [], embeds: [] });
+      } else {
+        await i.reply({ ephemeral: true, content: '👍 Correct! Keep going.' });
+      }
+    } else {
+      sessions.delete(sessionId);
+      await i.update({ content: '❌ Sequence broken. The runes fade.', components: [], embeds: [] });
+    }
+    return;
+  }
+  if (type === 'reaction') {
+    const delta = Date.now() - session.state.started;
+    storeScore(i.user.id, 'reaction', Math.max(0, 5000 - delta));
+    sessions.delete(sessionId);
+    await i.update({ content: `⚡ Reaction time: ${delta}ms`, components: [], embeds: [] });
+    return;
+  }
+  if (type === 'cipher') {
+    session.state.guesses += 1;
+    session.state.progress += payload;
+    if (session.state.progress.length >= session.state.answer.length) {
+      const success = session.state.progress === session.state.answer;
+      storeScore(i.user.id, 'cipher', success ? 100 - session.state.guesses * 5 : 0);
+      sessions.delete(sessionId);
+      await i.update({ content: success ? '🔓 Cipher solved!' : '❌ Incorrect cipher.', components: [], embeds: [] });
+    } else {
+      await i.reply({ ephemeral: true, content: `Current guess: ${session.state.progress}` });
+    }
+    return;
+  }
+  if (type === 'gambit') {
+    const pick = Number(payload);
+    const win = pick === session.state.pick;
+    storeScore(i.user.id, 'gambit', win ? 50 : 0);
+    sessions.delete(sessionId);
+    await i.update({ content: win ? '🎉 You found the chip!' : '😵 Rugged! Gremlins cackle.', components: [], embeds: [] });
+    return;
+  }
+}

--- a/src/ui/recovery.ts
+++ b/src/ui/recovery.ts
@@ -1,0 +1,67 @@
+import db from '../persistence/db.js';
+
+export function attemptSelfReboot(user_id: string) {
+  const prof = db
+    .prepare('SELECT hp, hp_max, focus, focus_max, coins, fragments, downed_at FROM profiles WHERE user_id=?')
+    .get(user_id) as {
+      hp: number;
+      hp_max: number;
+      focus: number;
+      focus_max: number;
+      coins: number;
+      fragments: number;
+      downed_at?: number;
+    } | undefined;
+  if (!prof?.downed_at) {
+    return { success: false, message: '✅ You are already standing.' };
+  }
+
+  const coinCost = 250;
+  const fragmentCost = 25;
+
+  if (prof.coins >= coinCost) {
+    db.prepare('UPDATE profiles SET coins=coins-?, hp=?, focus=?, downed_at=NULL WHERE user_id=?')
+      .run(coinCost, Math.ceil(prof.hp_max * 0.5), Math.ceil(prof.focus_max * 0.5), user_id);
+    return { success: true, message: `🔁 Rebooted for ${coinCost} coins. HP and Focus restored to 50%.` };
+  }
+
+  if (prof.fragments >= fragmentCost) {
+    db.prepare('UPDATE profiles SET fragments=fragments-?, hp=?, focus=?, downed_at=NULL WHERE user_id=?')
+      .run(fragmentCost, Math.ceil(prof.hp_max * 0.4), Math.ceil(prof.focus_max * 0.4), user_id);
+    return { success: true, message: `🔁 Rebooted for ${fragmentCost} fragments. HP and Focus restored to 40%.` };
+  }
+
+  return { success: false, message: '❌ Not enough coins or fragments to reboot. Ask an ally to revive you!' };
+}
+
+export function attemptAllyRevive(actor_id: string, target_id: string) {
+  if (actor_id === target_id) {
+    return { success: false, message: '❌ Use reboot to revive yourself.' };
+  }
+  const target = db
+    .prepare('SELECT hp, hp_max, focus, focus_max, downed_at FROM profiles WHERE user_id=?')
+    .get(target_id) as { hp: number; hp_max: number; focus: number; focus_max: number; downed_at?: number } | undefined;
+  if (!target?.downed_at) {
+    return { success: false, message: '✅ That adventurer is already up.' };
+  }
+
+  const actor = db
+    .prepare('SELECT fragments, coins FROM profiles WHERE user_id=?')
+    .get(actor_id) as { fragments: number; coins: number } | undefined;
+
+  const costCoins = 150;
+  if ((actor?.fragments ?? 0) >= 15) {
+    db.prepare('UPDATE profiles SET fragments=fragments-15 WHERE user_id=?').run(actor_id);
+    db.prepare('UPDATE profiles SET hp=?, focus=?, downed_at=NULL WHERE user_id=?')
+      .run(Math.ceil(target.hp_max * 0.6), Math.ceil(target.focus_max * 0.6), target_id);
+    return { success: true, message: `✨ Revived ally using 15 fragments! <@${target_id}> is back at 60% strength.` };
+  }
+  if ((actor?.coins ?? 0) >= costCoins) {
+    db.prepare('UPDATE profiles SET coins=coins-? WHERE user_id=?').run(costCoins, actor_id);
+    db.prepare('UPDATE profiles SET hp=?, focus=?, downed_at=NULL WHERE user_id=?')
+      .run(Math.ceil(target.hp_max * 0.4), Math.ceil(target.focus_max * 0.4), target_id);
+    return { success: true, message: `✨ Revived ally for ${costCoins} coins! <@${target_id}> returns with 40% HP.` };
+  }
+
+  return { success: false, message: '❌ Not enough resources to revive. Need 15 fragments or 150 coins.' };
+}

--- a/src/ui/roles.ts
+++ b/src/ui/roles.ts
@@ -1,0 +1,349 @@
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  EmbedBuilder,
+  StringSelectMenuBuilder,
+} from 'discord.js';
+import db from '../persistence/db.js';
+import { startRun } from '../engine/orchestrator.js';
+
+interface Role {
+  id: string;
+  name: string;
+  description: string;
+  emoji: string;
+  banter_key: string;
+}
+
+export const AVAILABLE_ROLES: Role[] = [
+  {
+    id: 'dev',
+    name: 'Dev Wizard',
+    description: 'See the code beneath reality. Master of logic and systems.',
+    emoji: '🧙‍♂️',
+    banter_key: 'dev',
+  },
+  {
+    id: 'trader',
+    name: 'Market Trader',
+    description: 'Navigate volatility with precision. Risk and reward specialist.',
+    emoji: '📈',
+    banter_key: 'trader',
+  },
+  {
+    id: 'validator',
+    name: 'Consensus Keeper',
+    description: 'Maintain order and integrity. Guardian of the network.',
+    emoji: '⚖️',
+    banter_key: 'validator',
+  },
+  {
+    id: 'hacker',
+    name: 'Edge Walker',
+    description: 'Find exploits in any system. Master of unconventional solutions.',
+    emoji: '🔓',
+    banter_key: 'hacker',
+  },
+  {
+    id: 'whale',
+    name: 'Deep Pocket',
+    description: 'Move markets with presence alone. Influence through weight.',
+    emoji: '🐋',
+    banter_key: 'whale',
+  },
+  {
+    id: 'miner',
+    name: 'Block Forger',
+    description: 'Turn computation into consensus. Builder of the chain.',
+    emoji: '⛏️',
+    banter_key: 'miner',
+  },
+  {
+    id: 'shiller',
+    name: 'Hype Architect',
+    description: 'Craft narratives that move crowds. Master of momentum.',
+    emoji: '📢',
+    banter_key: 'shiller',
+  },
+  {
+    id: 'meme',
+    name: 'Meme Lord',
+    description: 'Weaponize culture and humor. Chaos with purpose.',
+    emoji: '🎭',
+    banter_key: 'meme',
+  },
+];
+
+export const ROLE_SCHEMA_UPDATES = `
+-- Add role tracking to profiles
+ALTER TABLE profiles ADD COLUMN selected_role TEXT DEFAULT NULL;
+
+-- Track multiple concurrent runs per user
+CREATE TABLE IF NOT EXISTS user_runs (
+  user_id TEXT,
+  run_id TEXT,
+  role_id TEXT,
+  scene_id TEXT,
+  status TEXT DEFAULT 'active',
+  created_at INTEGER,
+  updated_at INTEGER,
+  PRIMARY KEY(user_id, run_id),
+  FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
+  FOREIGN KEY (run_id) REFERENCES runs(run_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_runs_status ON user_runs(user_id, status);
+`;
+
+export async function showRoleSelection(user_id: string, for_tutorial = false) {
+  const userRuns = getUserActiveRuns(user_id);
+  const currentRole = getCurrentRole(user_id);
+
+  let description = for_tutorial
+    ? '🎭 **Choose Your Role for Tutorial**\nEach role experiences the story differently with unique dialogue and options.\n\n'
+    : '🎭 **Role Selection**\nYour role affects dialogue, available actions, and story perspective.\n\n';
+
+  if (currentRole?.selected_role) {
+    const role = getRoleById(currentRole.selected_role);
+    if (role) {
+      description += `**Current Role**: ${role.emoji} ${role.name}\n\n`;
+    }
+  }
+
+  if (userRuns.length > 0) {
+    description += `**Active Games**: ${userRuns.length}\n`;
+    userRuns.forEach((run) => {
+      const role = getRoleById(run.role_id);
+      description += `• ${role?.emoji ?? '🎲'} Scene ${run.scene_id} (${role?.name ?? 'Unknown'})\n`;
+    });
+    description += '\n';
+  }
+
+  description += '**Available Roles**:\n';
+
+  const embed = new EmbedBuilder()
+    .setTitle('🎭 Role Selection')
+    .setDescription(description)
+    .setColor(0x5b8cff);
+
+  AVAILABLE_ROLES.forEach((role) => {
+    embed.addFields({
+      name: `${role.emoji} ${role.name}`,
+      value: role.description,
+      inline: true,
+    });
+  });
+
+  const selectMenu = new StringSelectMenuBuilder()
+    .setCustomId(for_tutorial ? 'role:select:tutorial' : 'role:select:main')
+    .setPlaceholder('Choose your role...')
+    .addOptions(
+      AVAILABLE_ROLES.map((role) => ({
+        label: role.name,
+        description: role.description.slice(0, 100),
+        value: role.id,
+        emoji: role.emoji,
+      }))
+    );
+
+  const row1 = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(selectMenu);
+
+  const buttons: ButtonBuilder[] = [
+    new ButtonBuilder()
+      .setCustomId('role:tutorial:replay')
+      .setLabel('🔄 Replay Tutorial')
+      .setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder()
+      .setCustomId('role:games:list')
+      .setLabel('📋 My Games')
+      .setStyle(ButtonStyle.Primary),
+  ];
+
+  if (userRuns.length > 0) {
+    buttons.push(
+      new ButtonBuilder()
+        .setCustomId('role:resume:select')
+        .setLabel('▶️ Resume Game')
+        .setStyle(ButtonStyle.Success)
+    );
+  }
+
+  const row2 = new ActionRowBuilder<ButtonBuilder>().addComponents(...buttons);
+
+  return { embeds: [embed], components: [row1, row2] };
+}
+
+export function handleRoleSelection(customId: string, user_id: string, values?: string[]) {
+  const parts = customId.split(':');
+
+  if (parts[0] !== 'role') return 'Unknown role action.';
+
+  if (parts[1] === 'select') {
+    const roleId = values?.[0];
+    if (!roleId) return '❌ No role selected.';
+
+    const role = getRoleById(roleId);
+    if (!role) return '❌ Invalid role.';
+
+    db.prepare('UPDATE profiles SET selected_role=? WHERE user_id=?').run(roleId, user_id);
+
+    if (parts[2] === 'tutorial') {
+      startRoleBasedRun(user_id, roleId, '1.1', { is_tutorial: true });
+      return `🎭 **Tutorial Started**\nYou are now playing as **${role.emoji} ${role.name}**!\n\nThe tutorial will show you unique dialogue and choices for this role.`;
+    }
+
+    return `🎭 **Role Selected**\nYou are now **${role.emoji} ${role.name}**!\n\nYour role will affect dialogue and available actions in all future games.`;
+  }
+
+  if (parts[1] === 'tutorial' && parts[2] === 'replay') {
+    const currentRole = getCurrentRole(user_id);
+    if (!currentRole?.selected_role) {
+      return '❌ Please select a role first.';
+    }
+
+    startRoleBasedRun(user_id, currentRole.selected_role, '1.1', { is_tutorial: true });
+    const role = getRoleById(currentRole.selected_role);
+    return `🔄 **Tutorial Restarted**\nPlaying as ${role?.emoji ?? '🎭'} ${role?.name ?? 'Unknown'}`;
+  }
+
+  if (parts[1] === 'games' && parts[2] === 'list') {
+    return showUserGames(user_id);
+  }
+
+  if (parts[1] === 'resume' && parts[2] === 'select') {
+    return '▶️ Resume flow coming soon!';
+  }
+
+  return 'Unknown role action.';
+}
+
+export function startRoleBasedRun(
+  user_id: string,
+  role_id: string,
+  scene_id: string,
+  options: { is_tutorial?: boolean; guild_id?: string; channel_id?: string } = {}
+): string {
+  const guild_id = options.guild_id ?? (options.is_tutorial ? 'tutorial' : 'solo');
+  const channel_id = options.channel_id ?? `${guild_id}:${user_id}`;
+  const run_id = startRun(guild_id, channel_id, [user_id], 'genesis', scene_id);
+
+  db.prepare(
+    `
+    INSERT INTO user_runs (user_id, run_id, role_id, scene_id, status, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `
+  ).run(user_id, run_id, role_id, scene_id, 'active', Date.now(), Date.now());
+
+  return run_id;
+}
+
+export function getUserActiveRuns(user_id: string) {
+  return db
+    .prepare(
+      `
+    SELECT ur.*, r.scene_id as current_scene_id, r.round_id
+    FROM user_runs ur
+    JOIN runs r ON ur.run_id = r.run_id
+    WHERE ur.user_id = ? AND ur.status = 'active'
+    ORDER BY ur.updated_at DESC
+  `
+    )
+    .all(user_id) as Array<{
+    run_id: string;
+    role_id: string;
+    scene_id: string;
+    status: string;
+    created_at: number;
+    updated_at: number;
+    current_scene_id: string;
+    round_id: string;
+  }>;
+}
+
+export function getCurrentRole(user_id: string) {
+  return db
+    .prepare('SELECT selected_role FROM profiles WHERE user_id=?')
+    .get(user_id) as { selected_role?: string } | undefined;
+}
+
+export function getRoleById(role_id: string): Role | undefined {
+  return AVAILABLE_ROLES.find((r) => r.id === role_id);
+}
+
+export function showUserGames(user_id: string): string {
+  const runs = getUserActiveRuns(user_id);
+
+  if (runs.length === 0) {
+    return '📋 **Your Games**\nNo active games. Start a new game or replay the tutorial!';
+  }
+
+  let response = '📋 **Your Active Games**\n\n';
+  runs.forEach((run, index) => {
+    const role = getRoleById(run.role_id);
+    response += `**${index + 1}.** ${role?.emoji ?? '🎲'} Scene ${run.current_scene_id}\n`;
+    response += `   Role: ${role?.name ?? 'Unknown'}\n`;
+    response += `   Progress: ${run.round_id}\n`;
+    response += `   Started: <t:${Math.floor(run.created_at / 1000)}:R>\n\n`;
+  });
+
+  response += 'Use "Resume Game" to continue where you left off!';
+  return response;
+}
+
+export function getRoleBanter(action: any, role_id: string): string | undefined {
+  const role = getRoleById(role_id);
+  if (!role || !action?.banter) return undefined;
+  return action.banter[role.banter_key];
+}
+
+export function joinGameWithRole(user_id: string, scene_id: string, guild_id: string, channel_id: string) {
+  const currentRole = getCurrentRole(user_id);
+
+  if (!currentRole?.selected_role) {
+    return {
+      success: false,
+      message: '❌ Please select a role first using the role selection menu.',
+    };
+  }
+
+  const existingRun = db
+    .prepare(
+      `
+    SELECT run_id FROM user_runs
+    WHERE user_id = ? AND scene_id = ? AND status = 'active'
+  `
+    )
+    .get(user_id, scene_id) as { run_id: string } | undefined;
+
+  if (existingRun) {
+    return {
+      success: false,
+      message: `❌ You already have an active game in Scene ${scene_id}. Resume it instead!`,
+    };
+  }
+
+  const run_id = startRoleBasedRun(user_id, currentRole.selected_role, scene_id, {
+    guild_id,
+    channel_id,
+  });
+  const role = getRoleById(currentRole.selected_role);
+
+  return {
+    success: true,
+    message: `🎮 **Game Started**\nScene ${scene_id} as ${role?.emoji ?? '🎭'} ${role?.name ?? 'Unknown'}`,
+    run_id,
+  };
+}
+
+export function completeTutorial(user_id: string, run_id: string) {
+  db.prepare(
+    `
+    UPDATE user_runs
+    SET status = 'completed', updated_at = ?
+    WHERE user_id = ? AND run_id = ?
+  `
+  ).run(Date.now(), user_id, run_id);
+
+  db.prepare('UPDATE profiles SET coins = coins + ? WHERE user_id = ?').run(500, user_id);
+}

--- a/src/ui/seasonal.ts
+++ b/src/ui/seasonal.ts
@@ -1,0 +1,48 @@
+import fs from 'fs-extra';
+import path from 'node:path';
+import { CFG } from '../config.js';
+import { startRun } from '../engine/orchestrator.js';
+
+interface SeasonInfo {
+  id: string;
+  title: string;
+  version: string;
+  description: string;
+}
+
+function seasonsRoot() {
+  return path.join(CFG.contentRoot, 'seasons');
+}
+
+export function listSeasons(): SeasonInfo[] {
+  const root = seasonsRoot();
+  if (!fs.existsSync(root)) return [];
+  const entries = fs.readdirSync(root);
+  const seasons: SeasonInfo[] = [];
+  for (const entry of entries) {
+    const manifestPath = path.join(root, entry, 'manifest.json');
+    if (!fs.existsSync(manifestPath)) continue;
+    try {
+      const manifest = fs.readJSONSync(manifestPath) as any;
+      seasons.push({
+        id: entry,
+        title: manifest.book_name || entry,
+        version: manifest.version || '1.0.0',
+        description: manifest.description || 'Seasonal event',
+      });
+    } catch (err) {
+      console.warn('Failed to load season manifest', entry, err);
+    }
+  }
+  return seasons;
+}
+
+export function startSeasonalRun(user_id: string, guild_id: string, channel_id: string, seasonId: string) {
+  const seasonPath = path.join('seasons', seasonId);
+  const manifestPath = path.join(CFG.contentRoot, seasonPath, 'manifest.json');
+  if (!fs.existsSync(manifestPath)) {
+    throw new Error('Season not found');
+  }
+  const run_id = startRun(guild_id, channel_id, [user_id], seasonPath, '6.1');
+  return run_id;
+}

--- a/src/ui/shop.ts
+++ b/src/ui/shop.ts
@@ -1,35 +1,278 @@
-import { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, ButtonInteraction } from 'discord.js';
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonInteraction,
+  ButtonStyle,
+  EmbedBuilder,
+  StringSelectMenuBuilder,
+} from 'discord.js';
+import { nanoid } from 'nanoid';
 import db from '../persistence/db.js';
 import { openPack } from './backpacks.js';
+import { craftItem, listCraftables } from './crafting.js';
 
-export async function renderShop(user_id:string){
-  const prof = db.prepare('SELECT coins,gems FROM profiles WHERE user_id=?').get(user_id) || {coins:0,gems:0};
-  const embed = new EmbedBuilder()
-    .setTitle('🛒 Shop')
-    .setDescription(`Coins: **${prof.coins}**\nGems: **${prof.gems}**\n\nPacks:\n• Genesis Pack — 350 Coins`)
-    .setColor(0x00ccaa);
-  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
-    new ButtonBuilder().setCustomId('shop:open:genesis').setLabel('Buy Genesis Pack (350)').setStyle(ButtonStyle.Primary)
-  );
-  return { embeds:[embed], components:[row] };
+interface ShopPack {
+  id: string;
+  name: string;
+  category: 'normal' | 'era' | 'featured';
+  cost: { coins?: number; gems?: number };
+  stock?: number;
+  emoji: string;
+  dropTable: string;
 }
 
-export function handleShopInteraction(customId:string, user_id:string){
+const SHOP_PACKS: ShopPack[] = [
+  { id: 'genesis_small', name: 'Small', category: 'normal', cost: { coins: 10000 }, emoji: '📦', dropTable: 'packs_genesis.json' },
+  { id: 'genesis_medium', name: 'Medium', category: 'normal', cost: { coins: 20000 }, emoji: '📫', dropTable: 'packs_genesis.json' },
+  { id: 'genesis_large', name: 'Large', category: 'normal', cost: { coins: 40000 }, emoji: '🎁', stock: 5, dropTable: 'packs_genesis.json' },
+  { id: 'classic_era', name: 'Classic Era', category: 'era', cost: { gems: 100 }, emoji: '♦️', dropTable: 'packs_genesis.json' },
+  { id: 'gremlin_era', name: 'Gremlin Era', category: 'era', cost: { gems: 120 }, emoji: '📢', dropTable: 'packs_genesis.json' },
+  { id: 'frost_signal', name: 'Frost Signal', category: 'featured', cost: { coins: 25000 }, emoji: '❄️', dropTable: 'packs_genesis.json' }
+];
+
+interface RotationRecord {
+  rotation_id: string;
+  packs: string[];
+  items: { id: string; cost: number; emoji: string }[];
+  active_from: number;
+  active_to: number;
+}
+
+function startOfWeek(now: Date) {
+  const copy = new Date(now);
+  const day = copy.getUTCDay();
+  const diff = (day + 6) % 7; // Monday start
+  copy.setUTCDate(copy.getUTCDate() - diff);
+  copy.setUTCHours(0, 0, 0, 0);
+  return copy;
+}
+
+function ensureWeeklyRotation(force = false): RotationRecord {
+  const now = Date.now();
+  const row = db
+    .prepare('SELECT * FROM shop_rotations WHERE active_from <= ? AND active_to >= ? ORDER BY active_from DESC LIMIT 1')
+    .get(now, now) as { rotation_id: string; packs_json: string; items_json: string; active_from: number; active_to: number } | undefined;
+  if (row && !force) {
+    return {
+      rotation_id: row.rotation_id,
+      packs: JSON.parse(row.packs_json || '[]'),
+      items: JSON.parse(row.items_json || '[]'),
+      active_from: row.active_from,
+      active_to: row.active_to,
+    };
+  }
+  const base = startOfWeek(new Date());
+  const active_from = base.getTime();
+  const active_to = active_from + 7 * 24 * 60 * 60 * 1000;
+  const rotation_id = `rot_${nanoid(6)}`;
+  const featured = SHOP_PACKS.filter((p) => p.category !== 'normal').map((p) => p.id);
+  const packs = featured.sort(() => Math.random() - 0.5).slice(0, 3);
+  const items = [
+    { id: 'cosmetic_spark_trail', cost: 180, emoji: '✨' },
+    { id: 'gift_frostsigil', cost: 220, emoji: '❄️' }
+  ];
+  db.prepare(
+    'INSERT INTO shop_rotations (rotation_id, active_from, active_to, packs_json, items_json) VALUES (?,?,?,?,?)'
+  ).run(rotation_id, active_from, active_to, JSON.stringify(packs), JSON.stringify(items));
+  return { rotation_id, packs, items, active_from, active_to };
+}
+
+function rotationLabel(rot: RotationRecord) {
+  return `Rotation ${rot.rotation_id} • Ends <t:${Math.floor(rot.active_to / 1000)}:R>`;
+}
+
+function packById(id: string) {
+  return SHOP_PACKS.find((p) => p.id === id);
+}
+
+function pityProgress(user_id: string, pack: ShopPack) {
+  const row = db
+    .prepare('SELECT opened, last_rarity FROM pity WHERE user_id=? AND pack_id=?')
+    .get(user_id, pack.id) as { opened?: number; last_rarity?: string } | undefined;
+  if (!row) return 'Fresh pity track';
+  return `Opened ${row.opened} • Last ${row.last_rarity ?? 'none'}`;
+}
+
+function purchasePack(user_id: string, pack: ShopPack) {
+  if (pack.stock !== undefined && pack.stock <= 0) {
+    throw new Error('Out of stock');
+  }
+  const prof = db
+    .prepare('SELECT coins, gems FROM profiles WHERE user_id=?')
+    .get(user_id) as { coins?: number; gems?: number } | undefined;
+  const coins = prof?.coins ?? 0;
+  const gems = prof?.gems ?? 0;
+  if (pack.cost.coins && coins < pack.cost.coins) throw new Error(`Need ${pack.cost.coins} coins`);
+  if (pack.cost.gems && gems < pack.cost.gems) throw new Error(`Need ${pack.cost.gems} gems`);
+  if (pack.cost.coins) {
+    db.prepare('UPDATE profiles SET coins=coins-? WHERE user_id=?').run(pack.cost.coins, user_id);
+  }
+  if (pack.cost.gems) {
+    db.prepare('UPDATE profiles SET gems=gems-? WHERE user_id=?').run(pack.cost.gems, user_id);
+  }
+  if (pack.cost.coins || pack.cost.gems) {
+    db.prepare('INSERT INTO economy_ledger (txn_id,user_id,kind,amount,reason,meta_json,ts) VALUES (?,?,?,?,?,?,?)')
+      .run(
+        `txn_${nanoid(8)}`,
+        user_id,
+        'shop_purchase',
+        pack.cost.coins ?? pack.cost.gems ?? 0,
+        'pack_purchase',
+        JSON.stringify({ pack_id: pack.id }),
+        Date.now()
+      );
+  }
+  const { rarity, drop, duplicate } = openPack(user_id, pack.dropTable, {
+    skipCost: true,
+    spendAmountOverride: pack.cost.coins ?? pack.cost.gems ?? 0,
+    packIdOverride: pack.id,
+  });
+  if (pack.stock !== undefined) {
+    db.prepare('UPDATE shop_rotations SET items_json=items_json WHERE rotation_id=?').run('noop'); // noop to ensure row exists
+    pack.stock -= 1;
+  }
+  const pity = pityProgress(user_id, pack);
+  const duplicateNote = duplicate ? ' (duplicate converted to fragments)' : '';
+  return `🎁 ${pack.name} → **[${rarity.toUpperCase()}] ${drop.id}**${duplicateNote}\n${pity}`;
+}
+
+export async function renderEnhancedShop(user_id: string) {
+  const profile =
+    (db.prepare('SELECT coins, gems, fragments FROM profiles WHERE user_id=?').get(user_id) as
+      | { coins: number; gems: number; fragments: number }
+      | undefined) ?? { coins: 0, gems: 0, fragments: 0 };
+  const rotation = ensureWeeklyRotation();
+  const embed = new EmbedBuilder()
+    .setTitle('🛒 Black Market')
+    .setColor(0x2b2d31)
+    .setDescription(
+      `**Gold:** 🪙 ${profile.coins.toLocaleString()}\n**Gems:** 💎 ${profile.gems.toLocaleString()}\n**Fragments:** ✨ ${profile.fragments}\n${rotationLabel(
+        rotation
+      )}`
+    );
+
+  const normal = SHOP_PACKS.filter((p) => p.category === 'normal')
+    .map((p) => `${p.emoji} **${p.name}** — ${p.cost.coins?.toLocaleString() ?? p.cost.gems} ${p.cost.coins ? '🪙' : '💎'}`)
+    .join('\n');
+  embed.addFields({ name: 'Normal Backpacks', value: normal || 'None', inline: false });
+
+  const featured = rotation.packs
+    .map((id) => packById(id))
+    .filter(Boolean)
+    .map((pack) => `${pack!.emoji} **${pack!.name}** — ${pityProgress(user_id, pack!)}`)
+    .join('\n');
+  embed.addFields({ name: 'Weekly Featured Packs', value: featured || 'Rotation warming up…', inline: false });
+
+  const limitedItems = rotation.items
+    .map((item) => `${item.emoji} ${item.id} — ${item.cost} fragments`)
+    .join('\n');
+  embed.addFields({ name: 'Limited Stock', value: limitedItems || 'Check back soon!', inline: false });
+
+  const craftables = listCraftables()
+    .map((craft) => `${craft.id} — ${craft.costFragments} fragments`)
+    .join('\n');
+  embed.addFields({ name: 'Crafting', value: craftables || 'No recipes yet.', inline: false });
+
+  const packOptions = new StringSelectMenuBuilder()
+    .setCustomId('shop:select')
+    .setPlaceholder('Open a pack...')
+    .addOptions(
+      rotation.packs
+        .map((id) => packById(id))
+        .filter(Boolean)
+        .map((pack) => ({
+          label: pack!.name,
+          description: `Open ${pack!.name}`,
+          value: pack!.id,
+          emoji: pack!.emoji,
+        }))
+    );
+
+  const craftMenu = new StringSelectMenuBuilder()
+    .setCustomId('shop:craft')
+    .setPlaceholder('Craft gear...')
+    .addOptions(
+      listCraftables().map((craft) => ({
+        label: craft.id,
+        description: craft.description,
+        value: craft.id,
+        emoji: '🛠️',
+      }))
+    );
+
+  const actionRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(packOptions);
+  const craftRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(craftMenu);
+  const buttons = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder().setCustomId('shop:refresh').setLabel('Refresh Rotation').setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder().setCustomId('shop:category:skins').setLabel('Seasonals').setStyle(ButtonStyle.Primary)
+  );
+
+  return { embeds: [embed], components: [actionRow, craftRow, buttons] };
+}
+
+export async function handleEnhancedShopInteraction(customId: string, user_id: string, values?: string[]) {
   const parts = customId.split(':');
   if (parts[0] !== 'shop') return 'Unknown shop action.';
-  if (parts[1] === 'open' && parts[2] === 'genesis'){
+
+  if (parts[1] === 'select' && values?.[0]) {
+    const pack = packById(values[0]);
+    if (!pack) return '❌ Pack not found.';
     try {
-      const { rarity, drop } = openPack(user_id, 'Genesis');
-      return `🎁 You opened a Genesis Pack and received **[${rarity.toUpperCase()}] ${drop.id}**`;
-    } catch (e:any) {
-      return `❌ ${e.message || 'Could not open pack.'}`;
+      const message = purchasePack(user_id, pack);
+      return message;
+    } catch (err: any) {
+      return `❌ ${err.message ?? 'Unable to open pack.'}`;
     }
   }
+
+  if (parts[1] === 'craft' && values?.[0]) {
+    const result = craftItem(user_id, values[0]);
+    return result.message;
+  }
+
+  if (parts[1] === 'category' && parts[2] === 'skins') {
+    const rotation = ensureWeeklyRotation();
+    return `🎨 Seasonal stock: ${rotation.items.map((i) => `${i.emoji} ${i.id}`).join(', ')}`;
+  }
+
+  if (parts[1] === 'refresh') {
+    const rotation = ensureWeeklyRotation(true);
+    return `🔄 Rotation refreshed. New packs: ${rotation.packs.join(', ')}`;
+  }
+
   return 'Unknown shop action.';
 }
 
-export async function showShop(i: ButtonInteraction){
-  await i.deferReply({ ephemeral:true });
-  const v = await renderShop(i.user.id);
-  await i.editReply(v);
+export async function showShop(i: ButtonInteraction) {
+  await i.deferReply({ ephemeral: true });
+  const view = await renderEnhancedShop(i.user.id);
+  await i.editReply(view);
 }
+
+export function claimWeeklyReward(user_id: string): { success: boolean; amount?: number; streak?: number } {
+  const lastClaim = db
+    .prepare('SELECT last_weekly_claim, weekly_streak FROM profiles WHERE user_id=?')
+    .get(user_id) as { last_weekly_claim?: number; weekly_streak?: number } | undefined;
+  const now = Date.now();
+  const weekMs = 7 * 24 * 60 * 60 * 1000;
+
+  if (lastClaim?.last_weekly_claim && now - lastClaim.last_weekly_claim < weekMs) {
+    return { success: false };
+  }
+
+  const newStreak = (lastClaim?.weekly_streak ?? 0) + 1;
+  const baseReward = 10000;
+  const streakBonus = Math.min(newStreak * 1000, 10000);
+  const totalReward = baseReward + streakBonus;
+
+  db.prepare('UPDATE profiles SET coins=coins+?, last_weekly_claim=?, weekly_streak=? WHERE user_id=?').run(
+    totalReward,
+    now,
+    newStreak,
+    user_id
+  );
+
+  return { success: true, amount: totalReward, streak: newStreak };
+}
+
+export { renderEnhancedShop as renderShop, handleEnhancedShopInteraction as handleShopInteraction };

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -1,45 +1,184 @@
-import { ButtonInteraction, ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, TextChannel } from 'discord.js';
+import {
+  ButtonInteraction,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  EmbedBuilder,
+  StringSelectMenuInteraction,
+  Message,
+  TextChannel,
+} from 'discord.js';
 import { sceneState, handleAction } from '../engine/orchestrator.js';
 import db from '../persistence/db.js';
-import { showShop, handleShopInteraction } from './shop.js';
+import { renderEnhancedShop, handleEnhancedShopInteraction, showShop } from './shop.js';
+import { handleRoleSelection, showRoleSelection } from './roles.js';
+import {
+  renderEquipment,
+  handleEquipmentButton,
+  handleEquipmentEquip,
+  handleEquipmentSelect,
+} from './equipment.js';
 
-export async function renderScene(run_id:string){
+export async function renderScene(run_id: string) {
   const run = db.prepare('SELECT * FROM runs WHERE run_id=?').get(run_id);
   const scene = sceneState(run);
-  const round = scene.rounds.find(r => r.round_id === run.round_id)!;
+  const round = scene.rounds.find((r) => r.round_id === run.round_id)!;
 
   const embed = new EmbedBuilder()
     .setTitle(`📖 ${scene.title}`)
     .setDescription(`${scene.narration}\n\n**${round.description}**`)
     .setColor(0x5b8cff);
 
+  if (run.active_user_id) {
+    const expires = run.turn_expires_at ? `<t:${Math.floor(run.turn_expires_at / 1000)}:R>` : '—';
+    embed.addFields({
+      name: 'Current Turn',
+      value: `<@${run.active_user_id}> • Expires ${expires}`,
+      inline: false,
+    });
+  }
+  embed.addFields({ name: 'Sleight Score', value: `${run.sleight_score ?? 0}`, inline: true });
+
   const rows: any[] = [];
   let row = new ActionRowBuilder<ButtonBuilder>();
-  for (const a of round.actions){
-    if ((row as any).components.length >= 5){
+  for (const a of round.actions) {
+    if ((row as any).components.length >= 5) {
       rows.push(row);
       row = new ActionRowBuilder<ButtonBuilder>();
     }
-    row.addComponents(new ButtonBuilder().setCustomId(`act:${run_id}:${a.id}`).setLabel(a.label).setStyle(ButtonStyle.Secondary));
+    row.addComponents(
+      new ButtonBuilder()
+        .setCustomId(`act:${run_id}:${a.id}`)
+        .setLabel(a.label)
+        .setStyle(ButtonStyle.Secondary)
+    );
   }
   rows.push(row);
-  return { embeds:[embed], components: rows };
+  rows.push(
+    new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder().setCustomId(`equipment:open:${run_id}`).setLabel('Loadout').setStyle(ButtonStyle.Secondary),
+      new ButtonBuilder().setCustomId('shop:open').setLabel('Shop').setStyle(ButtonStyle.Primary)
+    )
+  );
+  return { embeds: [embed], components: rows };
 }
 
-export async function onButton(i: ButtonInteraction){
+async function ensureUiReference(run_id: string, message: Message) {
+  if (!message.pinned) {
+    try {
+      await message.pin();
+    } catch (err) {
+      console.warn('Unable to pin UI message', err);
+    }
+  }
+  db.prepare('UPDATE runs SET ui_message_id=?, ui_channel_id=? WHERE run_id=?').run(
+    message.id,
+    message.channelId,
+    run_id
+  );
+}
+
+export async function syncPinnedUi(channel: TextChannel, run_id: string, reuse?: Message | null) {
+  const run = db.prepare('SELECT ui_message_id, ui_channel_id FROM runs WHERE run_id=?').get(run_id) as
+    | { ui_message_id?: string; ui_channel_id?: string }
+    | undefined;
+  const payload = await renderScene(run_id);
+  let target = reuse ?? null;
+  if (!target && run?.ui_message_id) {
+    try {
+      target = await channel.messages.fetch(run.ui_message_id);
+    } catch {
+      target = null;
+    }
+  }
+  if (target) {
+    await target.edit(payload);
+  } else {
+    target = await channel.send(payload);
+  }
+  if (!target) throw new Error('Failed to render scene UI');
+  await ensureUiReference(run_id, target);
+  return target;
+}
+
+export async function onButton(i: ButtonInteraction) {
   const [prefix, run_id, rest] = i.customId.split(':');
-  if (prefix === 'act'){
-    await i.deferReply({ ephemeral:true });
-    const res = handleAction(run_id, i.user.id, rest);
-    await i.editReply(`🎲 You chose **${rest}** → ${res.summary}`);
-    const payload = await renderScene(run_id);
-    await i.message.edit(payload);
+  if (prefix === 'act') {
+    await i.deferReply({ ephemeral: true });
+    let res;
+    try {
+      res = handleAction(run_id, i.user.id, rest);
+      await i.editReply(`🎲 You chose **${rest}** → ${res.summary}`);
+    } catch (err: any) {
+      await i.editReply(`❌ ${err.message ?? 'Could not resolve action.'}`);
+      return;
+    }
+    if (i.channel && (i.channel as any).isTextBased?.()) {
+      await syncPinnedUi(i.channel as unknown as TextChannel, run_id, i.message as Message);
+    }
+    const channel = i.channel;
+    if (res.compliment && channel && channel.isTextBased() && 'send' in channel) {
+      await (channel as any).send({ content: `✨ ${res.compliment} (<@${i.user.id}>)` });
+    }
     return;
   }
-  if (prefix === 'shop'){
-    await i.deferReply({ ephemeral:true });
-    const msg = handleShopInteraction(i.customId, i.user.id);
+  if (prefix === 'shop') {
+    await i.deferReply({ ephemeral: true });
+    const msg = await handleEnhancedShopInteraction(i.customId, i.user.id);
+    if (i.customId === 'shop:refresh') {
+      const view = await renderEnhancedShop(i.user.id);
+      await i.message.edit(view);
+    }
     await i.editReply(msg);
+    return;
+  }
+  if (prefix === 'role') {
+    await i.deferReply({ ephemeral: true });
+    const msg = handleRoleSelection(i.customId, i.user.id);
+    const isTutorial = i.customId.includes('tutorial');
+    const view = await showRoleSelection(i.user.id, isTutorial);
+    await i.message.edit(view);
+    await i.editReply(msg);
+    return;
+  }
+  if (prefix === 'equipment') {
+    if (rest === 'open') {
+      await i.deferReply({ ephemeral: true });
+      const view = await renderEquipment(i.user.id);
+      await i.editReply(view);
+      return;
+    }
+    await handleEquipmentButton(i);
+    return;
+  }
+}
+
+export async function onSelectMenu(i: StringSelectMenuInteraction) {
+  if (i.customId.startsWith('shop:')) {
+    await i.deferReply({ ephemeral: true });
+    const msg = await handleEnhancedShopInteraction(i.customId, i.user.id, i.values);
+    if (i.customId === 'shop:select' || i.customId === 'shop:craft') {
+      const view = await renderEnhancedShop(i.user.id);
+      await i.message.edit(view);
+    }
+    await i.editReply(msg);
+    return;
+  }
+  if (i.customId.startsWith('role:')) {
+    await i.deferReply({ ephemeral: true });
+    const msg = handleRoleSelection(i.customId, i.user.id, i.values);
+    const isTutorial = i.customId.includes('tutorial');
+    const view = await showRoleSelection(i.user.id, isTutorial);
+    await i.message.edit(view);
+    await i.editReply(msg);
+    return;
+  }
+  if (i.customId === 'equipment:slot') {
+    await handleEquipmentSelect(i);
+    return;
+  }
+  if (i.customId.startsWith('equipment:equip:')) {
+    await handleEquipmentEquip(i);
     return;
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ES2022",
-    "moduleResolution": "Bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,


### PR DESCRIPTION
## Summary
- implement a full equipment/loadout pipeline with durability, set bonuses, and loadout UI that influences action rolls and sleight scoring across the engine
- extend the bot experience with AFK turn handling, revival commands, crafting, seasonal runs, PvP queueing, and minigame modules alongside a lightweight dashboard server
- expand shop, backpack, and content assets with weekly rotations, fragment crafting, seasonal packs, and complete scene writing for chapters 1.4 through 1.7
- fix ambient Node typings so the dashboard OAuth server and gem webhook compile under the strict TypeScript build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0c4b27d40833093948a5315962347