### PR TITLE
Add content registry and integrate dynamic assets

### DIFF
--- a/content/registry/cards.json
+++ b/content/registry/cards.json
@@ -1,0 +1,20 @@
+{
+  "cards": {
+    "dev_recursion": {
+      "id": "dev_recursion",
+      "name": "Infinite Recursion",
+      "rarity": "epic",
+      "type": "instant",
+      "cost": { "focus": 3 },
+      "effects": [
+        { "type": "buff", "id": "reroll_next", "value": 1 },
+        { "type": "flag", "id": "recursion_active", "value": true }
+      ],
+      "tags": ["dev", "logic", "instant"],
+      "description": "Reroll your next failed action. If successful, draw another card.",
+      "flavorText": "Stack overflow is just another kind of infinity.",
+      "set": "genesis",
+      "requiresClass": ["dev"]
+    }
+  }
+}

--- a/content/registry/items.json
+++ b/content/registry/items.json
@@ -1,0 +1,20 @@
+{
+  "items": {
+    "wp_liquidity_spear": {
+      "id": "wp_liquidity_spear",
+      "name": "Liquidity Spear",
+      "type": "weapon",
+      "slot": "weapon",
+      "rarity": "epic",
+      "emoji": "⚔️",
+      "description": "A spear that flows through gaps in consensus.",
+      "bonuses": {
+        "dcOffset": -1,
+        "advantageTags": ["rush", "momentum", "gremlin"],
+        "sleightBonus": 1
+      },
+      "setKey": "liquidity",
+      "durability": 100
+    }
+  }
+}

--- a/content/registry/roles.json
+++ b/content/registry/roles.json
@@ -1,0 +1,21 @@
+{
+  "roles": {
+    "dev": {
+      "id": "dev",
+      "name": "Dev Wizard",
+      "description": "See the code beneath reality. Master of logic and systems.",
+      "emoji": "🧙‍♂️",
+      "banter_key": "dev",
+      "startingStats": {
+        "hp": 18,
+        "focus": 12,
+        "coins": 500
+      },
+      "passiveEffects": [
+        { "type": "buff", "id": "debug_vision", "value": 1 }
+      ],
+      "advantageTags": ["logic", "puzzle", "insight"],
+      "unlockRequirements": null
+    }
+  }
+}

--- a/src/content/contentRegistry.ts
+++ b/src/content/contentRegistry.ts
@@ -1,0 +1,212 @@
+import fs from 'fs-extra';
+import path from 'path';
+import { CFG } from '../config.js';
+
+export interface ItemDefinition {
+  id: string;
+  name: string;
+  type: string;
+  slot?: string;
+  rarity: string;
+  emoji: string;
+  description: string;
+  bonuses?: any;
+  setKey?: string;
+  durability?: number;
+}
+
+export interface CardDefinition {
+  id: string;
+  name: string;
+  rarity: string;
+  type: string;
+  cost: any;
+  effects: any[];
+  tags: string[];
+  description: string;
+  flavorText?: string;
+  set: string;
+  requiresClass?: string[];
+}
+
+export interface RoleDefinition {
+  id: string;
+  name: string;
+  description: string;
+  emoji: string;
+  banter_key: string;
+  startingStats?: any;
+  passiveEffects?: any[];
+  advantageTags?: string[];
+  unlockRequirements?: any;
+}
+
+class ContentRegistry {
+  private items: Map<string, ItemDefinition> = new Map();
+  private cards: Map<string, CardDefinition> = new Map();
+  private roles: Map<string, RoleDefinition> = new Map();
+  private loaded = false;
+  private version = 0;
+  private reloadListeners = new Set<() => void>();
+
+  async loadAll() {
+    this.ensureLoadedSync();
+  }
+
+  getVersion() {
+    this.ensureLoadedSync();
+    return this.version;
+  }
+
+  getItem(id: string): ItemDefinition | undefined {
+    this.ensureLoadedSync();
+    return this.items.get(id);
+  }
+
+  getCard(id: string): CardDefinition | undefined {
+    this.ensureLoadedSync();
+    return this.cards.get(id);
+  }
+
+  getRole(id: string): RoleDefinition | undefined {
+    this.ensureLoadedSync();
+    return this.roles.get(id);
+  }
+
+  getAllItems(): ItemDefinition[] {
+    this.ensureLoadedSync();
+    return Array.from(this.items.values());
+  }
+
+  getAllCards(): CardDefinition[] {
+    this.ensureLoadedSync();
+    return Array.from(this.cards.values());
+  }
+
+  getAllRoles(): RoleDefinition[] {
+    this.ensureLoadedSync();
+    return Array.from(this.roles.values());
+  }
+
+  getItemsByType(type: string): ItemDefinition[] {
+    return this.getAllItems().filter((item) => item.type === type);
+  }
+
+  getCardsBySet(set: string): CardDefinition[] {
+    return this.getAllCards().filter((card) => card.set === set);
+  }
+
+  getRolesByUnlockRequirement(requirement: any): RoleDefinition[] {
+    return this.getAllRoles().filter((role) => !role.unlockRequirements || this.meetsRequirement(requirement, role.unlockRequirements));
+  }
+
+  onReload(listener: () => void) {
+    this.reloadListeners.add(listener);
+    return () => this.reloadListeners.delete(listener);
+  }
+
+  async reload() {
+    this.loadFromDisk();
+  }
+
+  private ensureLoadedSync() {
+    if (this.loaded) return;
+    this.loadFromDisk();
+  }
+
+  private loadFromDisk() {
+    const itemsPath = path.join(CFG.contentRoot, 'registry', 'items.json');
+    const cardsPath = path.join(CFG.contentRoot, 'registry', 'cards.json');
+    const rolesPath = path.join(CFG.contentRoot, 'registry', 'roles.json');
+
+    this.items.clear();
+    this.cards.clear();
+    this.roles.clear();
+
+    this.loadItems(itemsPath);
+    this.loadCards(cardsPath);
+    this.loadRoles(rolesPath);
+
+    this.loaded = true;
+    this.version += 1;
+    this.notifyReload();
+  }
+
+  private loadItems(filePath: string) {
+    try {
+      if (!fs.pathExistsSync(filePath)) return;
+      const data = fs.readJSONSync(filePath) as { items?: Record<string, ItemDefinition> };
+      if (!data?.items) return;
+      for (const [id, item] of Object.entries(data.items)) {
+        this.items.set(id, item);
+      }
+      console.log(`Loaded ${this.items.size} items`);
+    } catch (error) {
+      console.warn('Failed to load items registry:', error);
+    }
+  }
+
+  private loadCards(filePath: string) {
+    try {
+      if (!fs.pathExistsSync(filePath)) return;
+      const data = fs.readJSONSync(filePath) as { cards?: Record<string, CardDefinition> };
+      if (!data?.cards) return;
+      for (const [id, card] of Object.entries(data.cards)) {
+        this.cards.set(id, card);
+      }
+      console.log(`Loaded ${this.cards.size} cards`);
+    } catch (error) {
+      console.warn('Failed to load cards registry:', error);
+    }
+  }
+
+  private loadRoles(filePath: string) {
+    try {
+      if (!fs.pathExistsSync(filePath)) return;
+      const data = fs.readJSONSync(filePath) as { roles?: Record<string, RoleDefinition> };
+      if (!data?.roles) return;
+      for (const [id, role] of Object.entries(data.roles)) {
+        this.roles.set(id, role);
+      }
+      console.log(`Loaded ${this.roles.size} roles`);
+    } catch (error) {
+      console.warn('Failed to load roles registry:', error);
+    }
+  }
+
+  private meetsRequirement(_userProgress: any, _requirement: any): boolean {
+    // Requirement checking can be implemented later.
+    return true;
+  }
+
+  private notifyReload() {
+    for (const listener of this.reloadListeners) {
+      try {
+        listener();
+      } catch (error) {
+        console.error('Content reload listener failed', error);
+      }
+    }
+  }
+}
+
+export const contentRegistry = new ContentRegistry();
+
+contentRegistry.loadAll().catch((error) => {
+  console.error('Failed to load content registry on startup', error);
+});
+
+if (process.env.NODE_ENV === 'development') {
+  const watchPath = path.join(CFG.contentRoot, 'registry');
+  if (fs.pathExistsSync(watchPath)) {
+    try {
+      fs.watch(watchPath, { recursive: true }, () => {
+        setTimeout(() => {
+          contentRegistry.reload().catch((error) => console.error('Registry reload failed', error));
+        }, 1000);
+      });
+    } catch (error) {
+      console.warn('Registry watch unavailable on this platform:', error);
+    }
+  }
+}

--- a/src/engine/dynamicBranching.ts
+++ b/src/engine/dynamicBranching.ts
@@ -1,0 +1,360 @@
+import db from '../persistence/db.js';
+import { BranchContext, buildBranchContext } from './branching.js';
+
+type BranchConditionType = 'stat' | 'item' | 'flag' | 'history' | 'role' | 'karma';
+type BranchOperator = 'eq' | 'neq' | 'gt' | 'gte' | 'lt' | 'lte' | 'contains';
+
+export interface DynamicSceneRoute {
+  sceneId: string;
+  conditions: BranchCondition[];
+  weight: number;
+  tags: string[];
+}
+
+export interface BranchCondition {
+  type: BranchConditionType;
+  field: string;
+  operator: BranchOperator;
+  value: unknown;
+}
+
+interface EnhancedBranchContext extends BranchContext {
+  karma: {
+    alignment: number;
+    redemption_arc: boolean;
+  };
+  total_sleight: number;
+  party_deaths: number;
+  party_strength: number;
+  role_interactions: number;
+  gremlin_interactions: number;
+}
+
+export class DynamicBranchingEngine {
+  private readonly routeCache = new Map<string, DynamicSceneRoute[]>();
+
+  constructor() {
+    this.initializeRoutes();
+  }
+
+  private initializeRoutes() {
+    this.registerRoutes('1.7', [
+      {
+        sceneId: '2.1.dev',
+        conditions: [
+          { type: 'role', field: 'selected_role', operator: 'eq', value: 'dev' },
+          { type: 'stat', field: 'sleight', operator: 'gte', value: 10 }
+        ],
+        weight: 100,
+        tags: ['role_specific', 'dev_path']
+      },
+      {
+        sceneId: '2.1.trader',
+        conditions: [
+          { type: 'role', field: 'selected_role', operator: 'eq', value: 'trader' },
+          { type: 'stat', field: 'coins', operator: 'gte', value: 5000 }
+        ],
+        weight: 100,
+        tags: ['role_specific', 'trader_path']
+      },
+      {
+        sceneId: '2.1.whale',
+        conditions: [
+          { type: 'role', field: 'selected_role', operator: 'eq', value: 'whale' },
+          { type: 'item', field: 'legendary_count', operator: 'gte', value: 2 }
+        ],
+        weight: 100,
+        tags: ['role_specific', 'whale_path']
+      },
+      {
+        sceneId: '2.1.karma_good',
+        conditions: [{ type: 'karma', field: 'alignment', operator: 'gte', value: 5 }],
+        weight: 90,
+        tags: ['moral_path', 'good_karma']
+      },
+      {
+        sceneId: '2.1.karma_evil',
+        conditions: [{ type: 'karma', field: 'alignment', operator: 'lte', value: -5 }],
+        weight: 90,
+        tags: ['moral_path', 'evil_karma']
+      },
+      {
+        sceneId: '2.1',
+        conditions: [],
+        weight: 1,
+        tags: ['default']
+      }
+    ]);
+
+    this.registerRoutes('3.7', [
+      {
+        sceneId: 'boss.custodian',
+        conditions: [
+          { type: 'flag', field: 'custodian_key', operator: 'eq', value: true },
+          { type: 'stat', field: 'party_strength', operator: 'gte', value: 100 }
+        ],
+        weight: 100,
+        tags: ['boss', 'custodian']
+      },
+      {
+        sceneId: 'boss.gremlin_king',
+        conditions: [
+          { type: 'flag', field: 'gremlin_alliance', operator: 'eq', value: true },
+          { type: 'history', field: 'gremlin_interactions', operator: 'gte', value: 10 }
+        ],
+        weight: 100,
+        tags: ['boss', 'gremlin']
+      },
+      {
+        sceneId: 'boss.shadow_ledger',
+        conditions: [{ type: 'flag', field: 'corrupted_path', operator: 'eq', value: true }],
+        weight: 100,
+        tags: ['boss', 'corruption']
+      }
+    ]);
+
+    this.registerRoutes('4.7', [
+      {
+        sceneId: 'ending.transcendence',
+        conditions: [
+          { type: 'stat', field: 'total_sleight', operator: 'gte', value: 100 },
+          { type: 'flag', field: 'perfect_run', operator: 'eq', value: true }
+        ],
+        weight: 200,
+        tags: ['ending', 'perfect']
+      },
+      {
+        sceneId: 'ending.redemption',
+        conditions: [
+          { type: 'karma', field: 'redemption_arc', operator: 'eq', value: true },
+          { type: 'flag', field: 'saved_party', operator: 'eq', value: true }
+        ],
+        weight: 150,
+        tags: ['ending', 'redemption']
+      },
+      {
+        sceneId: 'ending.corruption',
+        conditions: [
+          { type: 'flag', field: 'embraced_darkness', operator: 'eq', value: true },
+          { type: 'stat', field: 'party_deaths', operator: 'gte', value: 2 }
+        ],
+        weight: 150,
+        tags: ['ending', 'dark']
+      },
+      {
+        sceneId: 'ending.neutral',
+        conditions: [],
+        weight: 50,
+        tags: ['ending', 'neutral']
+      }
+    ]);
+  }
+
+  registerRoutes(fromScene: string, routes: DynamicSceneRoute[]) {
+    const sorted = [...routes].sort((a, b) => b.weight - a.weight);
+    this.routeCache.set(fromScene, sorted);
+  }
+
+  async determineNextScene(runId: string, currentScene: string): Promise<string> {
+    const context = await this.buildEnhancedContext(runId);
+    const routes = this.routeCache.get(currentScene) ?? [];
+
+    for (const route of routes) {
+      if (this.evaluateAllConditions(route.conditions, context)) {
+        this.logBranchDecision(runId, currentScene, route.sceneId, route.tags, context);
+        return route.sceneId;
+      }
+    }
+
+    return this.getDefaultNextScene(currentScene);
+  }
+
+  private async buildEnhancedContext(runId: string): Promise<EnhancedBranchContext> {
+    const baseContext = buildBranchContext(runId);
+
+    const karmaEvents = db
+      .prepare(
+        `SELECT payload_json FROM events
+         WHERE run_id=? AND type='moral_choice'
+         ORDER BY ts DESC`
+      )
+      .all(runId)
+      .map((row: { payload_json: string }) => JSON.parse(row.payload_json) as { choice?: string });
+
+    const karmaAlignment = karmaEvents.reduce((sum: number, evt: { choice?: string }) => {
+      if (evt.choice === 'good') return sum + 1;
+      if (evt.choice === 'evil') return sum - 1;
+      return sum;
+    }, 0);
+
+    const totalSleightRow = db
+      .prepare(`SELECT SUM(sleight_score) as total FROM runs WHERE run_id=?`)
+      .get(runId) as { total: number | null } | undefined;
+
+    const partyIds = baseContext.players.map((player) => player.id);
+    const partyDeaths = partyIds.filter((id) => {
+      const prof = db
+        .prepare('SELECT downed_at FROM profiles WHERE user_id=?')
+        .get(id) as { downed_at?: number | null } | undefined;
+      return prof?.downed_at != null;
+    }).length;
+
+    const roleInteractionRow = db
+      .prepare(
+        `SELECT COUNT(*) as count FROM events
+         WHERE run_id=? AND type='role_specific_action'`
+      )
+      .get(runId) as { count: number | null } | undefined;
+
+    const enhanced: EnhancedBranchContext = {
+      ...baseContext,
+      karma: {
+        alignment: karmaAlignment,
+        redemption_arc:
+          karmaAlignment < -3 && karmaEvents.slice(0, 3).every((event: { choice?: string }) => event.choice === 'good')
+      },
+      total_sleight: totalSleightRow?.total ?? 0,
+      party_deaths: partyDeaths,
+      party_strength: this.calculatePartyStrength(baseContext),
+      role_interactions: roleInteractionRow?.count ?? 0,
+      gremlin_interactions: baseContext.choiceHistory.filter((entry) =>
+        entry.tags?.includes('gremlin')
+      ).length
+    };
+
+    return enhanced;
+  }
+
+  private calculatePartyStrength(context: BranchContext): number {
+    return context.players.reduce((sum, player) => {
+      const currentHp = player?.hp ?? 0;
+      const hpRatio = currentHp > 0 ? Math.min(currentHp / 20, 1) : 0;
+      const level = player.level || 1;
+      return sum + hpRatio * level * 10;
+    }, 0);
+  }
+
+  private evaluateAllConditions(conditions: BranchCondition[], context: EnhancedBranchContext): boolean {
+    if (conditions.length === 0) return true;
+    return conditions.every((condition) => this.evaluateCondition(condition, context));
+  }
+
+  private evaluateCondition(condition: BranchCondition, context: EnhancedBranchContext): boolean {
+    const value = this.getContextValue(condition.type, condition.field, context);
+    const target = condition.value as number | string | boolean;
+
+    switch (condition.operator) {
+      case 'eq':
+        return value === target;
+      case 'neq':
+        return value !== target;
+      case 'gt':
+        return typeof value === 'number' && value > (target as number);
+      case 'gte':
+        return typeof value === 'number' && value >= (target as number);
+      case 'lt':
+        return typeof value === 'number' && value < (target as number);
+      case 'lte':
+        return typeof value === 'number' && value <= (target as number);
+      case 'contains':
+        return Array.isArray(value) && value.includes(target);
+      default:
+        return false;
+    }
+  }
+
+  private getContextValue(type: BranchConditionType, field: string, context: EnhancedBranchContext): unknown {
+    switch (type) {
+      case 'stat':
+        if (field === 'sleight') return context.sleight;
+        if (field === 'total_sleight') return context.total_sleight;
+        if (field === 'party_strength') return context.party_strength;
+        if (field === 'party_deaths') return context.party_deaths;
+        if (field === 'coins') {
+          const prof = db
+            .prepare('SELECT coins FROM profiles WHERE user_id=?')
+            .get(context.activePlayer) as { coins?: number } | undefined;
+          return prof?.coins ?? 0;
+        }
+        return 0;
+      case 'item':
+        if (field === 'legendary_count') {
+          return context.items.filter((item) => item.rarity === 'legendary').length;
+        }
+        return context.items.some((item) => item.id === field);
+      case 'flag':
+        return context.flags[field];
+      case 'history':
+        if (field === 'gremlin_interactions') return context.gremlin_interactions;
+        if (field === 'role_interactions') return context.role_interactions;
+        return 0;
+      case 'role': {
+        const player = context.players.find((p) => p.id === context.activePlayer);
+        return player ? (player as Record<string, unknown>)[field] : undefined;
+      }
+      case 'karma':
+        if (field === 'alignment') return context.karma.alignment;
+        if (field === 'redemption_arc') return context.karma.redemption_arc;
+        return 0;
+      default:
+        return undefined;
+    }
+  }
+
+  private getDefaultNextScene(currentScene: string): string {
+    if (currentScene.startsWith('boss.')) {
+      return '4.1';
+    }
+
+    if (currentScene.startsWith('ending.')) {
+      return 'credits';
+    }
+
+    const [majorRaw, minorRaw] = currentScene.split('.');
+    const major = Number(majorRaw);
+    const minor = Number(minorRaw);
+
+    if (!Number.isNaN(minor) && minor < 7) {
+      return `${major}.${minor + 1}`;
+    }
+
+    if (!Number.isNaN(major)) {
+      return `${major + 1}.1`;
+    }
+
+    return currentScene;
+  }
+
+  private logBranchDecision(
+    runId: string,
+    from: string,
+    to: string,
+    tags: string[],
+    context: EnhancedBranchContext
+  ) {
+    const payload = {
+      from,
+      to,
+      tags,
+      context_snapshot: {
+        karma: context.karma.alignment,
+        total_sleight: context.total_sleight,
+        party_strength: context.party_strength,
+        party_deaths: context.party_deaths
+      }
+    };
+
+    db.prepare(
+      'INSERT INTO events (event_id, run_id, user_id, type, payload_json, ts) VALUES (?,?,?,?,?,?)'
+    ).run(
+      `branch_${Date.now()}`,
+      runId,
+      context.activePlayer,
+      'scene.branch.dynamic',
+      JSON.stringify(payload),
+      Date.now()
+    );
+  }
+}
+
+export const dynamicBranchingEngine = new DynamicBranchingEngine();

--- a/src/engine/orchestrator.ts
+++ b/src/engine/orchestrator.ts
@@ -6,6 +6,7 @@ import { thresholdRewards, groupBonusAllSurvive, loneSurvivor } from './rewards.
 import { computeHiddenTier, flavorForTier } from './difficulty.js';
 import { calculatePartyDifficultyInputs } from './partyStrength.js';
 import { SceneDef } from '../models.js';
+import { worldEventManager } from '../events/worldEvents.js';
 import {
   equipmentAdvantageState,
   loadoutSleightBonus,
@@ -243,6 +244,7 @@ export function handleAction(
 
   const tags: string[] = act.roll?.tags ?? [];
   const { advantage, disadvantage, dcShift, dcOffset, focusBonus, hpBonus } = equipmentAdvantageState(user_id, tags);
+  const { contexts: worldContexts, modifiers: worldModifiers } = worldEventManager.prepareAction(run.guild_id, act);
   const difficultyInputs = calculatePartyDifficultyInputs(run);
   const settings = getGuildSettings(run.guild_id);
   const { dcOffset: hiddenOffset, tier } = computeHiddenTier(
@@ -267,20 +269,20 @@ export function handleAction(
       members: difficultyInputs.members,
     })
   );
-  
-  const { dcOffset: hiddenOffset, tier } = computeHiddenTier(10, 1200, 0);
 
-  const baseDc = 13 + dcShift;
+  const baseDc = 13 + dcShift + worldModifiers.dcShift;
   const totalOffset = hiddenOffset + dcOffset;
   let roll = act.roll
     ? phiD20(baseDc, totalOffset)
     : ({ kind: 'success', roll: 20, dc: baseDc + totalOffset } as any);
 
   if (act.roll) {
-    if (advantage && !disadvantage) {
+    const advCount = (advantage ? 1 : 0) + worldModifiers.advantageStacks;
+    const disadvCount = (disadvantage ? 1 : 0) + worldModifiers.disadvantageStacks;
+    if (advCount > disadvCount) {
       const contender = phiD20(baseDc, totalOffset);
       roll = contender.roll >= roll.roll ? contender : roll;
-    } else if (disadvantage && !advantage) {
+    } else if (disadvCount > advCount) {
       const contender = phiD20(baseDc, totalOffset);
       roll = contender.roll <= roll.roll ? contender : roll;
     }
@@ -324,7 +326,34 @@ export function handleAction(
   }
 
   const summary = applyEffects(outcome.effects || [], state as any, user_id);
+
+  const rewardFields: Array<{ target: 'coins' | 'xp' | 'fragments'; field: '_coins' | '_xp' | '_fragments' }> = [
+    { target: 'coins', field: '_coins' },
+    { target: 'xp', field: '_xp' },
+    { target: 'fragments', field: '_fragments' },
+  ];
+  for (const { target, field } of rewardFields) {
+    const multiplier = worldModifiers.multipliers[target];
+    if (multiplier !== undefined && multiplier !== 1 && state[field][user_id] !== undefined) {
+      state[field][user_id] = Math.round((state[field][user_id] ?? 0) * multiplier);
+    }
+    const bonus = worldModifiers.bonuses[target];
+    if (bonus !== undefined && bonus !== 0 && (roll.kind === 'success' || roll.kind === 'crit_success')) {
+      state[field][user_id] = Math.round((state[field][user_id] ?? 0) + bonus);
+    }
+  }
+
   commitState(user_id, state);
+
+  worldEventManager.recordActionImpact(worldContexts, {
+    serverId: run.guild_id,
+    userId: user_id,
+    tags,
+    rollKind: roll.kind,
+    coinsDelta: state._coins[user_id] ?? 0,
+    xpDelta: state._xp[user_id] ?? 0,
+    fragmentsDelta: state._fragments[user_id] ?? 0,
+  });
 
   const newFlags = { ...(JSON.parse(run.flags_json || '{}')), ...(state.flags || {}) };
   run.flags_json = JSON.stringify(newFlags);
@@ -337,6 +366,19 @@ export function handleAction(
   run.sleight_score += sleightDelta;
   appendSleightHistory(run, { user_id, delta: sleightDelta, reason: roll.kind, ts: Date.now() });
 
+  if ((roll.kind === 'success' || roll.kind === 'crit_success') && worldModifiers.sleightSuccessBonus) {
+    const eventBonus = Math.round(worldModifiers.sleightSuccessBonus);
+    if (eventBonus) {
+      run.sleight_score += eventBonus;
+      appendSleightHistory(run, {
+        user_id,
+        delta: eventBonus,
+        reason: 'world_event_bonus',
+        ts: Date.now(),
+      });
+    }
+  }
+
   const rounds = scene.rounds.map((r: any) => r.round_id);
   const idx = rounds.indexOf(run.round_id);
   let completedScene = false;
@@ -345,25 +387,16 @@ export function handleAction(
   } else {
     completedScene = true;
     applyThresholdRewards(run, user_id, scene, state);
-    const arr = scene.arrivals || [];
+    const arrivals = scene.arrivals || [];
     const next =
-      arr.find((a) => a.when.startsWith('flags') && (newFlags as any)[a.when.split('.')[1]])?.goto ||
-      arr.find((a) => a.when === 'else')?.goto ||
+      arrivals.find((a) => a.when.startsWith('flags') && (newFlags as any)[a.when.split('.')[1]])?.goto ||
+      arrivals.find((a) => a.when === 'else')?.goto ||
       '2B';
     const sceneMap: Record<'A' | 'B' | 'C' | 'D', string> = { A: '2.1', B: '2.1', C: '2.1', D: '2.1' };
     run.scene_id = ('' + next)
       .replace(/^\s*→?\s*/, '')
       .replace(/^Scene\s*/, '')
       .replace(/^2([A-D])$/, (m, p: 'A' | 'B' | 'C' | 'D') => sceneMap[p]);
-    const rewards = thresholdRewards(run.sleight_score, scene.threshold_rewards);
-    applyEffects(rewards, state, user_id);
-    const arr = scene.arrivals||[];
-    const next = arr.find(a => a.when.startsWith('flags') && (newFlags as any)[a.when.split('.')[1]])?.goto || arr.find(a=>a.when==='else')?.goto || '2B';
-    const sceneMap: Record<'A'|'B'|'C'|'D', string> = { A: '2.1', B: '2.1', C: '2.1', D: '2.1' };
-    run.scene_id = (''+next)
-      .replace(/^\s*→?\s*/,'')
-      .replace(/^Scene\s*/,'')
-      .replace(/^2([A-D])$/,(m, p: 'A'|'B'|'C'|'D')=> sceneMap[p]);
     run.round_id = `${run.scene_id}-R1`;
     run.micro_ix += 1;
     run.sleight_score = 0;
@@ -407,7 +440,6 @@ export function processAfkTimeouts(now = Date.now()) {
     .prepare('SELECT * FROM runs WHERE turn_expires_at IS NOT NULL AND turn_expires_at <= ?')
     .all(now) as any[];
   const events: { run_id: string; user_id: string; action_id: string; message: string; channel_id: string; refresh?: boolean }[] = [];
-  const events: { run_id: string; user_id: string; action_id: string; message: string; channel_id: string }[] = [];
   for (const run of timedOut) {
     if (!run.active_user_id) continue;
     const scene = loadScene(run.content_id, run.scene_id);
@@ -439,6 +471,5 @@ export function processAfkTimeouts(now = Date.now()) {
     }
   }
   return events;
-  
-  return { roll, outcome, summary, tier };
 }
+

--- a/src/events/worldEvents.ts
+++ b/src/events/worldEvents.ts
@@ -1,5 +1,7 @@
+import { nanoid } from 'nanoid';
 import db from '../persistence/db.js';
 import { Effect } from '../models.js';
+import { applyEffects } from '../engine/rules.js';
 
 export interface GlobalEffect {
   type: 'multiplier' | 'bonus' | 'penalty' | 'advantage' | 'disadvantage' | 'unlock';
@@ -47,18 +49,54 @@ export interface WorldEvent {
   triggerConditions?: TriggerCondition[];
 }
 
+type WorldEventGoalProgress = {
+  goalId: string;
+  current: number;
+  target: number;
+  participants: Set<string>;
+  completed: boolean;
+};
+
 export interface WorldEventInstance {
   eventId: string;
   serverId: string;
   startTime: number;
   endTime: number;
-  communityProgress: {
-    goalId: string;
-    current: number;
-    target: number;
-    participants: Set<string>;
-  }[];
+  communityProgress: WorldEventGoalProgress[];
   participants: Set<string>;
+}
+
+interface SerializedProgress {
+  goalId: string;
+  current: number;
+  target: number;
+  participants: string[];
+  completed?: boolean;
+}
+
+interface ActiveEventContext {
+  event: WorldEvent;
+  instance: WorldEventInstance;
+  effects: GlobalEffect[];
+}
+
+export interface ActionModifiers {
+  advantageStacks: number;
+  disadvantageStacks: number;
+  dcShift: number;
+  multipliers: Record<string, number>;
+  bonuses: Record<string, number>;
+  sleightSuccessBonus: number;
+}
+
+export interface ActiveWorldEventSummary {
+  event: WorldEvent;
+  serverId: string;
+  startedAt: number;
+  endsAt: number;
+  remainingMs: number;
+  participantCount: number;
+  progress: { goalId: string; current: number; target: number; completed: boolean; participantCount: number }[];
 }
 
 export const WORLD_EVENTS: WorldEvent[] = [
@@ -289,33 +327,160 @@ export const WORLD_EVENTS: WorldEvent[] = [
   },
 ];
 
-export class WorldEventManager {
+class WorldEventManager {
   private readonly activeEvents = new Map<string, WorldEventInstance>();
+  private readonly timers = new Map<string, ReturnType<typeof setTimeout>>();
+  private triggerInterval?: ReturnType<typeof setTimeout>;
+  private initialized = false;
 
-  async triggerEvent(eventId: string, serverId: string = 'global'): Promise<void> {
+  initialize(): void {
+    if (this.initialized) return;
+    this.initialized = true;
+
+    const rows = db.prepare('SELECT * FROM world_events_active').all() as {
+      event_id: string;
+      server_id: string;
+      start_time: number;
+      end_time: number;
+      community_progress_json: string;
+      participants_json: string;
+    }[];
+
+    for (const row of rows) {
+      const progressRaw = JSON.parse(row.community_progress_json || '[]') as SerializedProgress[];
+      const progress: WorldEventGoalProgress[] = progressRaw.map((entry) => ({
+        goalId: entry.goalId,
+        current: entry.current,
+        target: entry.target,
+        completed: Boolean(entry.completed),
+        participants: new Set(entry.participants ?? []),
+      }));
+      const instance: WorldEventInstance = {
+        eventId: row.event_id,
+        serverId: row.server_id,
+        startTime: row.start_time,
+        endTime: row.end_time,
+        communityProgress: progress,
+        participants: new Set(JSON.parse(row.participants_json || '[]') as string[]),
+      };
+      this.activeEvents.set(this.instanceKey(instance.eventId, instance.serverId), instance);
+      this.scheduleEnd(instance);
+    }
+
+    const timer = setInterval(() => {
+      try {
+        this.checkEventTriggers().catch((err) => console.error('World event trigger sweep failed', err));
+      } catch (err) {
+        console.error('World event trigger sweep failed', err);
+      }
+    }, 30 * 60 * 1000);
+    (timer as any).unref?.();
+    this.triggerInterval = timer;
+  }
+
+  listActiveEvents(): ActiveWorldEventSummary[] {
+    const now = Date.now();
+    const summaries: ActiveWorldEventSummary[] = [];
+    for (const instance of this.activeEvents.values()) {
+      const event = WORLD_EVENTS.find((e) => e.id === instance.eventId);
+      if (!event) continue;
+      summaries.push({
+        event,
+        serverId: instance.serverId,
+        startedAt: instance.startTime,
+        endsAt: instance.endTime,
+        remainingMs: Math.max(0, instance.endTime - now),
+        participantCount: instance.participants.size,
+        progress: instance.communityProgress.map((goal) => ({
+          goalId: goal.goalId,
+          current: goal.current,
+          target: goal.target,
+          completed: goal.completed,
+          participantCount: goal.participants.size,
+        })),
+      });
+    }
+    return summaries.sort((a, b) => a.endsAt - b.endsAt);
+  }
+
+  prepareAction(serverId: string, action: { roll?: { tags?: string[] } }): { contexts: ActiveEventContext[]; modifiers: ActionModifiers } {
+    const contexts = this.collectActiveContexts(action, serverId);
+    return { contexts, modifiers: this.computeModifiers(contexts) };
+  }
+
+  recordActionImpact(
+    contexts: ActiveEventContext[],
+    impact: { serverId: string; userId: string; tags: string[]; rollKind: 'crit_success' | 'success' | 'fail' | 'crit_fail'; coinsDelta: number; xpDelta: number; fragmentsDelta: number }
+  ): void {
+    if (!contexts.length) return;
+    const coinsLost = impact.coinsDelta < 0 ? Math.abs(impact.coinsDelta) : 0;
+    const coinsGained = impact.coinsDelta > 0 ? impact.coinsDelta : 0;
+    const xpGained = impact.xpDelta > 0 ? impact.xpDelta : 0;
+    const fragmentsGained = impact.fragmentsDelta > 0 ? impact.fragmentsDelta : 0;
+    const success = impact.rollKind === 'success' || impact.rollKind === 'crit_success';
+    const failure = impact.rollKind === 'fail' || impact.rollKind === 'crit_fail';
+
+    for (const ctx of contexts) {
+      const instance = this.activeEvents.get(this.instanceKey(ctx.instance.eventId, ctx.instance.serverId));
+      if (!instance) continue;
+      instance.participants.add(impact.userId);
+
+      const eventDef = ctx.event;
+      if (eventDef.communityGoals?.length) {
+        for (const goalProgress of instance.communityProgress) {
+          if (goalProgress.completed) continue;
+          const goalDef = eventDef.communityGoals.find((goal) => goal.description === goalProgress.goalId);
+          if (!goalDef) continue;
+          const delta = this.calculateGoalDelta(goalDef, {
+            tags: impact.tags,
+            success,
+            failure,
+            coinsLost,
+            coinsGained,
+            xpGained,
+            fragmentsGained,
+          });
+          if (delta > 0) {
+            goalProgress.current = Math.min(goalProgress.target, goalProgress.current + delta);
+            goalProgress.participants.add(impact.userId);
+            if (goalProgress.current >= goalProgress.target) {
+              goalProgress.completed = true;
+              this.handleGoalCompletion(eventDef, goalDef, goalProgress, instance);
+            }
+          }
+        }
+      }
+      this.saveInstance(instance);
+    }
+  }
+
+  async triggerEvent(eventId: string, serverId: string = 'global', opts: { source?: 'manual' | 'automatic' } = {}): Promise<boolean> {
     const event = WORLD_EVENTS.find((e) => e.id === eventId);
-    if (!event) return;
+    if (!event) return false;
+    if (this.isEventActive(eventId, serverId)) return false;
 
+    const now = Date.now();
     const instance: WorldEventInstance = {
       eventId: event.id,
       serverId,
-      startTime: Date.now(),
-      endTime: Date.now() + event.duration * 60 * 60 * 1000,
+      startTime: now,
+      endTime: now + event.duration * 60 * 60 * 1000,
       communityProgress:
         event.communityGoals?.map((goal) => ({
           goalId: goal.description,
           current: 0,
           target: goal.target,
+          completed: false,
           participants: new Set<string>(),
         })) ?? [],
       participants: new Set<string>(),
     };
 
     this.activeEvents.set(this.instanceKey(eventId, serverId), instance);
-    await this.broadcastEventStart(event, instance);
-    const timer = setTimeout(() => this.endEvent(instance), event.duration * 60 * 60 * 1000);
-    const maybeUnref = (timer as { unref?: () => void }).unref;
-    if (maybeUnref) maybeUnref.call(timer);
+    this.saveInstance(instance);
+    this.scheduleEnd(instance);
+    await this.broadcastEventStart(event, instance, opts.source ?? 'manual');
+    return true;
   }
 
   async checkEventTriggers(): Promise<void> {
@@ -323,53 +488,299 @@ export class WorldEventManager {
       if (!event.triggerConditions || event.triggerConditions.length === 0) continue;
       const shouldTrigger = await this.evaluateTriggerConditions(event.triggerConditions);
       if (shouldTrigger && !this.isEventActive(event.id)) {
-        await this.triggerEvent(event.id);
+        await this.triggerEvent(event.id, 'global', { source: 'automatic' });
       }
     }
   }
 
-  getActiveEventsForAction(action: { roll?: { tags?: string[] } }, serverId: string): GlobalEffect[] {
-    const effects: GlobalEffect[] = [];
+  async forceEndEvent(eventId: string, serverId: string = 'global'): Promise<boolean> {
+    const instance = this.activeEvents.get(this.instanceKey(eventId, serverId));
+    if (!instance) return false;
+    this.finalizeEvent(instance, 'forced');
+    return true;
+  }
+
+  private collectActiveContexts(action: { roll?: { tags?: string[] } }, serverId: string): ActiveEventContext[] {
+    const contexts: ActiveEventContext[] = [];
     for (const [key, instance] of this.activeEvents.entries()) {
       const [, storedServer] = key.split(':');
       if (storedServer !== 'global' && storedServer !== serverId) continue;
       const event = WORLD_EVENTS.find((e) => e.id === instance.eventId);
       if (!event) continue;
-      for (const effect of event.globalEffects) {
-        if (this.effectApplies(effect, action)) {
-          effects.push(effect);
+      const effects = event.globalEffects.filter((effect) => this.effectApplies(effect, action));
+      contexts.push({ event, instance, effects });
+    }
+    return contexts;
+  }
+
+  private computeModifiers(contexts: ActiveEventContext[]): ActionModifiers {
+    const modifiers: ActionModifiers = {
+      advantageStacks: 0,
+      disadvantageStacks: 0,
+      dcShift: 0,
+      multipliers: {},
+      bonuses: {},
+      sleightSuccessBonus: 0,
+    };
+
+    for (const ctx of contexts) {
+      for (const effect of ctx.effects) {
+        switch (effect.type) {
+          case 'advantage':
+            modifiers.advantageStacks += effect.value ?? 1;
+            break;
+          case 'disadvantage':
+            modifiers.disadvantageStacks += effect.value ?? 1;
+            break;
+          case 'penalty': {
+            const amount = Number(effect.value ?? 0);
+            modifiers.dcShift += -amount;
+            const lowerTarget = effect.target.toLowerCase();
+            const lowerDesc = effect.description.toLowerCase();
+            if (
+              lowerTarget.includes('sleight') ||
+              lowerTarget.includes('survival') ||
+              lowerTarget.includes('integrity') ||
+              lowerDesc.includes('sleight')
+            ) {
+              modifiers.sleightSuccessBonus += amount;
+            }
+            break;
+          }
+          case 'bonus': {
+            const amount = Number(effect.value ?? 0);
+            modifiers.bonuses[effect.target] = (modifiers.bonuses[effect.target] ?? 0) + amount;
+            const lowerTarget = effect.target.toLowerCase();
+            const lowerDesc = effect.description.toLowerCase();
+            if (
+              lowerTarget.includes('sleight') ||
+              lowerTarget.includes('survival') ||
+              lowerTarget.includes('integrity') ||
+              lowerDesc.includes('sleight')
+            ) {
+              modifiers.sleightSuccessBonus += amount;
+            }
+            break;
+          }
+          case 'multiplier': {
+            const amount = Number(effect.value ?? 1);
+            modifiers.multipliers[effect.target] = (modifiers.multipliers[effect.target] ?? 1) * amount;
+            break;
+          }
         }
       }
     }
-    return effects;
+
+    return modifiers;
   }
 
-  private effectApplies(effect: GlobalEffect, action: { roll?: { tags?: string[] } }): boolean {
-    if (!action.roll) {
-      return effect.target === 'all' || ['coins', 'xp', 'fragments'].includes(effect.target);
+  private scheduleEnd(instance: WorldEventInstance) {
+    const key = this.instanceKey(instance.eventId, instance.serverId);
+    const existing = this.timers.get(key);
+    if (existing) {
+      clearTimeout(existing);
+      this.timers.delete(key);
     }
-    if (effect.target === 'all') return true;
-    if (['coins', 'xp', 'fragments', 'shop_prices', 'crafting_success', 'rare_drops'].includes(effect.target)) return true;
-    const tags = action.roll.tags ?? [];
-    const targetTags = effect.target.split(',').map((tag) => tag.trim());
-    return targetTags.some((tag) => tags.includes(tag));
+    const ms = Math.max(0, instance.endTime - Date.now());
+    const timer = setTimeout(() => {
+      this.finalizeEvent(instance, 'expired');
+    }, ms);
+    (timer as any).unref?.();
+    this.timers.set(key, timer);
   }
 
-  private async broadcastEventStart(event: WorldEvent, instance: WorldEventInstance): Promise<void> {
+  private finalizeEvent(instance: WorldEventInstance, reason: 'expired' | 'forced') {
+    const key = this.instanceKey(instance.eventId, instance.serverId);
+    if (!this.activeEvents.has(key)) return;
+    this.activeEvents.delete(key);
+    const timer = this.timers.get(key);
+    if (timer) {
+      clearTimeout(timer);
+      this.timers.delete(key);
+    }
+    db.prepare('DELETE FROM world_events_active WHERE event_id=? AND server_id=?').run(instance.eventId, instance.serverId);
+    db.prepare('INSERT INTO events (event_id, run_id, user_id, type, payload_json, ts) VALUES (?,?,?,?,?,?)').run(
+      `world_event_${instance.eventId}_${instance.endTime}_${reason}`,
+      null,
+      null,
+      'world_event_ended',
+      JSON.stringify({ eventId: instance.eventId, serverId: instance.serverId, reason }),
+      Date.now()
+    );
+  }
+
+  private calculateGoalDelta(
+    goal: CommunityGoal,
+    impact: {
+      tags: string[];
+      success: boolean;
+      failure: boolean;
+      coinsLost: number;
+      coinsGained: number;
+      xpGained: number;
+      fragmentsGained: number;
+    }
+  ): number {
+    const desc = goal.description.toLowerCase();
+    if (desc.includes('lose') && desc.includes('coin')) {
+      return Math.round(impact.coinsLost);
+    }
+    if (desc.includes('gain') && desc.includes('xp')) {
+      return Math.round(impact.xpGained);
+    }
+    if (desc.includes('fragment')) {
+      return Math.round(impact.fragmentsGained);
+    }
+    if (desc.includes('gremlin')) {
+      return impact.success && impact.tags.some((tag) => tag.includes('gremlin')) ? 1 : 0;
+    }
+    if (desc.includes('craft')) {
+      return impact.success ? 1 : 0;
+    }
+    if (desc.includes('non-validator')) {
+      return impact.success ? 1 : 0;
+    }
+    if (desc.includes('timeline') || desc.includes('support')) {
+      return impact.success ? 1 : 0;
+    }
+    if (desc.includes('integrity')) {
+      return impact.success ? 1 : 0;
+    }
+    if (desc.includes('death') || desc.includes('downed')) {
+      return impact.failure ? 1 : 0;
+    }
+    if (desc.includes('restore') || desc.includes('consensus')) {
+      return impact.success ? 1 : 0;
+    }
+    return impact.success ? 1 : 0;
+  }
+
+  private handleGoalCompletion(
+    event: WorldEvent,
+    goal: CommunityGoal,
+    progress: WorldEventGoalProgress,
+    instance: WorldEventInstance
+  ) {
+    db.prepare('INSERT INTO events (event_id, run_id, user_id, type, payload_json, ts) VALUES (?,?,?,?,?,?)').run(
+      `world_event_goal_${event.id}_${Date.now()}`,
+      null,
+      null,
+      'world_event_goal_completed',
+      JSON.stringify({ eventId: event.id, serverId: instance.serverId, goal: goal.description }),
+      Date.now()
+    );
+
+    if (goal.participantRewards?.length) {
+      const participants = Array.from(progress.participants);
+      for (const userId of participants) {
+        this.applyOutOfRunRewards(userId, goal.participantRewards, event.id, goal.description);
+      }
+    }
+
+    if (goal.rewards?.length) {
+      // Server wide rewards are recorded for operators to process manually.
+      db.prepare('INSERT INTO events (event_id, run_id, user_id, type, payload_json, ts) VALUES (?,?,?,?,?,?)').run(
+        `world_event_reward_${event.id}_${Date.now()}`,
+        null,
+        null,
+        'world_event_global_reward',
+        JSON.stringify({ eventId: event.id, serverId: instance.serverId, rewards: goal.rewards }),
+        Date.now()
+      );
+    }
+  }
+
+  private applyOutOfRunRewards(userId: string, rewards: Effect[], eventId: string, goalId: string) {
+    if (!rewards.length) return;
+    const state: any = {
+      hp: {},
+      focus: {},
+      flags: {},
+      _coins: {},
+      _xp: {},
+      _fragments: {},
+      _items: {},
+      _buffs: {},
+      _debuffs: {},
+      _gems: {},
+    };
+    const summary = applyEffects(rewards, state, userId);
+    const coins = Math.round(state._coins[userId] ?? 0);
+    const xp = Math.round(state._xp[userId] ?? 0);
+    const fragments = Math.round(state._fragments[userId] ?? 0);
+    const gems = Math.round(state._gems[userId] ?? 0);
+
+    if (coins) {
+      db.prepare('UPDATE profiles SET coins=coins+? WHERE user_id=?').run(coins, userId);
+    }
+    if (xp) {
+      db.prepare('UPDATE profiles SET xp=xp+? WHERE user_id=?').run(xp, userId);
+    }
+    if (fragments) {
+      db.prepare('UPDATE profiles SET fragments=fragments+? WHERE user_id=?').run(fragments, userId);
+    }
+    if (gems) {
+      db.prepare('UPDATE profiles SET gems=gems+? WHERE user_id=?').run(gems, userId);
+    }
+    if (Array.isArray(state._items[userId]) && state._items[userId].length) {
+      const stmt = db.prepare(
+        'INSERT INTO inventories (user_id,item_id,kind,rarity,qty,meta_json) VALUES (?,?,?,?,?,?) ON CONFLICT(user_id,item_id) DO UPDATE SET qty=qty+excluded.qty'
+      );
+      for (const itemId of state._items[userId]) {
+        stmt.run(userId, itemId, 'reward', 'unknown', 1, '{}');
+      }
+    }
+
+    db.prepare('INSERT INTO events (event_id, run_id, user_id, type, payload_json, ts) VALUES (?,?,?,?,?,?)').run(
+      `world_event_participant_reward_${nanoid(8)}`,
+      null,
+      userId,
+      'world_event_participant_reward',
+      JSON.stringify({ eventId, goalId, summary }),
+      Date.now()
+    );
+  }
+
+  private async broadcastEventStart(event: WorldEvent, instance: WorldEventInstance, source: 'manual' | 'automatic') {
     const message =
       `🌍 **${event.name}** has begun!\n\n${event.description}\n\nDuration: ${event.duration} hours\n\n${event.globalEffects
         .map((effect) => `• ${effect.description}`)
         .join('\n')}`;
-    // Actual broadcast will depend on the bot runtime. For now we store a log entry for observability.
-    db.prepare(
-      'INSERT INTO events (event_id, run_id, user_id, type, payload_json, ts) VALUES (?,?,?,?,?,?)'
-    ).run(
-      `world_event_${instance.eventId}_${instance.startTime}`,
+    db.prepare('INSERT INTO events (event_id, run_id, user_id, type, payload_json, ts) VALUES (?,?,?,?,?,?)').run(
+      `world_event_${instance.eventId}_${instance.startTime}_${source}`,
       null,
       null,
       'world_event_started',
-      JSON.stringify({ eventId: event.id, serverId: instance.serverId, duration: event.duration, message }),
+      JSON.stringify({
+        eventId: event.id,
+        serverId: instance.serverId,
+        duration: event.duration,
+        message,
+        source,
+      }),
       Date.now()
+    );
+  }
+
+  private saveInstance(instance: WorldEventInstance) {
+    const progress: SerializedProgress[] = instance.communityProgress.map((goal) => ({
+      goalId: goal.goalId,
+      current: goal.current,
+      target: goal.target,
+      completed: goal.completed,
+      participants: Array.from(goal.participants),
+    }));
+    db.prepare(
+      `INSERT INTO world_events_active (event_id, server_id, start_time, end_time, community_progress_json, participants_json)
+       VALUES (?,?,?,?,?,?)
+       ON CONFLICT(event_id, server_id) DO UPDATE SET start_time=excluded.start_time, end_time=excluded.end_time, community_progress_json=excluded.community_progress_json, participants_json=excluded.participants_json`
+    ).run(
+      instance.eventId,
+      instance.serverId,
+      instance.startTime,
+      instance.endTime,
+      JSON.stringify(progress),
+      JSON.stringify(Array.from(instance.participants))
     );
   }
 
@@ -390,7 +801,7 @@ export class WorldEventManager {
           | { coins: number | null; gems: number | null }
           | undefined;
         const coins = row?.coins ?? 0;
-        const gems = (row?.gems ?? 0) * 1000; // weight gems heavily to count toward wealth
+        const gems = (row?.gems ?? 0) * 1000;
         return coins + gems >= Number(condition.value);
       }
       case 'community_sleight_threshold': {
@@ -401,9 +812,7 @@ export class WorldEventManager {
       }
       case 'community_flag': {
         const flag = db
-          .prepare(
-            'SELECT enabled FROM feature_flags WHERE guild_id=? AND feature=?'
-          )
+          .prepare('SELECT enabled FROM feature_flags WHERE guild_id=? AND feature=?')
           .get('global', condition.value) as { enabled?: number } | undefined;
         return (flag?.enabled ?? 0) === 1;
       }
@@ -438,18 +847,15 @@ export class WorldEventManager {
     }
   }
 
-  private endEvent(instance: WorldEventInstance) {
-    const key = this.instanceKey(instance.eventId, instance.serverId);
-    if (!this.activeEvents.has(key)) return;
-    this.activeEvents.delete(key);
-    db.prepare('INSERT INTO events (event_id, run_id, user_id, type, payload_json, ts) VALUES (?,?,?,?,?,?)').run(
-      `world_event_${instance.eventId}_${instance.endTime}`,
-      null,
-      null,
-      'world_event_ended',
-      JSON.stringify({ eventId: instance.eventId, serverId: instance.serverId }),
-      Date.now()
-    );
+  private effectApplies(effect: GlobalEffect, action: { roll?: { tags?: string[] } }): boolean {
+    if (!action.roll) {
+      return effect.target === 'all' || ['coins', 'xp', 'fragments'].includes(effect.target);
+    }
+    if (effect.target === 'all') return true;
+    if (['coins', 'xp', 'fragments', 'shop_prices', 'crafting_success', 'rare_drops'].includes(effect.target)) return true;
+    const tags = action.roll.tags ?? [];
+    const targetTags = effect.target.split(',').map((tag) => tag.trim());
+    return targetTags.some((tag) => tags.includes(tag));
   }
 
   private isEventActive(eventId: string, serverId: string = 'global'): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,10 @@
 import { client } from './bot.js';
 import { CFG } from './config.js';
 import { startDashboardServer } from './dashboard/server.js';
+import { worldEventManager } from './events/worldEvents.js';
+import { initializePvP } from './pvp/duels.js';
 
+worldEventManager.initialize();
+initializePvP();
 startDashboardServer(CFG.dashboardPort);
 client.login(CFG.token);

--- a/src/integrations/algorand.ts
+++ b/src/integrations/algorand.ts
@@ -1,0 +1,331 @@
+import db from '../persistence/db.js';
+import { logger } from '../utils/logger.js';
+
+export interface AlgorandConfig {
+  apiUrl: string;
+  apiKey: string;
+  network: 'mainnet' | 'testnet';
+  appId: number;
+  assetId: number;
+}
+
+export interface AlgorandNFT {
+  assetId: number;
+  creator: string;
+  owner: string;
+  name: string;
+  unitName: string;
+  url: string;
+  metadata: Record<string, unknown>;
+  rarity?: string;
+  power?: number;
+}
+
+type AlgorandLib = typeof import('algosdk');
+
+export class AlgorandIntegration {
+  private algod: any | null = null;
+  private indexer: any | null = null;
+  private sdk: AlgorandLib | null = null;
+  private readonly config: AlgorandConfig;
+
+  constructor(config?: Partial<AlgorandConfig>) {
+    this.config = {
+      apiUrl: process.env.ALGORAND_API_URL || 'https://mainnet-api.algonode.cloud',
+      apiKey: process.env.ALGORAND_API_KEY || '',
+      network: (process.env.ALGORAND_NETWORK as 'mainnet' | 'testnet') || 'mainnet',
+      appId: Number(process.env.ALGORAND_APP_ID) || 0,
+      assetId: Number(process.env.ALGORAND_ASSET_ID) || 0,
+      ...config,
+    } as AlgorandConfig;
+  }
+
+  async verifyWalletOwnership(userId: string, walletAddress: string): Promise<boolean> {
+    try {
+      const challenge = this.generateChallenge(userId);
+
+      db.prepare(
+        `INSERT OR REPLACE INTO wallet_verifications
+         (user_id, wallet_address, chain, challenge, created_at, status)
+         VALUES (?,?,?,?,?,?)`
+      ).run(userId, walletAddress, 'algorand', challenge, Date.now(), 'pending');
+
+      return true;
+    } catch (error) {
+      logger.error('Algorand wallet verification failed', { userId, walletAddress, error });
+      return false;
+    }
+  }
+
+  async verifySignature(userId: string, signature: string): Promise<boolean> {
+    try {
+      const verification = db
+        .prepare(
+          `SELECT * FROM wallet_verifications
+           WHERE user_id=? AND chain='algorand' AND status='pending'
+           ORDER BY created_at DESC LIMIT 1`
+        )
+        .get(userId) as
+        | {
+            wallet_address: string;
+            challenge: string;
+          }
+        | undefined;
+
+      if (!verification) {
+        return false;
+      }
+
+      const isValid = await this.verifyAlgorandSignature(
+        verification.wallet_address,
+        verification.challenge,
+        signature
+      );
+
+      if (!isValid) {
+        return false;
+      }
+
+      db.prepare(
+        `UPDATE wallet_verifications SET status='verified', verified_at=?
+         WHERE user_id=? AND wallet_address=? AND chain='algorand'`
+      ).run(Date.now(), userId, verification.wallet_address);
+
+      this.linkWalletToUser(userId, verification.wallet_address);
+      return true;
+    } catch (error) {
+      logger.error('Algorand signature verification failed', { userId, error });
+      return false;
+    }
+  }
+
+  async getNFTsForWallet(walletAddress: string): Promise<AlgorandNFT[]> {
+    if (!walletAddress) return [];
+
+    try {
+      const algod = await this.ensureAlgod();
+      if (!algod) return [];
+
+      const accountInfo = await algod.accountInformation(walletAddress).do();
+      const assets: { [key: string]: unknown }[] = accountInfo.assets || [];
+      const nfts: AlgorandNFT[] = [];
+
+      for (const asset of assets) {
+        if (!asset || typeof asset !== 'object') continue;
+        const amount = Number((asset as any).amount ?? 0);
+        if (amount <= 0) continue;
+
+        const assetId = Number((asset as any)['asset-id']);
+        if (!assetId) continue;
+
+        try {
+          const info = await algod.getAssetByID(assetId).do();
+          const params = info?.params ?? {};
+
+          if (params.total !== 1 || params.decimals !== 0) {
+            continue;
+          }
+
+          const parsed = await this.parseNFTMetadata(info, walletAddress);
+          if (parsed) {
+            nfts.push(parsed);
+          }
+        } catch (innerError) {
+          logger.warn('Skipping non-NFT asset', { walletAddress, assetId, error: innerError });
+        }
+      }
+
+      return nfts;
+    } catch (error) {
+      logger.error('Failed to fetch Algorand NFTs', { walletAddress, error });
+      return [];
+    }
+  }
+
+  async parseNFTMetadata(assetInfo: any, owner: string): Promise<AlgorandNFT | null> {
+    try {
+      const params = assetInfo?.params ?? {};
+      let metadata: Record<string, unknown> = {};
+
+      if (params.url) {
+        try {
+          const response = await globalThis.fetch(params.url as string);
+          if (response.ok) {
+            metadata = await response.json();
+          }
+        } catch (error) {
+          logger.warn('Failed to fetch metadata URL', { url: params.url, error });
+        }
+      }
+
+      if (params.note) {
+        try {
+          const raw = Buffer.from(params.note as string, 'base64').toString('utf-8');
+          const parsed = JSON.parse(raw);
+          metadata = { ...metadata, ...parsed };
+        } catch (error) {
+          logger.warn('Failed to parse ARC69 metadata', { assetId: assetInfo?.index, error });
+        }
+      }
+
+      return {
+        assetId: Number(assetInfo?.index) || 0,
+        creator: (params.creator as string) || '',
+        owner,
+        name: (params.name as string) || `Asset #${assetInfo?.index}`,
+        unitName: (params['unit-name'] as string) || '',
+        url: (params.url as string) || '',
+        metadata,
+        rarity: (metadata?.rarity as string) || this.calculateRarity(metadata),
+        power: (metadata?.power as number) || this.calculatePower(metadata),
+      };
+    } catch (error) {
+      logger.error('Failed to parse Algorand NFT metadata', { assetId: assetInfo?.index, error });
+      return null;
+    }
+  }
+
+  async mintRewardNFT(
+    userId: string,
+    rewardType: string,
+    metadata: Record<string, unknown>
+  ): Promise<string | null> {
+    try {
+      const wallet = this.getUserWallet(userId);
+      if (!wallet) {
+        logger.warn('No Algorand wallet linked for user', { userId });
+        return null;
+      }
+
+    const simulatedAssetId = Math.floor(Math.random() * 1_000_000);
+
+      db.prepare(
+        `INSERT INTO nft_rewards
+         (id, user_id, wallet_address, chain, asset_id, reward_type, metadata_json, minted_at)
+         VALUES (?,?,?,?,?,?,?,?)`
+      ).run(
+        `algo_${Date.now()}`,
+        userId,
+        wallet,
+        'algorand',
+        simulatedAssetId.toString(),
+        rewardType,
+        JSON.stringify(metadata),
+        Date.now()
+      );
+
+      logger.info('Simulated Algorand NFT reward minted', {
+        userId,
+        rewardType,
+        assetId: simulatedAssetId,
+      });
+      return `algo_${simulatedAssetId}`;
+    } catch (error) {
+      logger.error('Failed to mint Algorand NFT reward', { userId, rewardType, error });
+      return null;
+    }
+  }
+
+  private async ensureAlgod() {
+    if (this.algod) return this.algod;
+    const sdk = await this.loadSdk();
+    if (!sdk) return null;
+
+    this.algod = new sdk.Algodv2(this.config.apiKey, this.config.apiUrl, '');
+    return this.algod;
+  }
+
+  private async ensureIndexer() {
+    if (this.indexer) return this.indexer;
+    const sdk = await this.loadSdk();
+    if (!sdk) return null;
+
+    const indexerUrl = this.config.apiUrl.replace('api', 'idx');
+    this.indexer = new sdk.Indexer(this.config.apiKey, indexerUrl, '');
+    return this.indexer;
+  }
+
+  private async loadSdk(): Promise<AlgorandLib | null> {
+    if (this.sdk) return this.sdk;
+    try {
+      const sdk = await import('algosdk');
+      this.sdk = sdk;
+      return sdk;
+    } catch (error) {
+      logger.error('Failed to load algosdk library', { error });
+      return null;
+    }
+  }
+
+  private generateChallenge(userId: string): string {
+    const timestamp = Date.now();
+    const nonce = Math.random().toString(36).slice(2);
+    return `LedgerLegends Authentication\nUser: ${userId}\nTimestamp: ${timestamp}\nNonce: ${nonce}`;
+  }
+
+  private async verifyAlgorandSignature(address: string, message: string, signature: string) {
+    try {
+      const sdk = await this.loadSdk();
+      if (!sdk) return false;
+
+      const sigBytes = Buffer.from(signature, 'base64');
+      const messageBytes = new TextEncoder().encode(message);
+      return sdk.verifyBytes(messageBytes, sigBytes, address);
+    } catch (error) {
+      logger.error('Algorand signature verification failed', { error });
+      return false;
+    }
+  }
+
+  private linkWalletToUser(userId: string, walletAddress: string) {
+    db.prepare(
+      `INSERT OR REPLACE INTO user_wallets (user_id, wallet_address, chain, linked_at, is_primary)
+       VALUES (?,?,?,?,?)`
+    ).run(userId, walletAddress, 'algorand', Date.now(), 1);
+  }
+
+  private getUserWallet(userId: string): string | null {
+    const wallet = db
+      .prepare(
+        `SELECT wallet_address FROM user_wallets
+         WHERE user_id=? AND chain='algorand' AND is_primary=1`
+      )
+      .get(userId) as { wallet_address: string } | undefined;
+
+    return wallet?.wallet_address ?? null;
+  }
+
+  private calculateRarity(metadata: Record<string, unknown>): string {
+    const attributes = (metadata?.attributes as Array<Record<string, unknown>>) || [];
+    const rareTraits = attributes.filter((attr) => {
+      const frequency = Number((attr as any).frequency ?? 0);
+      return frequency > 0 && frequency < 0.1;
+    });
+
+    if (rareTraits.length >= 3) return 'mythic';
+    if (rareTraits.length >= 2) return 'legendary';
+    if (rareTraits.length >= 1) return 'epic';
+    if (attributes.length >= 5) return 'rare';
+    if (attributes.length >= 3) return 'uncommon';
+    return 'common';
+  }
+
+  private calculatePower(metadata: Record<string, unknown>): number {
+    const attributes = (metadata?.attributes as Array<Record<string, unknown>>) || [];
+    let power = 0;
+
+    for (const attribute of attributes) {
+      const trait = (attribute as any).trait_type;
+      const value = Number((attribute as any).value ?? 0);
+
+      if (trait === 'attack' || trait === 'defense') power += value;
+      if (trait === 'magic') power += value * 1.5;
+      if (trait === 'speed') power += value * 0.5;
+    }
+
+    return Math.round(power);
+  }
+}
+
+export const algorandIntegration = new AlgorandIntegration();
+export const algorand = algorandIntegration;

--- a/src/integrations/base.ts
+++ b/src/integrations/base.ts
@@ -1,0 +1,440 @@
+import { randomBytes } from 'node:crypto';
+import { nanoid } from 'nanoid';
+import db from '../persistence/db.js';
+import { logger } from '../utils/logger.js';
+
+type EthersLib = typeof import('ethers');
+
+type BaseNFTRarity = 'common' | 'uncommon' | 'rare' | 'epic' | 'legendary';
+
+type Attribute = {
+  trait_type?: string;
+  value?: unknown;
+};
+
+export interface BaseNFT {
+  tokenId: string;
+  owner: string;
+  contractAddress: string;
+  chain: 'base';
+  name: string;
+  description: string;
+  image: string;
+  attributes: Attribute[];
+  rarity: BaseNFTRarity;
+  power: number;
+}
+
+const LEDGER_LEGENDS_ABI = [
+  'function balanceOf(address owner) view returns (uint256)',
+  'function tokenOfOwnerByIndex(address owner, uint256 index) view returns (uint256)',
+  'function tokenURI(uint256 tokenId) view returns (string)',
+  'function mintReward(address to, uint256 rewardType, string memory metadata) returns (uint256)',
+  'event RewardMinted(address indexed to, uint256 indexed tokenId, uint256 rewardType)'
+] as const;
+
+interface BaseIntegrationConfig {
+  rpcUrl: string;
+  contractAddress: string;
+  privateKey?: string;
+}
+
+export class BaseIntegration {
+  private ethersLib: EthersLib | null = null;
+  private provider: any | null = null;
+  private contract: any | null = null;
+  private contractInterface: any | null = null;
+  private readonly config: BaseIntegrationConfig;
+
+  constructor() {
+    this.config = {
+      rpcUrl: process.env.BASE_RPC_URL || 'https://mainnet.base.org',
+      contractAddress: process.env.BASE_CONTRACT_ADDRESS || '',
+      privateKey: process.env.BASE_PRIVATE_KEY
+    };
+  }
+
+  async verifyWalletOwnership(userId: string, walletAddress: string): Promise<boolean> {
+    try {
+      const nonce = this.generateNonce();
+      const message = `LedgerLegends Authentication\nWallet: ${walletAddress}\nNonce: ${nonce}`;
+
+      db.prepare(
+        `INSERT OR REPLACE INTO wallet_verifications
+         (user_id, wallet_address, chain, challenge, created_at, status)
+         VALUES (?,?,?,?,?,?)`
+      ).run(userId, walletAddress, 'base', message, Date.now(), 'pending');
+
+      return true;
+    } catch (error) {
+      logger.error('Base wallet verification failed', { userId, walletAddress, error });
+      return false;
+    }
+  }
+
+  async verifySignature(userId: string, signature: string): Promise<boolean> {
+    try {
+      const verification = db
+        .prepare(
+          `SELECT * FROM wallet_verifications
+           WHERE user_id=? AND chain='base' AND status='pending'
+           ORDER BY created_at DESC LIMIT 1`
+        )
+        .get(userId) as
+        | {
+            wallet_address: string;
+            challenge: string;
+          }
+        | undefined;
+
+      if (!verification) {
+        return false;
+      }
+
+      const ethers = await this.loadEthers();
+      const recoveredAddress = ethers.verifyMessage(verification.challenge, signature);
+
+      if (recoveredAddress.toLowerCase() !== verification.wallet_address.toLowerCase()) {
+        return false;
+      }
+
+      db.prepare(
+        `UPDATE wallet_verifications
+         SET status='verified', verified_at=?
+         WHERE user_id=? AND wallet_address=? AND chain='base'`
+      ).run(Date.now(), userId, verification.wallet_address);
+
+      this.linkWalletToUser(userId, verification.wallet_address);
+      return true;
+    } catch (error) {
+      logger.error('Signature verification failed', { userId, error });
+      return false;
+    }
+  }
+
+  async getNFTsForWallet(walletAddress: string): Promise<BaseNFT[]> {
+    if (!walletAddress) return [];
+
+    try {
+      const contract = await this.ensureContract();
+      if (!contract) {
+        return [];
+      }
+
+      const balanceRaw = await contract.balanceOf(walletAddress);
+      const balance = this.normalizeBigInt(balanceRaw);
+      const nfts: BaseNFT[] = [];
+
+      for (let index = 0; index < balance; index += 1) {
+        const tokenIdRaw = await contract.tokenOfOwnerByIndex(walletAddress, index);
+        const tokenId = this.normalizeBigInt(tokenIdRaw).toString();
+        const uri: string = await contract.tokenURI(tokenIdRaw);
+        const metadata = await this.fetchMetadata(uri);
+
+        nfts.push({
+          tokenId,
+          owner: walletAddress,
+          contractAddress: this.config.contractAddress,
+          chain: 'base',
+          name: (metadata?.name as string) || `LedgerLegends #${tokenId}`,
+          description: (metadata?.description as string) || '',
+          image: (metadata?.image as string) || '',
+          attributes: (metadata?.attributes as Attribute[]) || [],
+          rarity: this.calculateRarity((metadata?.attributes as Attribute[]) || []),
+          power: this.calculatePower((metadata?.attributes as Attribute[]) || [])
+        });
+      }
+
+      return nfts;
+    } catch (error) {
+      logger.error('Failed to fetch Base NFTs', { walletAddress, error });
+      return [];
+    }
+  }
+
+  async mintRewardNFT(
+    userId: string,
+    rewardType: number,
+    metadata: Record<string, unknown>
+  ): Promise<string | null> {
+    try {
+      const wallet = this.getUserWallet(userId);
+      if (!wallet) {
+        logger.warn('No wallet linked for user', { userId });
+        return null;
+      }
+
+      const contractWithSigner = await this.getContractWithSigner();
+      if (!contractWithSigner) {
+        return null;
+      }
+
+      const tx = await contractWithSigner.mintReward(wallet, rewardType, JSON.stringify(metadata));
+      const receipt = await tx.wait();
+
+      const parsed = this.parseMintEvent(receipt?.logs ?? []);
+      if (!parsed) {
+        return null;
+      }
+
+      const rewardId = `base_${parsed.tokenId}`;
+      db.prepare(
+        `INSERT INTO nft_rewards
+         (id, user_id, wallet_address, chain, asset_id, reward_type, metadata_json, minted_at, tx_hash)
+         VALUES (?,?,?,?,?,?,?,?,?)`
+      ).run(
+        nanoid(12),
+        userId,
+        wallet,
+        'base',
+        parsed.tokenId,
+        rewardType.toString(),
+        JSON.stringify(metadata),
+        Date.now(),
+        receipt?.hash ?? ''
+      );
+
+      logger.info('NFT reward minted on Base', { userId, tokenId: parsed.tokenId, txHash: receipt?.hash });
+      return rewardId;
+    } catch (error) {
+      logger.error('Failed to mint NFT on Base', { userId, rewardType, error });
+      return null;
+    }
+  }
+
+  private async fetchMetadata(uri: string): Promise<any> {
+    try {
+      if (!uri) return {};
+
+      const normalized = uri.startsWith('ipfs://')
+        ? `https://ipfs.io/ipfs/${uri.slice('ipfs://'.length)}`
+        : uri;
+
+      const response = await fetch(normalized, { headers: { Accept: 'application/json' } });
+      if (!response.ok) {
+        throw new Error(`Metadata fetch failed with status ${response.status}`);
+      }
+
+      return response.json();
+    } catch (error) {
+      logger.warn('Failed to fetch NFT metadata', { uri, error });
+      return {};
+    }
+  }
+
+  private async ensureContract(): Promise<any | null> {
+    if (!this.config.contractAddress) {
+      logger.warn('Base contract address not configured');
+      return null;
+    }
+
+    if (this.contract) {
+      return this.contract;
+    }
+
+    const ethers = await this.loadEthers();
+    const provider = await this.ensureProvider();
+    if (!provider) {
+      return null;
+    }
+
+    this.contract = new ethers.Contract(this.config.contractAddress, LEDGER_LEGENDS_ABI, provider);
+    return this.contract;
+  }
+
+  private async ensureProvider(): Promise<any | null> {
+    if (this.provider) {
+      return this.provider;
+    }
+
+    try {
+      const ethers = await this.loadEthers();
+      this.provider = new ethers.JsonRpcProvider(this.config.rpcUrl);
+      return this.provider;
+    } catch (error) {
+      logger.error('Failed to initialize Base provider', { error });
+      return null;
+    }
+  }
+
+  private async getContractWithSigner(): Promise<any | null> {
+    if (!this.config.privateKey) {
+      logger.error('No private key configured for Base integration');
+      return null;
+    }
+
+    const ethers = await this.loadEthers();
+    const provider = await this.ensureProvider();
+    if (!provider) {
+      return null;
+    }
+
+    return new ethers.Contract(
+      this.config.contractAddress,
+      LEDGER_LEGENDS_ABI,
+      new ethers.Wallet(this.config.privateKey, provider)
+    );
+  }
+
+  private async loadEthers(): Promise<EthersLib> {
+    if (this.ethersLib) {
+      return this.ethersLib;
+    }
+
+    try {
+      const mod = await import('ethers');
+      this.ethersLib = mod;
+      this.contractInterface = new mod.Interface(LEDGER_LEGENDS_ABI);
+      return mod;
+    } catch (error) {
+      logger.error('Ethers library unavailable', { error });
+      throw new Error('Ethers library unavailable');
+    }
+  }
+
+  private parseMintEvent(logs: Array<{ topics?: string[]; data?: string }>): { tokenId: string } | null {
+    if (!this.contractInterface) {
+      return null;
+    }
+
+    for (const log of logs) {
+      if (!log?.topics) continue;
+      try {
+        const parsed = this.contractInterface.parseLog({
+          topics: log.topics,
+          data: log.data ?? '0x'
+        });
+
+        if (parsed?.name === 'RewardMinted') {
+          const candidate = (parsed.args as Record<string, unknown>)?.tokenId ??
+            (Array.isArray(parsed?.args) ? parsed.args[1] : undefined);
+
+          if (candidate != null) {
+            return { tokenId: this.normalizeBigInt(candidate).toString() };
+          }
+        }
+      } catch (error) {
+        logger.debug('Failed to parse mint event log', { error });
+      }
+    }
+
+    for (const log of logs) {
+      const tokenTopic = log?.topics?.[2];
+      if (tokenTopic) {
+        try {
+          return { tokenId: this.normalizeBigInt(tokenTopic).toString() };
+        } catch (error) {
+          logger.debug('Failed to decode token topic', { error });
+        }
+      }
+    }
+
+    return null;
+  }
+
+  private calculateRarity(attributes: Attribute[]): BaseNFTRarity {
+    const rarityAttr = attributes.find((attr) =>
+      typeof attr?.trait_type === 'string' && attr.trait_type.toLowerCase() === 'rarity'
+    );
+
+    if (rarityAttr && typeof rarityAttr.value === 'string') {
+      const normalized = rarityAttr.value.toLowerCase();
+      if (['common', 'uncommon', 'rare', 'epic', 'legendary'].includes(normalized)) {
+        return normalized as BaseNFTRarity;
+      }
+    }
+
+    const numericScore = attributes.reduce((score, attr) => {
+      if (typeof attr?.value === 'number') {
+        return score + attr.value;
+      }
+
+      const maybeNumber = Number(attr?.value);
+      return Number.isFinite(maybeNumber) ? score + maybeNumber : score;
+    }, 0);
+
+    if (numericScore >= 50) return 'legendary';
+    if (numericScore >= 30) return 'epic';
+    if (numericScore >= 20) return 'rare';
+    if (numericScore >= 10) return 'uncommon';
+    return 'common';
+  }
+
+  private calculatePower(attributes: Attribute[]): number {
+    const powerAttr = attributes.find((attr) =>
+      typeof attr?.trait_type === 'string' && attr.trait_type.toLowerCase() === 'power'
+    );
+
+    if (powerAttr) {
+      const direct = Number(powerAttr.value);
+      if (Number.isFinite(direct)) {
+        return Math.max(0, Math.floor(direct));
+      }
+    }
+
+    const aggregate = attributes.reduce((total, attr) => {
+      if (typeof attr?.value === 'number') {
+        return total + attr.value;
+      }
+
+      const parsed = Number(attr?.value);
+      return Number.isFinite(parsed) ? total + parsed : total;
+    }, 0);
+
+    return Math.max(0, Math.floor(aggregate / Math.max(attributes.length, 1)));
+  }
+
+  private linkWalletToUser(userId: string, walletAddress: string) {
+    const existing = db
+      .prepare(
+        'SELECT nft_ids FROM nft_ownership WHERE user_id=? AND chain=?'
+      )
+      .get(userId, 'base') as { nft_ids?: string } | undefined;
+
+    db.prepare(
+      `INSERT OR REPLACE INTO nft_ownership
+       (user_id, wallet_address, chain, nft_ids, verified_at)
+       VALUES (?,?,?,?,?)`
+    ).run(
+      userId,
+      walletAddress,
+      'base',
+      existing?.nft_ids ?? '[]',
+      Date.now()
+    );
+  }
+
+  private getUserWallet(userId: string): string | null {
+    const row = db
+      .prepare(
+        `SELECT wallet_address FROM wallet_verifications
+         WHERE user_id=? AND chain='base' AND status='verified'
+         ORDER BY verified_at DESC LIMIT 1`
+      )
+      .get(userId) as { wallet_address: string } | undefined;
+
+    return row?.wallet_address ?? null;
+  }
+
+  private generateNonce(): string {
+    return randomBytes(16).toString('hex');
+  }
+
+  private normalizeBigInt(value: unknown): bigint {
+    if (typeof value === 'bigint') return value;
+    if (typeof value === 'number') return BigInt(value);
+    if (typeof value === 'string' && value.startsWith('0x')) {
+      return BigInt(value);
+    }
+    if (typeof value === 'string') {
+      return BigInt(Number(value));
+    }
+    if (value && typeof (value as { toString: () => string }).toString === 'function') {
+      return BigInt((value as { toString: () => string }).toString());
+    }
+    return BigInt(0);
+  }
+}
+
+export const baseIntegration = new BaseIntegration();
+export const base = baseIntegration;

--- a/src/nft/cards.ts
+++ b/src/nft/cards.ts
@@ -1,5 +1,6 @@
 import db from '../persistence/db.js';
 import { Effect } from '../models.js';
+import { contentRegistry, CardDefinition } from '../content/contentRegistry.js';
 
 export interface Card {
   id: string;
@@ -214,6 +215,66 @@ export const CARD_REGISTRY: Record<string, Card> = {
     set: 'genesis'
   }
 };
+
+function cloneCard(card: Card): Card {
+  return {
+    ...card,
+    cost: { ...(card.cost ?? {}) },
+    effects: card.effects?.map((effect) => ({ ...effect })) ?? [],
+    tags: [...(card.tags ?? [])],
+  };
+}
+
+const FALLBACK_CARD_DEFS = new Map<string, Card>(Object.entries(CARD_REGISTRY).map(([id, card]) => [id, cloneCard(card)]));
+const DYNAMIC_CARD_IDS = new Set<string>();
+
+function hydrateCardRegistry() {
+  for (const id of DYNAMIC_CARD_IDS) {
+    const fallback = FALLBACK_CARD_DEFS.get(id);
+    if (fallback) {
+      CARD_REGISTRY[id] = cloneCard(fallback);
+    } else {
+      delete CARD_REGISTRY[id];
+    }
+  }
+  DYNAMIC_CARD_IDS.clear();
+
+  const cardDefs: CardDefinition[] = contentRegistry.getAllCards();
+  for (const def of cardDefs) {
+    const fallback = FALLBACK_CARD_DEFS.get(def.id);
+    const merged: Card = fallback ? cloneCard(fallback) : {
+      id: def.id,
+      name: def.name,
+      rarity: def.rarity as Card['rarity'],
+      type: def.type as Card['type'],
+      cost: {},
+      effects: [],
+      tags: [],
+      description: def.description,
+      set: def.set,
+    };
+
+    merged.name = def.name ?? merged.name;
+    merged.rarity = (def.rarity as Card['rarity']) ?? merged.rarity;
+    merged.type = (def.type as Card['type']) ?? merged.type;
+    merged.description = def.description ?? merged.description;
+    merged.flavorText = def.flavorText ?? merged.flavorText;
+    merged.set = def.set ?? merged.set;
+    merged.requiresClass = def.requiresClass ?? merged.requiresClass;
+    merged.cost = def.cost ? { ...def.cost } : merged.cost;
+    merged.tags = def.tags ? [...def.tags] : merged.tags;
+    merged.effects = def.effects ? (def.effects as Effect[]).map((effect) => ({ ...effect })) : merged.effects;
+
+    CARD_REGISTRY[def.id] = merged;
+
+    if (!fallback) {
+      DYNAMIC_CARD_IDS.add(def.id);
+    }
+  }
+}
+
+hydrateCardRegistry();
+contentRegistry.onReload(hydrateCardRegistry);
 
 // Deck management
 export class DeckManager {
@@ -688,15 +749,15 @@ export class CardEngine {
     return results;
   }
   
-  async getHand(runId: string): Promise<Card[]> {
+  getHand(runId: string): Card[] {
     return this.hand.get(runId) || [];
   }
-  
-  async getDiscardPile(runId: string): Promise<Card[]> {
+
+  getDiscardPile(runId: string): Card[] {
     return this.discardPile.get(runId) || [];
   }
   
-  async clearRunData(runId: string): void {
+  async clearRunData(runId: string): Promise<void> {
     this.hand.delete(runId);
     this.discardPile.delete(runId);
   }

--- a/src/persistence/schema.sql
+++ b/src/persistence/schema.sql
@@ -112,6 +112,15 @@ CREATE TABLE IF NOT EXISTS pvp_matches (
   result_json TEXT
 );
 
+CREATE TABLE IF NOT EXISTS pvp_records (
+  user_id TEXT PRIMARY KEY,
+  wins INTEGER DEFAULT 0,
+  losses INTEGER DEFAULT 0,
+  draws INTEGER DEFAULT 0,
+  rating INTEGER DEFAULT 1200,
+  updated_at INTEGER
+);
+
 CREATE TABLE IF NOT EXISTS difficulty_snapshots (
   run_id TEXT,
   scene_id TEXT,
@@ -138,6 +147,16 @@ CREATE TABLE IF NOT EXISTS events (
   type TEXT,
   payload_json TEXT,
   ts INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS world_events_active (
+  event_id TEXT,
+  server_id TEXT,
+  start_time INTEGER,
+  end_time INTEGER,
+  community_progress_json TEXT,
+  participants_json TEXT,
+  PRIMARY KEY(event_id, server_id)
 );
 
 CREATE TABLE IF NOT EXISTS pity (
@@ -286,6 +305,31 @@ CREATE TABLE IF NOT EXISTS nft_ownership (
   FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS wallet_verifications (
+  user_id TEXT,
+  wallet_address TEXT,
+  chain TEXT,
+  challenge TEXT,
+  created_at INTEGER,
+  status TEXT,
+  verified_at INTEGER,
+  PRIMARY KEY(user_id, chain),
+  FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS nft_rewards (
+  id TEXT PRIMARY KEY,
+  user_id TEXT,
+  wallet_address TEXT,
+  chain TEXT,
+  asset_id TEXT,
+  reward_type TEXT,
+  metadata_json TEXT,
+  minted_at INTEGER,
+  tx_hash TEXT,
+  FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);
+
 CREATE TABLE IF NOT EXISTS card_collection (
   user_id TEXT,
   card_id TEXT,
@@ -294,4 +338,97 @@ CREATE TABLE IF NOT EXISTS card_collection (
   source TEXT,
   PRIMARY KEY(user_id, card_id),
   FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS vault_rooms (
+  room_id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  room_type TEXT NOT NULL,
+  level INTEGER DEFAULT 1,
+  capacity INTEGER DEFAULT 5,
+  decorations_json TEXT DEFAULT '[]',
+  effects_json TEXT DEFAULT '[]',
+  visitors_json TEXT DEFAULT '[]',
+  active INTEGER DEFAULT 1,
+  created_at INTEGER,
+  last_updated INTEGER,
+  FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS vault_visits (
+  visitor_id TEXT,
+  host_id TEXT,
+  visited_at INTEGER,
+  rewards_json TEXT,
+  PRIMARY KEY(visitor_id, host_id, visited_at)
+);
+
+CREATE TABLE IF NOT EXISTS user_achievements (
+  user_id TEXT,
+  achievement_id TEXT,
+  earned_at INTEGER,
+  PRIMARY KEY(user_id, achievement_id)
+);
+
+CREATE TABLE IF NOT EXISTS tournaments (
+  tournament_id TEXT PRIMARY KEY,
+  name TEXT,
+  format TEXT,
+  status TEXT,
+  max_participants INTEGER,
+  current_round INTEGER,
+  total_rounds INTEGER,
+  start_time INTEGER,
+  end_time INTEGER,
+  entry_fee_json TEXT,
+  prizes_json TEXT,
+  rules_json TEXT,
+  metadata_json TEXT,
+  created_at INTEGER,
+  updated_at INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS tournament_registrations (
+  tournament_id TEXT,
+  user_id TEXT,
+  registered_at INTEGER,
+  seed REAL,
+  PRIMARY KEY(tournament_id, user_id),
+  FOREIGN KEY (tournament_id) REFERENCES tournaments(tournament_id) ON DELETE CASCADE,
+  FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS tournament_brackets (
+  tournament_id TEXT,
+  round INTEGER,
+  match_id TEXT PRIMARY KEY,
+  player1_id TEXT,
+  player2_id TEXT,
+  winner_id TEXT,
+  loser_id TEXT,
+  scores_json TEXT,
+  status TEXT,
+  scheduled_time INTEGER,
+  created_at INTEGER,
+  completed_at INTEGER,
+  FOREIGN KEY (tournament_id) REFERENCES tournaments(tournament_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS tournament_prizes (
+  tournament_id TEXT,
+  user_id TEXT,
+  placement TEXT,
+  prizes_json TEXT,
+  awarded_at INTEGER,
+  PRIMARY KEY(tournament_id, user_id),
+  FOREIGN KEY (tournament_id) REFERENCES tournaments(tournament_id) ON DELETE CASCADE,
+  FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS tournament_bans (
+  user_id TEXT,
+  reason TEXT,
+  issued_at INTEGER,
+  expires_at INTEGER,
+  PRIMARY KEY(user_id)
 );

--- a/src/pvp/duels.ts
+++ b/src/pvp/duels.ts
@@ -1,7 +1,7 @@
 import { nanoid } from 'nanoid';
 import db from '../persistence/db.js';
 
-type PvPMode = '1v1' | '2v2';
+export type PvPMode = '1v1' | '2v2';
 
 interface MatchState {
   matchId: string;
@@ -10,6 +10,16 @@ interface MatchState {
   turnIndex: number;
   scores: Record<string, number>;
   createdAt: number;
+  updatedAt: number;
+}
+
+interface LeaderboardEntry {
+  user_id: string;
+  wins: number;
+  losses: number;
+  draws: number;
+  rating: number;
+  updated_at: number;
 }
 
 const queue: Record<PvPMode, string[]> = {
@@ -19,29 +29,114 @@ const queue: Record<PvPMode, string[]> = {
 
 const activeMatches = new Map<string, MatchState>();
 
-function storeMatch(state: MatchState) {
+const WIN_REWARD = 750;
+const DRAW_REWARD = 350;
+const LOSS_REWARD = 200;
+
+function ensureProfile(userId: string) {
+  const now = Date.now();
+  db.prepare('INSERT OR IGNORE INTO users (user_id, discord_id, created_at) VALUES (?,?,?)').run(userId, userId, now);
+  db.prepare('INSERT OR IGNORE INTO profiles (user_id, coins, gems) VALUES (?,?,?)').run(userId, 0, 0);
+}
+
+function logEvent(type: string, payload: any) {
+  db.prepare('INSERT INTO events (event_id, run_id, user_id, type, payload_json, ts) VALUES (?,?,?,?,?,?)')
+    .run(`pvp_${type}_${Date.now()}_${nanoid(6)}`, null, null, type, JSON.stringify(payload), Date.now());
+}
+
+function persistMatch(state: MatchState) {
   db.prepare(
-    `INSERT OR REPLACE INTO pvp_matches (match_id,kind,status,participants_json,created_at,updated_at,result_json)
-     VALUES (?,?,?,?,?,?,?)`
+    `INSERT INTO pvp_matches (match_id,kind,status,participants_json,created_at,updated_at,result_json)
+     VALUES (?,?,?,?,?,?,?)
+     ON CONFLICT(match_id) DO UPDATE SET kind=excluded.kind, status=excluded.status, participants_json=excluded.participants_json,
+       updated_at=excluded.updated_at, result_json=excluded.result_json`
   ).run(
     state.matchId,
     state.mode,
     'active',
     JSON.stringify(state.participants),
     state.createdAt,
-    Date.now(),
-    '{}'
+    state.updatedAt,
+    JSON.stringify({ scores: state.scores, turnIndex: state.turnIndex })
   );
 }
 
-export function queueForMatch(user_id: string, mode: PvPMode = '1v1') {
+function removeMatch(matchId: string, result: any) {
+  db.prepare('UPDATE pvp_matches SET status=?, updated_at=?, result_json=? WHERE match_id=?')
+    .run('completed', Date.now(), JSON.stringify(result), matchId);
+  activeMatches.delete(matchId);
+}
+
+function loadActiveMatchesFromDb() {
+  const rows = db.prepare('SELECT * FROM pvp_matches WHERE status=?').all('active') as any[];
+  for (const row of rows) {
+    try {
+      const result = JSON.parse(row.result_json || '{}') as { scores?: Record<string, number>; turnIndex?: number };
+      const participants = JSON.parse(row.participants_json || '[]') as string[];
+      const state: MatchState = {
+        matchId: row.match_id,
+        mode: row.kind as PvPMode,
+        participants,
+        turnIndex: Number(result?.turnIndex ?? 0),
+        scores: result?.scores ?? Object.fromEntries(participants.map((p) => [p, 0])),
+        createdAt: row.created_at ?? Date.now(),
+        updatedAt: row.updated_at ?? Date.now(),
+      };
+      activeMatches.set(state.matchId, state);
+    } catch (err) {
+      console.error('Failed to restore PvP match', err);
+    }
+  }
+}
+
+export function initializePvP() {
+  loadActiveMatchesFromDb();
+}
+
+function awardCoins(userId: string, amount: number, reason: string) {
+  if (!amount) return;
+  ensureProfile(userId);
+  db.prepare('UPDATE profiles SET coins=coins+? WHERE user_id=?').run(amount, userId);
+  db.prepare(
+    'INSERT INTO economy_ledger (txn_id,user_id,kind,amount,reason,meta_json,ts) VALUES (?,?,?,?,?,?,?)'
+  ).run(`pvp_${Date.now()}_${nanoid(4)}`, userId, 'pvp_reward', amount, reason, '{}', Date.now());
+}
+
+function updateLeaderboard(userId: string, outcome: 'win' | 'loss' | 'draw') {
+  const existing = db
+    .prepare('SELECT wins, losses, draws, rating FROM pvp_records WHERE user_id=?')
+    .get(userId) as { wins: number; losses: number; draws: number; rating: number } | undefined;
+  const wins = (existing?.wins ?? 0) + (outcome === 'win' ? 1 : 0);
+  const losses = (existing?.losses ?? 0) + (outcome === 'loss' ? 1 : 0);
+  const draws = (existing?.draws ?? 0) + (outcome === 'draw' ? 1 : 0);
+  let rating = existing?.rating ?? 1200;
+  if (outcome === 'win') rating += 25;
+  if (outcome === 'loss') rating -= 15;
+  if (outcome === 'draw') rating += 5;
+  rating = Math.max(0, rating);
+  db.prepare(
+    `INSERT INTO pvp_records (user_id, wins, losses, draws, rating, updated_at)
+     VALUES (?,?,?,?,?,?)
+     ON CONFLICT(user_id) DO UPDATE SET wins=excluded.wins, losses=excluded.losses, draws=excluded.draws, rating=excluded.rating, updated_at=excluded.updated_at`
+  ).run(userId, wins, losses, draws, rating, Date.now());
+}
+
+function ensureMatchExists(state: MatchState) {
+  if (!activeMatches.has(state.matchId)) {
+    activeMatches.set(state.matchId, state);
+  }
+}
+
+export function queueForMatch(userId: string, mode: PvPMode = '1v1') {
+  ensureProfile(userId);
   const list = queue[mode];
-  if (list.includes(user_id)) {
+  if (list.includes(userId)) {
     return { message: 'Already in queue.' };
   }
-  list.push(user_id);
+  list.push(userId);
   if ((mode === '1v1' && list.length >= 2) || (mode === '2v2' && list.length >= 4)) {
     const players = mode === '1v1' ? list.splice(0, 2) : list.splice(0, 4);
+    players.forEach(ensureProfile);
     const matchId = `pvp_${nanoid(6)}`;
     const state: MatchState = {
       matchId,
@@ -50,43 +145,85 @@ export function queueForMatch(user_id: string, mode: PvPMode = '1v1') {
       turnIndex: 0,
       scores: Object.fromEntries(players.map((p) => [p, 0])),
       createdAt: Date.now(),
+      updatedAt: Date.now(),
     };
-    activeMatches.set(matchId, state);
-    storeMatch(state);
+    ensureMatchExists(state);
+    persistMatch(state);
+    logEvent('pvp.match_created', { matchId, mode, participants: players });
     return { message: `Match ${matchId} ready: ${players.map((p) => `<@${p}>`).join(' vs ')}`, matchId };
   }
   return { message: `Queued for ${mode}. Waiting for more challengers.` };
 }
 
-export function recordPvPAction(matchId: string, user_id: string, result: 'win' | 'loss' | 'draw') {
+export function recordPvPAction(matchId: string, userId: string, result: 'win' | 'loss' | 'draw') {
   const match = activeMatches.get(matchId);
   if (!match) return { success: false, message: 'Match not active.' };
-  if (!match.participants.includes(user_id)) {
+  if (!match.participants.includes(userId)) {
     return { success: false, message: 'You are not part of this match.' };
   }
-  if (result === 'win') match.scores[user_id] += 1;
-  if (result === 'loss') match.scores[user_id] -= 1;
+  if (result === 'win') match.scores[userId] = (match.scores[userId] ?? 0) + 1;
+  if (result === 'loss') match.scores[userId] = (match.scores[userId] ?? 0) - 1;
   match.turnIndex = (match.turnIndex + 1) % match.participants.length;
-  storeMatch(match);
+  match.updatedAt = Date.now();
+  persistMatch(match);
+  logEvent('pvp.action_recorded', { matchId, userId, result, scores: match.scores });
   return { success: true, message: `Score updated for ${matchId}.` };
 }
 
 export function concludeMatch(matchId: string) {
   const match = activeMatches.get(matchId);
-  if (!match) return { success: false };
+  if (!match) return { success: false, message: 'Match not active.' };
   const sorted = Object.entries(match.scores).sort((a, b) => b[1] - a[1]);
-  const winner = sorted[0]?.[0];
-  db.prepare('UPDATE pvp_matches SET status=?, updated_at=?, result_json=? WHERE match_id=?')
-    .run('completed', Date.now(), JSON.stringify({ scores: match.scores, winner }), matchId);
-  activeMatches.delete(matchId);
-  return { success: true, winner };
+  const topScore = sorted[0]?.[1] ?? 0;
+  const topPlayers = sorted.filter(([, score]) => score === topScore).map(([player]) => player);
+  const tie = topPlayers.length > 1;
+  const winners = tie ? [] : topPlayers;
+  const draws = tie ? topPlayers : [];
+  const losers = match.participants.filter((p) => !topPlayers.includes(p));
+
+  for (const winner of winners) {
+    awardCoins(winner, WIN_REWARD, 'pvp_win');
+    updateLeaderboard(winner, 'win');
+  }
+  for (const draw of draws) {
+    awardCoins(draw, DRAW_REWARD, 'pvp_draw');
+    updateLeaderboard(draw, 'draw');
+  }
+  for (const loser of losers) {
+    awardCoins(loser, LOSS_REWARD, 'pvp_loss');
+    updateLeaderboard(loser, 'loss');
+  }
+
+  const resultPayload = {
+    matchId,
+    mode: match.mode,
+    scores: match.scores,
+    winners,
+    draws,
+    losers,
+  };
+  removeMatch(matchId, resultPayload);
+  logEvent('pvp.match_completed', resultPayload);
+  return { success: true, winners: winners.length ? winners : draws };
 }
 
 export function listActiveMatches() {
-  return Array.from(activeMatches.values()).map((m) => ({
-    matchId: m.matchId,
-    mode: m.mode,
-    participants: m.participants,
-    scores: m.scores,
+  return Array.from(activeMatches.values()).map((match) => ({
+    matchId: match.matchId,
+    mode: match.mode,
+    participants: match.participants,
+    scores: match.scores,
+    updatedAt: match.updatedAt,
   }));
+}
+
+export function getPvPLeaderboard(limit = 10): LeaderboardEntry[] {
+  return db
+    .prepare('SELECT * FROM pvp_records ORDER BY rating DESC, wins DESC LIMIT ?')
+    .all(limit) as LeaderboardEntry[];
+}
+
+export function getPvPRecord(userId: string): LeaderboardEntry | null {
+  const row = db.prepare('SELECT * FROM pvp_records WHERE user_id=?').get(userId) as LeaderboardEntry | undefined;
+  return row ?? null;
 }

--- a/src/systems/tournament/tournamentManager.ts
+++ b/src/systems/tournament/tournamentManager.ts
@@ -1,0 +1,903 @@
+import { nanoid } from 'nanoid';
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonInteraction,
+  ButtonStyle,
+  EmbedBuilder,
+  StringSelectMenuBuilder,
+  StringSelectMenuInteraction,
+} from 'discord.js';
+import db from '../../persistence/db.js';
+import { Effect } from '../../models.js';
+import { applyEffects } from '../../engine/rules.js';
+
+export type TournamentFormat = 'single_elimination' | 'double_elimination' | 'round_robin' | 'swiss';
+export type TournamentStatus = 'registration' | 'in_progress' | 'completed' | 'cancelled';
+
+interface Tournament {
+  id: string;
+  name: string;
+  format: TournamentFormat;
+  status: TournamentStatus;
+  maxParticipants: number;
+  currentRound: number;
+  totalRounds: number;
+  startTime: number;
+  endTime?: number;
+  entryFee: { coins?: number; gems?: number; fragments?: number };
+  prizes: TournamentPrizes;
+  rules: TournamentRules;
+  metadata: Record<string, unknown>;
+}
+
+interface TournamentPrizes {
+  first: Effect[];
+  second: Effect[];
+  third: Effect[];
+  participation: Effect[];
+  milestones: { rounds: number; rewards: Effect[] }[];
+}
+
+interface TournamentRules {
+  banList: string[];
+  allowedClasses: string[];
+  levelRange: { min: number; max: number };
+  gearRestrictions: string[];
+  timeLimit: number;
+  bestOf: number;
+}
+
+interface Bracket {
+  tournamentId: string;
+  round: number;
+  matchId: string;
+  player1: string | null;
+  player2: string | null;
+  winner: string | null;
+  loser: string | null;
+  scores: { player1: number; player2: number };
+  status: 'pending' | 'in_progress' | 'completed';
+  scheduledTime?: number;
+}
+
+const DEFAULT_PRIZES: TournamentPrizes = {
+  first: [
+    { type: 'coins', value: 50_000 },
+    { type: 'item', id: 'trophy_champion' },
+    { type: 'xp', value: 5_000 },
+  ],
+  second: [
+    { type: 'coins', value: 25_000 },
+    { type: 'item', id: 'trophy_finalist' },
+    { type: 'xp', value: 2_500 },
+  ],
+  third: [
+    { type: 'coins', value: 10_000 },
+    { type: 'item', id: 'trophy_semifinalist' },
+    { type: 'xp', value: 1_000 },
+  ],
+  participation: [{ type: 'xp', value: 100 }],
+  milestones: [
+    { rounds: 1, rewards: [{ type: 'coins', value: 1_000 }] },
+    { rounds: 3, rewards: [{ type: 'fragment', value: 50 }] },
+    { rounds: 5, rewards: [{ type: 'item', id: 'tournament_badge' }] },
+  ],
+};
+
+const DEFAULT_RULES: TournamentRules = {
+  banList: [],
+  allowedClasses: ['dev', 'trader', 'whale', 'hacker', 'validator', 'miner', 'shiller', 'meme'],
+  levelRange: { min: 1, max: 100 },
+  gearRestrictions: [],
+  timeLimit: 30,
+  bestOf: 3,
+};
+
+export class TournamentManager {
+  private readonly activeTournaments = new Map<string, Tournament>();
+  private readonly brackets = new Map<string, Bracket[]>();
+  private readonly registrations = new Map<string, Set<string>>();
+
+  constructor() {
+    this.loadActiveTournaments();
+  }
+
+  private loadActiveTournaments() {
+    const rows = db
+      .prepare(
+        `SELECT * FROM tournaments WHERE status IN ('registration', 'in_progress')`
+      )
+      .all() as any[];
+
+    for (const row of rows) {
+      const tournament: Tournament = {
+        id: row.tournament_id,
+        name: row.name,
+        format: row.format,
+        status: row.status,
+        maxParticipants: row.max_participants,
+        currentRound: row.current_round,
+        totalRounds: row.total_rounds,
+        startTime: row.start_time,
+        endTime: row.end_time,
+        entryFee: JSON.parse(row.entry_fee_json || '{}'),
+        prizes: JSON.parse(row.prizes_json || '{}'),
+        rules: JSON.parse(row.rules_json || '{}'),
+        metadata: JSON.parse(row.metadata_json || '{}'),
+      };
+
+      this.activeTournaments.set(tournament.id, tournament);
+
+      const bracketRows = db
+        .prepare(`SELECT * FROM tournament_brackets WHERE tournament_id=?`)
+        .all(tournament.id) as any[];
+      const brackets = bracketRows.map((b) => ({
+        tournamentId: b.tournament_id,
+        round: b.round,
+        matchId: b.match_id,
+        player1: b.player1_id,
+        player2: b.player2_id,
+        winner: b.winner_id,
+        loser: b.loser_id,
+        scores: JSON.parse(b.scores_json || '{"player1":0,"player2":0}'),
+        status: b.status,
+        scheduledTime: b.scheduled_time,
+      }));
+      this.brackets.set(tournament.id, brackets);
+
+      const regRows = db
+        .prepare(`SELECT user_id FROM tournament_registrations WHERE tournament_id=?`)
+        .all(tournament.id) as any[];
+      this.registrations.set(tournament.id, new Set(regRows.map((r) => r.user_id)));
+    }
+  }
+
+  createTournament(config: {
+    name: string;
+    format: TournamentFormat;
+    maxParticipants: number;
+    startTime: number;
+    entryFee?: { coins?: number; gems?: number; fragments?: number };
+    prizes?: Partial<TournamentPrizes>;
+    rules?: Partial<TournamentRules>;
+  }): Tournament {
+    const id = `tour_${nanoid(8)}`;
+    const entryFee = config.entryFee || {};
+    const prizes: TournamentPrizes = {
+      ...DEFAULT_PRIZES,
+      ...config.prizes,
+      milestones: config.prizes?.milestones || DEFAULT_PRIZES.milestones,
+    };
+    const rules: TournamentRules = {
+      ...DEFAULT_RULES,
+      ...config.rules,
+    };
+
+    const tournament: Tournament = {
+      id,
+      name: config.name,
+      format: config.format,
+      status: 'registration',
+      maxParticipants: config.maxParticipants,
+      currentRound: 0,
+      totalRounds: this.calculateTotalRounds(config.format, config.maxParticipants),
+      startTime: config.startTime,
+      entryFee,
+      prizes,
+      rules,
+      metadata: {},
+    };
+
+    db.prepare(
+      `INSERT INTO tournaments (
+         tournament_id, name, format, status, max_participants, current_round, total_rounds,
+         start_time, entry_fee_json, prizes_json, rules_json, metadata_json, created_at
+       ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`
+    ).run(
+      tournament.id,
+      tournament.name,
+      tournament.format,
+      tournament.status,
+      tournament.maxParticipants,
+      tournament.currentRound,
+      tournament.totalRounds,
+      tournament.startTime,
+      JSON.stringify(tournament.entryFee),
+      JSON.stringify(tournament.prizes),
+      JSON.stringify(tournament.rules),
+      JSON.stringify(tournament.metadata),
+      Date.now()
+    );
+
+    this.activeTournaments.set(tournament.id, tournament);
+    this.registrations.set(tournament.id, new Set());
+    this.brackets.set(tournament.id, []);
+
+    return tournament;
+  }
+
+  registerPlayer(tournamentId: string, userId: string) {
+    const tournament = this.activeTournaments.get(tournamentId);
+    if (!tournament) {
+      return { success: false, message: 'Tournament not found.' };
+    }
+
+    if (tournament.status !== 'registration') {
+      return { success: false, message: 'Registration closed.' };
+    }
+
+    const registrations = this.registrations.get(tournamentId) || new Set<string>();
+    if (registrations.has(userId)) {
+      return { success: false, message: 'Already registered.' };
+    }
+
+    if (registrations.size >= tournament.maxParticipants) {
+      return { success: false, message: 'Tournament is full.' };
+    }
+
+    const eligibility = this.checkEligibility(userId, tournament);
+    if (!eligibility.eligible) {
+      return { success: false, message: eligibility.reason ?? 'Not eligible.' };
+    }
+
+    if (!this.payEntryFee(userId, tournament.entryFee)) {
+      return { success: false, message: 'Insufficient funds for entry fee.' };
+    }
+
+    db.prepare(
+      `INSERT INTO tournament_registrations (tournament_id, user_id, registered_at, seed)
+       VALUES (?,?,?,?)`
+    ).run(tournamentId, userId, Date.now(), Math.random());
+
+    registrations.add(userId);
+    this.registrations.set(tournamentId, registrations);
+
+    return {
+      success: true,
+      message: `Registered for ${tournament.name}! (${registrations.size}/${tournament.maxParticipants})`,
+    };
+  }
+
+  startTournament(tournamentId: string) {
+    const tournament = this.activeTournaments.get(tournamentId);
+    if (!tournament) {
+      return { success: false, message: 'Tournament not found.' };
+    }
+
+    const registrations = this.registrations.get(tournamentId) || new Set<string>();
+    if (registrations.size < 2) {
+      return { success: false, message: 'Not enough players to start.' };
+    }
+
+    const brackets = this.generateBrackets(tournament, Array.from(registrations));
+    this.brackets.set(tournament.id, brackets);
+
+    tournament.status = 'in_progress';
+    tournament.currentRound = 1;
+
+    db.prepare(
+      `UPDATE tournaments SET status='in_progress', current_round=?, updated_at=? WHERE tournament_id=?`
+    ).run(1, Date.now(), tournament.id);
+
+    for (const bracket of brackets) {
+      db.prepare(
+        `INSERT INTO tournament_brackets (
+           tournament_id, round, match_id, player1_id, player2_id, status, scores_json, created_at
+         ) VALUES (?,?,?,?,?,?,?,?)`
+      ).run(
+        bracket.tournamentId,
+        bracket.round,
+        bracket.matchId,
+        bracket.player1,
+        bracket.player2,
+        bracket.status,
+        JSON.stringify(bracket.scores),
+        Date.now()
+      );
+    }
+
+    return { success: true, message: `${tournament.name} has started!` };
+  }
+
+  reportMatchResult(
+    tournamentId: string,
+    matchId: string,
+    winnerId: string,
+    scores: { player1: number; player2: number }
+  ) {
+    const tournament = this.activeTournaments.get(tournamentId);
+    if (!tournament) {
+      return { success: false, message: 'Tournament not found.' };
+    }
+
+    const brackets = this.brackets.get(tournamentId) || [];
+    const bracket = brackets.find((b) => b.matchId === matchId);
+    if (!bracket) {
+      return { success: false, message: 'Match not found.' };
+    }
+
+    if (bracket.status === 'completed') {
+      return { success: false, message: 'Match already completed.' };
+    }
+
+    bracket.winner = winnerId;
+    bracket.loser = winnerId === bracket.player1 ? bracket.player2 : bracket.player1;
+    bracket.scores = scores;
+    bracket.status = 'completed';
+
+    db.prepare(
+      `UPDATE tournament_brackets
+       SET winner_id=?, loser_id=?, scores_json=?, status='completed', completed_at=?
+       WHERE tournament_id=? AND match_id=?`
+    ).run(bracket.winner, bracket.loser, JSON.stringify(scores), Date.now(), tournamentId, matchId);
+
+    const roundMatches = brackets.filter((b) => b.round === bracket.round);
+    const roundComplete = roundMatches.every((m) => m.status === 'completed');
+
+    if (roundComplete) {
+      if (tournament.currentRound < tournament.totalRounds) {
+        this.advanceToNextRound(tournament, brackets);
+      } else {
+        this.completeTournament(tournament, brackets);
+      }
+    }
+
+    return { success: true, message: 'Result recorded.' };
+  }
+
+  async renderTournamentHub(userId: string) {
+    const embed = new EmbedBuilder()
+      .setTitle('⚔️ Tournament Hub')
+      .setDescription('Compete for glory, rewards, and eternal bragging rights!')
+      .setColor(0xffd700);
+
+    const active = Array.from(this.activeTournaments.values());
+
+    if (!active.length) {
+      embed.addFields({ name: 'No active tournaments', value: 'Check back soon!', inline: false });
+    } else {
+      for (const tournament of active) {
+        const registrations = this.registrations.get(tournament.id) || new Set<string>();
+        const statusLine =
+          tournament.status === 'registration'
+            ? `📝 Registration Open (${registrations.size}/${tournament.maxParticipants})`
+            : `🏆 Round ${tournament.currentRound}/${tournament.totalRounds}`;
+
+        const entryFeeParts = [] as string[];
+        if (tournament.entryFee.coins) entryFeeParts.push(`${tournament.entryFee.coins} Coins`);
+        if (tournament.entryFee.gems) entryFeeParts.push(`${tournament.entryFee.gems} Gems`);
+        if (tournament.entryFee.fragments) entryFeeParts.push(`${tournament.entryFee.fragments} Fragments`);
+
+        embed.addFields({
+          name: tournament.name,
+          value: [
+            statusLine,
+            `Format: ${tournament.format}`,
+            `Entry: ${entryFeeParts.join(', ') || 'Free'}`,
+            `Starts: <t:${Math.floor(tournament.startTime / 1000)}:R>`,
+          ].join('\n'),
+          inline: true,
+        });
+      }
+    }
+
+    const selectMenu = new StringSelectMenuBuilder()
+      .setCustomId('tournament:select')
+      .setPlaceholder('Select a tournament...')
+      .addOptions(
+        active.map((t) => ({
+          label: t.name,
+          description: `${t.format} — ${t.status.replace('_', ' ')}`,
+          value: t.id,
+        }))
+      );
+
+    const buttons = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId('tournament:create')
+        .setLabel('Create Tournament')
+        .setEmoji('➕')
+        .setStyle(ButtonStyle.Primary),
+      new ButtonBuilder()
+        .setCustomId('tournament:history')
+        .setLabel('My History')
+        .setEmoji('📜')
+        .setStyle(ButtonStyle.Secondary),
+      new ButtonBuilder()
+        .setCustomId('tournament:leaderboard')
+        .setLabel('Global Leaderboard')
+        .setEmoji('🏆')
+        .setStyle(ButtonStyle.Secondary)
+    );
+
+    const components = active.length
+      ? [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(selectMenu), buttons]
+      : [buttons];
+
+    return { embeds: [embed], components };
+  }
+
+  async handleButton(interaction: ButtonInteraction) {
+    if (!interaction.customId.startsWith('tournament:')) {
+      return false;
+    }
+
+    const [, action, arg] = interaction.customId.split(':');
+
+    if (action === 'create') {
+      const start = Date.now() + 60 * 60 * 1000;
+      const tournament = this.createTournament({
+        name: `Community Cup ${new Date().toLocaleDateString()}`,
+        format: 'single_elimination',
+        maxParticipants: 16,
+        startTime: start,
+      });
+
+      await interaction.reply({
+        ephemeral: true,
+        content: `✅ Tournament **${tournament.name}** created. Registrations are open!`,
+      });
+      return true;
+    }
+
+    if (action === 'history') {
+      const history = this.getUserTournamentHistory(interaction.user.id);
+      if (!history.length) {
+        await interaction.reply({
+          ephemeral: true,
+          content: 'You have not participated in any tournaments yet.',
+        });
+        return true;
+      }
+
+      const embed = new EmbedBuilder()
+        .setTitle('📜 Tournament History')
+        .setColor(0x3498db);
+
+      for (const row of history) {
+        embed.addFields({
+          name: row.name,
+          value: `Status: ${row.status}\nPlacement: ${row.placement ?? '—'}`,
+          inline: false,
+        });
+      }
+
+      await interaction.reply({ ephemeral: true, embeds: [embed] });
+      return true;
+    }
+
+    if (action === 'leaderboard') {
+      const leaderboard = this.getGlobalLeaderboard();
+      const embed = new EmbedBuilder()
+        .setTitle('🏆 Tournament Champions')
+        .setDescription(
+          leaderboard
+            .map(
+              (entry, index) =>
+                `**${index + 1}.** <@${entry.user_id}> — ${entry.championships} championships`
+            )
+            .join('\n') || 'No champions yet.'
+        )
+        .setColor(0xe67e22);
+
+      await interaction.reply({ ephemeral: true, embeds: [embed] });
+      return true;
+    }
+
+    if (action === 'register' && arg) {
+      const result = this.registerPlayer(arg, interaction.user.id);
+      await interaction.reply({ ephemeral: true, content: result.message });
+      return true;
+    }
+
+    if (action === 'start' && arg) {
+      const result = this.startTournament(arg);
+      await interaction.reply({ ephemeral: true, content: result.message });
+      return true;
+    }
+
+    if (action === 'view' && arg) {
+      const detail = this.renderTournamentDetail(arg, interaction.user.id);
+      await interaction.reply({ ephemeral: true, ...detail });
+      return true;
+    }
+
+    return false;
+  }
+
+  async handleSelectMenu(interaction: StringSelectMenuInteraction) {
+    if (interaction.customId !== 'tournament:select') {
+      return false;
+    }
+
+    const [tournamentId] = interaction.values;
+    const detail = this.renderTournamentDetail(tournamentId, interaction.user.id);
+    await interaction.reply({ ephemeral: true, ...detail });
+    return true;
+  }
+
+  renderTournamentDetail(tournamentId: string, userId: string) {
+    const tournament = this.activeTournaments.get(tournamentId);
+    if (!tournament) {
+      return {
+        embeds: [new EmbedBuilder().setTitle('Tournament not found').setDescription('This event no longer exists.')],
+      };
+    }
+
+    const embed = new EmbedBuilder()
+      .setTitle(`🏟️ ${tournament.name}`)
+      .setDescription(`Format: **${tournament.format}**`)
+      .addFields(
+        { name: 'Status', value: tournament.status.replace('_', ' '), inline: true },
+        {
+          name: 'Registered',
+          value: `${(this.registrations.get(tournamentId) || new Set()).size}/${tournament.maxParticipants}`,
+          inline: true,
+        },
+        {
+          name: 'Starts',
+          value: `<t:${Math.floor(tournament.startTime / 1000)}:F>`,
+          inline: true,
+        }
+      )
+      .setColor(0x2ecc71);
+
+    if (tournament.status !== 'registration') {
+      const brackets = this.brackets.get(tournamentId) || [];
+      const current = brackets.filter((b) => b.round === tournament.currentRound);
+      if (current.length) {
+        const lines = current.map((match) => {
+          const p1 = match.player1 ? `<@${match.player1}>` : 'BYE';
+          const p2 = match.player2 ? `<@${match.player2}>` : 'BYE';
+          const score = `${match.scores.player1}-${match.scores.player2}`;
+          const status =
+            match.status === 'completed'
+              ? match.winner
+                ? `✅ <@${match.winner}>`
+                : '✅ Completed'
+              : '⏳ Pending';
+          return `${match.matchId}: ${p1} vs ${p2} — ${score} ${status}`;
+        });
+        embed.addFields({ name: `Round ${tournament.currentRound}`, value: lines.join('\n') });
+      }
+    }
+
+    const registrations = this.registrations.get(tournamentId) || new Set<string>();
+    const userRegistered = registrations.has(userId);
+
+    const buttons = new ActionRowBuilder<ButtonBuilder>();
+    if (tournament.status === 'registration') {
+      buttons.addComponents(
+        new ButtonBuilder()
+          .setCustomId(`tournament:register:${tournament.id}`)
+          .setLabel(userRegistered ? 'Registered' : 'Register')
+          .setStyle(userRegistered ? ButtonStyle.Secondary : ButtonStyle.Success)
+          .setDisabled(userRegistered)
+      );
+      buttons.addComponents(
+        new ButtonBuilder()
+          .setCustomId(`tournament:start:${tournament.id}`)
+          .setLabel('Start Tournament')
+          .setStyle(ButtonStyle.Primary)
+      );
+    } else {
+      buttons.addComponents(
+        new ButtonBuilder()
+          .setCustomId(`tournament:view:${tournament.id}`)
+          .setLabel('Refresh Overview')
+          .setStyle(ButtonStyle.Secondary)
+      );
+    }
+
+    return { embeds: [embed], components: [buttons] };
+  }
+
+  getUserTournamentHistory(userId: string, limit = 10) {
+    return db
+      .prepare(
+        `SELECT t.*, tp.placement
+         FROM tournaments t
+         LEFT JOIN tournament_prizes tp ON tp.tournament_id = t.tournament_id AND tp.user_id = ?
+         WHERE t.tournament_id IN (
+           SELECT tournament_id FROM tournament_registrations WHERE user_id = ?
+         )
+         ORDER BY COALESCE(t.end_time, t.start_time) DESC
+         LIMIT ?`
+      )
+      .all(userId, userId, limit) as any[];
+  }
+
+  getGlobalLeaderboard(limit = 10) {
+    return db
+      .prepare(
+        `SELECT user_id, COUNT(*) AS championships
+         FROM tournament_prizes
+         WHERE placement='champion'
+         GROUP BY user_id
+         ORDER BY championships DESC
+         LIMIT ?`
+      )
+      .all(limit) as Array<{ user_id: string; championships: number }>;
+  }
+
+  private calculateTotalRounds(format: TournamentFormat, participants: number) {
+    if (format === 'single_elimination' || format === 'double_elimination' || format === 'swiss') {
+      return Math.ceil(Math.log2(Math.max(participants, 2)));
+    }
+    if (format === 'round_robin') {
+      return Math.max(participants - 1, 1);
+    }
+    return 1;
+  }
+
+  private generateBrackets(tournament: Tournament, players: string[]): Bracket[] {
+    const brackets: Bracket[] = [];
+
+    if (tournament.format === 'single_elimination') {
+      const shuffled = [...players].sort(() => Math.random() - 0.5);
+      const bracketSize = Math.pow(2, Math.ceil(Math.log2(shuffled.length)));
+
+      while (shuffled.length < bracketSize) {
+        shuffled.push(null as any);
+      }
+
+      for (let i = 0; i < shuffled.length; i += 2) {
+        const player1 = shuffled[i];
+        const player2 = shuffled[i + 1];
+
+        const bracket: Bracket = {
+          tournamentId: tournament.id,
+          round: 1,
+          matchId: `${tournament.id}_R1_M${Math.floor(i / 2)}`,
+          player1,
+          player2,
+          winner: null,
+          loser: null,
+          scores: { player1: 0, player2: 0 },
+          status: player2 ? 'pending' : 'completed',
+        };
+
+        if (!player2) {
+          bracket.winner = player1;
+        }
+
+        brackets.push(bracket);
+      }
+    } else if (tournament.format === 'round_robin') {
+      for (let i = 0; i < players.length; i++) {
+        for (let j = i + 1; j < players.length; j++) {
+          brackets.push({
+            tournamentId: tournament.id,
+            round: 1,
+            matchId: `${tournament.id}_RR_${i}_${j}`,
+            player1: players[i],
+            player2: players[j],
+            winner: null,
+            loser: null,
+            scores: { player1: 0, player2: 0 },
+            status: 'pending',
+          });
+        }
+      }
+    }
+
+    return brackets;
+  }
+
+  private advanceToNextRound(tournament: Tournament, brackets: Bracket[]) {
+    const winners = brackets
+      .filter((b) => b.round === tournament.currentRound)
+      .map((b) => b.winner)
+      .filter((winner): winner is string => Boolean(winner));
+
+    if (!winners.length) {
+      return;
+    }
+
+    const nextRound = tournament.currentRound + 1;
+    const nextBrackets: Bracket[] = [];
+
+    for (let i = 0; i < winners.length; i += 2) {
+      const bracket: Bracket = {
+        tournamentId: tournament.id,
+        round: nextRound,
+        matchId: `${tournament.id}_R${nextRound}_M${Math.floor(i / 2)}`,
+        player1: winners[i] ?? null,
+        player2: winners[i + 1] ?? null,
+        winner: null,
+        loser: null,
+        scores: { player1: 0, player2: 0 },
+        status: winners[i + 1] ? 'pending' : 'completed',
+      };
+
+      if (!bracket.player2) {
+        bracket.winner = bracket.player1;
+      }
+
+      nextBrackets.push(bracket);
+      brackets.push(bracket);
+
+      db.prepare(
+        `INSERT INTO tournament_brackets (
+           tournament_id, round, match_id, player1_id, player2_id, status, scores_json, created_at
+         ) VALUES (?,?,?,?,?,?,?,?)`
+      ).run(
+        bracket.tournamentId,
+        bracket.round,
+        bracket.matchId,
+        bracket.player1,
+        bracket.player2,
+        bracket.status,
+        JSON.stringify(bracket.scores),
+        Date.now()
+      );
+    }
+
+    tournament.currentRound = nextRound;
+    db.prepare(`UPDATE tournaments SET current_round=?, updated_at=? WHERE tournament_id=?`).run(
+      nextRound,
+      Date.now(),
+      tournament.id
+    );
+  }
+
+  private completeTournament(tournament: Tournament, brackets: Bracket[]) {
+    tournament.status = 'completed';
+    tournament.endTime = Date.now();
+
+    const finalRound = brackets.filter((b) => b.round === tournament.totalRounds);
+    const finalMatch = finalRound[0];
+    const champion = finalMatch?.winner;
+    const runnerUp = finalMatch?.loser;
+    const previousRound = brackets.filter((b) => b.round === tournament.totalRounds - 1);
+    const thirdPlace = previousRound
+      .map((b) => b.loser)
+      .filter((player) => player && player !== runnerUp)[0];
+
+    if (champion) this.awardPrizes(champion, tournament.prizes.first, tournament.id, 'champion');
+    if (runnerUp) this.awardPrizes(runnerUp, tournament.prizes.second, tournament.id, 'runner_up');
+    if (thirdPlace)
+      this.awardPrizes(thirdPlace, tournament.prizes.third, tournament.id, 'third_place');
+
+    const participants = this.registrations.get(tournament.id) || new Set<string>();
+    for (const participant of participants) {
+      this.awardPrizes(participant, tournament.prizes.participation, tournament.id, 'participation');
+
+      const roundsPlayed = brackets.filter(
+        (b) => b.status === 'completed' && (b.player1 === participant || b.player2 === participant)
+      ).length;
+
+      for (const milestone of tournament.prizes.milestones) {
+        if (roundsPlayed >= milestone.rounds) {
+          this.awardPrizes(
+            participant,
+            milestone.rewards,
+            tournament.id,
+            `milestone_${milestone.rounds}`
+          );
+        }
+      }
+    }
+
+    db.prepare(
+      `UPDATE tournaments SET status='completed', end_time=?, updated_at=? WHERE tournament_id=?`
+    ).run(tournament.endTime, Date.now(), tournament.id);
+
+    this.activeTournaments.delete(tournament.id);
+  }
+
+  private checkEligibility(userId: string, tournament: Tournament) {
+    const profile = db
+      .prepare(`SELECT level, selected_role FROM profiles WHERE user_id=?`)
+      .get(userId) as { level: number; selected_role: string } | undefined;
+
+    if (!profile) {
+      return { eligible: false, reason: 'Player profile not found.' };
+    }
+
+    if (profile.level < tournament.rules.levelRange.min) {
+      return { eligible: false, reason: `Minimum level ${tournament.rules.levelRange.min} required.` };
+    }
+
+    if (profile.level > tournament.rules.levelRange.max) {
+      return { eligible: false, reason: `Maximum level ${tournament.rules.levelRange.max} exceeded.` };
+    }
+
+    if (!tournament.rules.allowedClasses.includes(profile.selected_role)) {
+      return { eligible: false, reason: 'Your role is not eligible for this event.' };
+    }
+
+    const banned = db
+      .prepare(
+        `SELECT 1 FROM tournament_bans WHERE user_id=? AND (expires_at IS NULL OR expires_at > ?)`
+      )
+      .get(userId, Date.now());
+
+    if (banned) {
+      return { eligible: false, reason: 'You are banned from tournaments.' };
+    }
+
+    return { eligible: true };
+  }
+
+  private payEntryFee(
+    userId: string,
+    fee: { coins?: number; gems?: number; fragments?: number }
+  ) {
+    const profile = db
+      .prepare(`SELECT coins, gems, fragments FROM profiles WHERE user_id=?`)
+      .get(userId) as { coins: number; gems: number; fragments: number } | undefined;
+
+    if (!profile) return false;
+
+    if (fee.coins && profile.coins < fee.coins) return false;
+    if (fee.gems && profile.gems < fee.gems) return false;
+    if (fee.fragments && profile.fragments < fee.fragments) return false;
+
+    if (fee.coins) {
+      db.prepare(`UPDATE profiles SET coins=coins-? WHERE user_id=?`).run(fee.coins, userId);
+    }
+    if (fee.gems) {
+      db.prepare(`UPDATE profiles SET gems=gems-? WHERE user_id=?`).run(fee.gems, userId);
+    }
+    if (fee.fragments) {
+      db.prepare(`UPDATE profiles SET fragments=fragments-? WHERE user_id=?`).run(
+        fee.fragments,
+        userId
+      );
+    }
+
+    return true;
+  }
+
+  private awardPrizes(
+    userId: string,
+    prizes: Effect[],
+    tournamentId: string,
+    placement: string
+  ) {
+    if (!prizes.length) return;
+    const state: any = {
+      _coins: {},
+      _xp: {},
+      _fragments: {},
+      _gems: {},
+      _items: {},
+    };
+
+    applyEffects(prizes, state, userId);
+
+    if (state._coins[userId]) {
+      db.prepare(`UPDATE profiles SET coins=coins+? WHERE user_id=?`).run(state._coins[userId], userId);
+    }
+    if (state._xp[userId]) {
+      db.prepare(`UPDATE profiles SET xp=xp+? WHERE user_id=?`).run(state._xp[userId], userId);
+    }
+    if (state._fragments[userId]) {
+      db.prepare(`UPDATE profiles SET fragments=fragments+? WHERE user_id=?`).run(
+        state._fragments[userId],
+        userId
+      );
+    }
+    if (state._gems[userId]) {
+      db.prepare(`UPDATE profiles SET gems=gems+? WHERE user_id=?`).run(state._gems[userId], userId);
+    }
+    if (state._items[userId]) {
+      for (const itemId of state._items[userId]) {
+        db.prepare(
+          `INSERT INTO inventories (user_id, item_id, kind, rarity, qty, meta_json)
+           VALUES (?,?,?,?,?,?)
+           ON CONFLICT(user_id, item_id) DO UPDATE SET qty=qty+excluded.qty`
+        ).run(userId, itemId, 'tournament_prize', 'epic', 1, JSON.stringify({ tournamentId, placement }));
+      }
+    }
+
+    db.prepare(
+      `INSERT INTO tournament_prizes (tournament_id, user_id, placement, prizes_json, awarded_at)
+       VALUES (?,?,?,?,?)`
+    ).run(tournamentId, userId, placement, JSON.stringify(prizes), Date.now());
+  }
+}
+
+export const tournamentManager = new TournamentManager();

--- a/src/systems/vault/vaultManager.ts
+++ b/src/systems/vault/vaultManager.ts
@@ -1,0 +1,703 @@
+import { nanoid } from 'nanoid';
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonInteraction,
+  ButtonStyle,
+  EmbedBuilder,
+  StringSelectMenuBuilder,
+  StringSelectMenuInteraction,
+} from 'discord.js';
+import db from '../../persistence/db.js';
+import { Effect } from '../../models.js';
+
+export type RoomType =
+  | 'workshop'
+  | 'shrine'
+  | 'trophy_hall'
+  | 'gremlin_den'
+  | 'treasury'
+  | 'meditation_chamber';
+
+export type DecorationSlot = 'floor' | 'wall' | 'ceiling' | 'furniture' | 'lighting' | 'special';
+
+interface RoomEffect {
+  type: 'passive' | 'active' | 'ambient';
+  effect: Effect;
+  cooldown?: number;
+  lastActivated?: number;
+}
+
+interface Decoration {
+  id: string;
+  name: string;
+  slot: DecorationSlot;
+  rarity: string;
+  effects?: RoomEffect[];
+  requirements?: { level?: number; achievements?: string[] };
+}
+
+export interface VaultRoom {
+  roomId: string;
+  userId: string;
+  type: RoomType;
+  level: number;
+  capacity: number;
+  decorations: Decoration[];
+  activeEffects: RoomEffect[];
+  visitors: { userId: string; timestamp: number }[];
+  lastUpdated: number;
+}
+
+interface RoomDefinition {
+  name: string;
+  description: string;
+  baseCapacity: number;
+  maxLevel: number;
+  baseEffects: RoomEffect[];
+  upgrades: RoomUpgrade[];
+}
+
+interface RoomUpgrade {
+  fromLevel: number;
+  toLevel: number;
+  cost: { coins?: number; fragments?: number; materials?: Record<string, number> };
+  benefits: string[];
+  requirements?: { achievements?: string[]; minLevel?: number };
+}
+
+const ROOM_DEFINITIONS: Record<RoomType, RoomDefinition> = {
+  workshop: {
+    name: 'Forge Workshop',
+    description: 'Craft and enhance gear with better odds and lower costs.',
+    baseCapacity: 5,
+    maxLevel: 10,
+    baseEffects: [{ type: 'passive', effect: { type: 'buff', id: 'crafting_discount', value: 10 } }],
+    upgrades: [
+      {
+        fromLevel: 1,
+        toLevel: 2,
+        cost: { coins: 10_000, fragments: 50 },
+        benefits: ['Crafting discount increased to 15%', '+2 decoration slots'],
+      },
+      {
+        fromLevel: 2,
+        toLevel: 3,
+        cost: { coins: 25_000, fragments: 100, materials: { ancient_ore: 5 } },
+        benefits: ['Crafting discount increased to 20%', 'Unlock rare recipes'],
+      },
+    ],
+  },
+  shrine: {
+    name: 'Harmony Shrine',
+    description: 'Meditate to restore HP and Focus and receive daily blessings.',
+    baseCapacity: 3,
+    maxLevel: 8,
+    baseEffects: [
+      { type: 'active', effect: { type: 'hp', op: '+', value: 5 }, cooldown: 60 * 60 * 1000 },
+      { type: 'active', effect: { type: 'focus', op: '+', value: 2 }, cooldown: 60 * 60 * 1000 },
+    ],
+    upgrades: [
+      {
+        fromLevel: 1,
+        toLevel: 2,
+        cost: { coins: 8_000, fragments: 40 },
+        benefits: ['Healing increased to 8 HP', 'Focus restore increased to 3'],
+      },
+    ],
+  },
+  trophy_hall: {
+    name: 'Trophy Hall',
+    description: 'Display your achievements and gain passive XP bonuses.',
+    baseCapacity: 10,
+    maxLevel: 5,
+    baseEffects: [{ type: 'passive', effect: { type: 'xp', value: 5 } }],
+    upgrades: [
+      {
+        fromLevel: 1,
+        toLevel: 2,
+        cost: { coins: 15_000 },
+        benefits: ['XP bonus increased to 10%', '+5 trophy slots'],
+      },
+    ],
+  },
+  gremlin_den: {
+    name: 'Gremlin Den',
+    description: 'House mischievous gremlins to generate resources and chaos.',
+    baseCapacity: 8,
+    maxLevel: 7,
+    baseEffects: [{ type: 'passive', effect: { type: 'coins', value: 100 } }],
+    upgrades: [
+      {
+        fromLevel: 1,
+        toLevel: 2,
+        cost: { coins: 12_000, materials: { gremlin_treats: 20 } },
+        benefits: ['Daily coins increased to 200', 'Gremlins occasionally find fragments'],
+      },
+    ],
+  },
+  treasury: {
+    name: 'Treasury Vault',
+    description: 'Secure storage that generates interest on your wealth.',
+    baseCapacity: 1,
+    maxLevel: 10,
+    baseEffects: [{ type: 'passive', effect: { type: 'buff', id: 'coin_interest', value: 1 } }],
+    upgrades: [
+      {
+        fromLevel: 1,
+        toLevel: 2,
+        cost: { coins: 50_000 },
+        benefits: ['Interest rate increased to 1.5%', 'Unlock gem storage'],
+      },
+    ],
+  },
+  meditation_chamber: {
+    name: 'Meditation Chamber',
+    description: 'Deep focus training that enhances regeneration.',
+    baseCapacity: 4,
+    maxLevel: 6,
+    baseEffects: [{ type: 'passive', effect: { type: 'buff', id: 'focus_regen', value: 1 } }],
+    upgrades: [
+      {
+        fromLevel: 1,
+        toLevel: 2,
+        cost: { coins: 10_000, fragments: 60 },
+        benefits: ['Focus regeneration doubled', 'Unlock meditation techniques'],
+      },
+    ],
+  },
+};
+
+const DECORATIONS: Decoration[] = [
+  {
+    id: 'golden_chandelier',
+    name: 'Golden Chandelier',
+    slot: 'ceiling',
+    rarity: 'rare',
+    effects: [{ type: 'ambient', effect: { type: 'buff', id: 'vault_prestige', value: 5 } }],
+  },
+  {
+    id: 'ledger_tapestry',
+    name: 'Ancient Ledger Tapestry',
+    slot: 'wall',
+    rarity: 'epic',
+    effects: [{ type: 'passive', effect: { type: 'xp', value: 10 } }],
+    requirements: { level: 5 },
+  },
+  {
+    id: 'gremlin_fountain',
+    name: 'Gremlin Fountain',
+    slot: 'furniture',
+    rarity: 'uncommon',
+    effects: [{ type: 'ambient', effect: { type: 'buff', id: 'gremlin_attraction', value: 2 } }],
+  },
+  {
+    id: 'crystal_focus',
+    name: 'Crystal Focus Array',
+    slot: 'special',
+    rarity: 'legendary',
+    effects: [{ type: 'passive', effect: { type: 'focus', op: '+', value: 5 } }],
+    requirements: { level: 10, achievements: ['focus_master'] },
+  },
+  {
+    id: 'merchants_rug',
+    name: "Merchant's Lucky Rug",
+    slot: 'floor',
+    rarity: 'rare',
+    effects: [{ type: 'passive', effect: { type: 'buff', id: 'shop_discount', value: 5 } }],
+  },
+  {
+    id: 'ethereal_lanterns',
+    name: 'Ethereal Lanterns',
+    slot: 'lighting',
+    rarity: 'epic',
+    effects: [{ type: 'ambient', effect: { type: 'buff', id: 'night_vision', value: 1 } }],
+  },
+];
+
+export class VaultManager {
+  private readonly vaultCache = new Map<string, VaultRoom[]>();
+
+  constructor() {
+    this.loadVaults();
+  }
+
+  private loadVaults() {
+    const rows = db.prepare(`SELECT * FROM vault_rooms WHERE active=1`).all() as any[];
+    for (const row of rows) {
+      const room: VaultRoom = {
+        roomId: row.room_id,
+        userId: row.user_id,
+        type: row.room_type,
+        level: row.level,
+        capacity: row.capacity,
+        decorations: JSON.parse(row.decorations_json || '[]'),
+        activeEffects: JSON.parse(row.effects_json || '[]'),
+        visitors: JSON.parse(row.visitors_json || '[]'),
+        lastUpdated: row.last_updated,
+      };
+
+      const rooms = this.vaultCache.get(room.userId) || [];
+      rooms.push(room);
+      this.vaultCache.set(room.userId, rooms);
+    }
+  }
+
+  async handleButton(interaction: ButtonInteraction) {
+    if (!interaction.customId.startsWith('vault:')) {
+      return false;
+    }
+
+    const [, action, arg] = interaction.customId.split(':');
+
+    if (action === 'create') {
+      const rooms = this.ensureVault(interaction.user.id);
+      await interaction.reply({
+        ephemeral: true,
+        content: rooms.length
+          ? '🏰 Your vault is ready! Use the menu to manage your rooms.'
+          : 'Vault already exists.',
+      });
+      return true;
+    }
+
+    if (action === 'leaderboard') {
+      const top = this.getTopVaults();
+      const lines = top.map(
+        (entry: any, idx: number) =>
+          `**${idx + 1}.** <@${entry.user_id}> — ${entry.total_levels} total room levels`
+      );
+      await interaction.reply({
+        ephemeral: true,
+        embeds: [
+          new EmbedBuilder()
+            .setTitle('🏆 Top Vaults')
+            .setColor(0x9b59b6)
+            .setDescription(lines.join('\n') || 'No vaults yet.'),
+        ],
+      });
+      return true;
+    }
+
+    if (action === 'upgrade' && arg) {
+      const result = this.upgradeRoom(interaction.user.id, arg);
+      await interaction.reply({ ephemeral: true, content: result.message });
+      return true;
+    }
+
+    if (action === 'visit' && arg) {
+      const host = arg;
+      const result = this.visitVault(interaction.user.id, host);
+      await interaction.reply({ ephemeral: true, content: result.message });
+      return true;
+    }
+
+    return false;
+  }
+
+  async handleSelectMenu(interaction: StringSelectMenuInteraction) {
+    if (interaction.customId !== 'vault:room:select') {
+      return false;
+    }
+
+    const [roomId] = interaction.values;
+    const detail = this.renderRoomDetail(interaction.user.id, roomId);
+    await interaction.reply({ ephemeral: true, ...detail });
+    return true;
+  }
+
+  ensureVault(userId: string) {
+    const existing = this.vaultCache.get(userId) || [];
+    if (existing.length) {
+      return existing;
+    }
+
+    const starterRooms: VaultRoom[] = [
+      this.buildRoom(userId, 'trophy_hall'),
+      this.buildRoom(userId, 'workshop'),
+    ];
+
+    for (const room of starterRooms) {
+      db.prepare(
+        `INSERT INTO vault_rooms (
+           room_id, user_id, room_type, level, capacity, decorations_json, effects_json, visitors_json, active, created_at, last_updated
+         ) VALUES (?,?,?,?,?,?,?,?,?,?,?)`
+      ).run(
+        room.roomId,
+        room.userId,
+        room.type,
+        room.level,
+        room.capacity,
+        JSON.stringify(room.decorations),
+        JSON.stringify(room.activeEffects),
+        JSON.stringify(room.visitors),
+        1,
+        Date.now(),
+        room.lastUpdated
+      );
+    }
+
+    this.vaultCache.set(userId, starterRooms);
+    return starterRooms;
+  }
+
+  renderVaultInterface(userId: string) {
+    const vault = this.ensureVault(userId);
+
+    const embed = new EmbedBuilder()
+      .setTitle('🏰 Personal Vault')
+      .setDescription('Manage rooms, upgrade layouts, and showcase your achievements.')
+      .setColor(0x9b59b6);
+
+    for (const room of vault) {
+      const def = ROOM_DEFINITIONS[room.type];
+      const decorationList = room.decorations.map((d) => d.name).join(', ') || 'None';
+      embed.addFields({
+        name: `${def.name} (Lv.${room.level})`,
+        value: `${def.description}\n**Decorations:** ${decorationList}\n**Capacity:** ${room.decorations.length}/${room.capacity}`,
+        inline: false,
+      });
+    }
+
+    const bonuses = this.calculatePassiveBonuses(vault);
+    if (Object.keys(bonuses).length) {
+      embed.addFields({
+        name: '✨ Active Bonuses',
+        value: Object.entries(bonuses)
+          .map(([label, value]) => `• ${label}: ${value}`)
+          .join('\n'),
+        inline: false,
+      });
+    }
+
+    const roomSelect = new StringSelectMenuBuilder()
+      .setCustomId('vault:room:select')
+      .setPlaceholder('Select a room to manage...')
+      .addOptions(
+        vault.map((room) => ({
+          label: ROOM_DEFINITIONS[room.type].name,
+          description: `Level ${room.level} — ${room.decorations.length}/${room.capacity} decorations`,
+          value: room.roomId,
+        }))
+      );
+
+    const buttons = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId('vault:create')
+        .setLabel('Create Vault')
+        .setEmoji('🏗️')
+        .setStyle(ButtonStyle.Primary),
+      new ButtonBuilder()
+        .setCustomId('vault:leaderboard')
+        .setLabel('Vault Leaderboard')
+        .setEmoji('🏆')
+        .setStyle(ButtonStyle.Secondary)
+    );
+
+    return {
+      embeds: [embed],
+      components: [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(roomSelect), buttons],
+    };
+  }
+
+  private renderRoomDetail(userId: string, roomId: string) {
+    const vault = this.ensureVault(userId);
+    const room = vault.find((r) => r.roomId === roomId);
+    if (!room) {
+      return {
+        embeds: [new EmbedBuilder().setTitle('Room not found').setDescription('Unable to locate this room.')],
+      };
+    }
+
+    const def = ROOM_DEFINITIONS[room.type];
+    const embed = new EmbedBuilder()
+      .setTitle(`${def.name} — Level ${room.level}`)
+      .setDescription(def.description)
+      .setColor(0x8e44ad)
+      .addFields(
+        {
+          name: 'Decorations',
+          value: room.decorations.length ? room.decorations.map((d) => d.name).join('\n') : 'None',
+          inline: false,
+        },
+        {
+          name: 'Capacity',
+          value: `${room.decorations.length}/${room.capacity}`,
+          inline: true,
+        }
+      );
+
+    const upgrade = def.upgrades.find((u) => u.fromLevel === room.level);
+    if (upgrade) {
+      embed.addFields({
+        name: `Next Upgrade — Level ${upgrade.toLevel}`,
+        value: [
+          `Cost: ${this.describeCost(upgrade.cost)}`,
+          `Benefits: ${upgrade.benefits.join(', ')}`,
+        ].join('\n'),
+        inline: false,
+      });
+    } else {
+      embed.addFields({ name: 'Upgrades', value: 'Room is at maximum level.', inline: false });
+    }
+
+    if (upgrade) {
+      const buttons = new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+          .setCustomId(`vault:upgrade:${room.roomId}`)
+          .setLabel('Upgrade Room')
+          .setStyle(ButtonStyle.Success)
+      );
+      return { embeds: [embed], components: [buttons] };
+    }
+
+    return { embeds: [embed], components: [] };
+  }
+
+  private buildRoom(userId: string, type: RoomType): VaultRoom {
+    const definition = ROOM_DEFINITIONS[type];
+    return {
+      roomId: `vault_${nanoid(8)}`,
+      userId,
+      type,
+      level: 1,
+      capacity: definition.baseCapacity,
+      decorations: [],
+      activeEffects: definition.baseEffects,
+      visitors: [],
+      lastUpdated: Date.now(),
+    };
+  }
+
+  private upgradeRoom(userId: string, roomId: string) {
+    const vault = this.ensureVault(userId);
+    const room = vault.find((r) => r.roomId === roomId);
+    if (!room) {
+      return { success: false, message: 'Room not found.' };
+    }
+
+    const definition = ROOM_DEFINITIONS[room.type];
+    if (room.level >= definition.maxLevel) {
+      return { success: false, message: 'Room already at maximum level.' };
+    }
+
+    const upgrade = definition.upgrades.find((u) => u.fromLevel === room.level);
+    if (!upgrade) {
+      return { success: false, message: 'No upgrade available.' };
+    }
+
+    const profile = db
+      .prepare(`SELECT level FROM profiles WHERE user_id=?`)
+      .get(userId) as { level: number } | undefined;
+
+    if (upgrade.requirements?.minLevel && (profile?.level ?? 0) < upgrade.requirements.minLevel) {
+      return { success: false, message: `Requires level ${upgrade.requirements.minLevel}.` };
+    }
+
+    if (!this.payUpgradeCost(userId, upgrade.cost)) {
+      return { success: false, message: 'Insufficient resources for upgrade.' };
+    }
+
+    room.level = upgrade.toLevel;
+    room.capacity += 2;
+    this.refreshRoomEffects(room);
+
+    db.prepare(
+      `UPDATE vault_rooms SET level=?, capacity=?, effects_json=?, last_updated=? WHERE room_id=?`
+    ).run(room.level, room.capacity, JSON.stringify(room.activeEffects), Date.now(), room.roomId);
+
+    return { success: true, message: `${definition.name} upgraded to level ${room.level}!` };
+  }
+
+  private payUpgradeCost(userId: string, cost: { coins?: number; fragments?: number; materials?: Record<string, number> }) {
+    const profile = db
+      .prepare(`SELECT coins, fragments FROM profiles WHERE user_id=?`)
+      .get(userId) as { coins: number; fragments: number } | undefined;
+
+    if (!profile) return false;
+
+    if (cost.coins && profile.coins < cost.coins) return false;
+    if (cost.fragments && profile.fragments < cost.fragments) return false;
+
+    if (cost.materials) {
+      for (const [item, qty] of Object.entries(cost.materials)) {
+        const owned = db
+          .prepare(`SELECT qty FROM inventories WHERE user_id=? AND item_id=?`)
+          .get(userId, item) as { qty: number } | undefined;
+        if (!owned || owned.qty < qty) {
+          return false;
+        }
+      }
+    }
+
+    if (cost.coins) {
+      db.prepare(`UPDATE profiles SET coins=coins-? WHERE user_id=?`).run(cost.coins, userId);
+    }
+    if (cost.fragments) {
+      db.prepare(`UPDATE profiles SET fragments=fragments-? WHERE user_id=?`).run(cost.fragments, userId);
+    }
+    if (cost.materials) {
+      for (const [item, qty] of Object.entries(cost.materials)) {
+        db.prepare(`UPDATE inventories SET qty=qty-? WHERE user_id=? AND item_id=?`).run(qty, userId, item);
+      }
+    }
+
+    return true;
+  }
+
+  private refreshRoomEffects(room: VaultRoom) {
+    const base = JSON.parse(JSON.stringify(ROOM_DEFINITIONS[room.type].baseEffects)) as RoomEffect[];
+    for (const effect of base) {
+      if (typeof effect.effect.value === 'number') {
+        effect.effect.value = Math.floor(effect.effect.value * (1 + (room.level - 1) * 0.2));
+      }
+    }
+
+    const decorationEffects = room.decorations.flatMap((d) => d.effects || []);
+    room.activeEffects = [...base, ...decorationEffects];
+  }
+
+  visitVault(visitorId: string, hostId: string) {
+    if (visitorId === hostId) {
+      return { success: false, message: 'Cannot visit your own vault.' };
+    }
+
+    const hostRooms = this.ensureVault(hostId);
+    if (!hostRooms.length) {
+      return { success: false, message: 'Host has no vault.' };
+    }
+
+    const recentVisit = db
+      .prepare(
+        `SELECT 1 FROM vault_visits WHERE visitor_id=? AND host_id=? AND visited_at > ?`
+      )
+      .get(visitorId, hostId, Date.now() - 24 * 60 * 60 * 1000);
+
+    if (recentVisit) {
+      return { success: false, message: 'You already visited this vault today.' };
+    }
+
+    const impressiveness = this.calculateVaultScore(hostRooms);
+    const rewards = this.calculateVisitRewards(impressiveness);
+
+    if (rewards.coins) {
+      db.prepare(`UPDATE profiles SET coins=coins+? WHERE user_id=?`).run(rewards.coins, visitorId);
+    }
+    if (rewards.xp) {
+      db.prepare(`UPDATE profiles SET xp=xp+? WHERE user_id=?`).run(rewards.xp, visitorId);
+    }
+
+    db.prepare(
+      `INSERT INTO vault_visits (visitor_id, host_id, visited_at, rewards_json) VALUES (?,?,?,?)`
+    ).run(visitorId, hostId, Date.now(), JSON.stringify(rewards));
+
+    for (const room of hostRooms) {
+      room.visitors.push({ userId: visitorId, timestamp: Date.now() });
+      if (room.visitors.length > 100) {
+        room.visitors = room.visitors.slice(-100);
+      }
+      db.prepare(`UPDATE vault_rooms SET visitors_json=? WHERE room_id=?`).run(
+        JSON.stringify(room.visitors),
+        room.roomId
+      );
+    }
+
+    const hostBonus = Math.floor(impressiveness * 10);
+    db.prepare(`UPDATE profiles SET coins=coins+? WHERE user_id=?`).run(hostBonus, hostId);
+
+    return {
+      success: true,
+      message: `Visited vault! Earned ${rewards.coins} Coins and ${rewards.xp} XP.`,
+      rewards,
+    };
+  }
+
+  private describeCost(cost: { coins?: number; fragments?: number; materials?: Record<string, number> }) {
+    const parts: string[] = [];
+    if (cost.coins) parts.push(`${cost.coins} Coins`);
+    if (cost.fragments) parts.push(`${cost.fragments} Fragments`);
+    if (cost.materials) {
+      for (const [item, qty] of Object.entries(cost.materials)) {
+        parts.push(`${qty}× ${item}`);
+      }
+    }
+    return parts.join(', ');
+  }
+
+  private calculatePassiveBonuses(rooms: VaultRoom[]) {
+    const bonuses: Record<string, string> = {};
+    for (const room of rooms) {
+      for (const effect of room.activeEffects) {
+        if (effect.type !== 'passive') continue;
+        const key = effect.effect.id || effect.effect.type;
+        const value = effect.effect.value;
+        if (!key || value == null) continue;
+
+        const numeric = Number(value);
+        if (!Number.isFinite(numeric)) continue;
+
+        if (bonuses[key]) {
+          const current = parseFloat(bonuses[key]) || 0;
+          bonuses[key] = `${current + numeric}`;
+        } else {
+          bonuses[key] = numeric >= 0 && numeric <= 100 ? `+${numeric}%` : `${numeric}`;
+        }
+      }
+    }
+    return bonuses;
+  }
+
+  private calculateVaultScore(rooms: VaultRoom[]) {
+    let score = 0;
+    const rarityScores: Record<string, number> = {
+      common: 2,
+      uncommon: 5,
+      rare: 10,
+      epic: 20,
+      legendary: 35,
+      mythic: 50,
+    };
+
+    for (const room of rooms) {
+      score += room.level * 5;
+      for (const decoration of room.decorations) {
+        score += rarityScores[decoration.rarity] || 1;
+      }
+      const recentVisitors = room.visitors.filter(
+        (v) => Date.now() - v.timestamp < 7 * 24 * 60 * 60 * 1000
+      );
+      score += Math.min(recentVisitors.length * 2, 20);
+    }
+
+    return Math.min(score, 100);
+  }
+
+  private calculateVisitRewards(impressiveness: number) {
+    const baseCoins = 50;
+    const baseXp = 10;
+    return {
+      coins: Math.floor(baseCoins * (1 + impressiveness / 100)),
+      xp: Math.floor(baseXp * (1 + impressiveness / 200)),
+    };
+  }
+
+  getTopVaults(limit = 10) {
+    return db
+      .prepare(
+        `SELECT 
+           vr.user_id,
+           COUNT(vr.room_id) AS room_count,
+           SUM(vr.level) AS total_levels,
+           COUNT(json_each.value) AS decoration_count
+         FROM vault_rooms vr
+         LEFT JOIN json_each(vr.decorations_json)
+         WHERE vr.active=1
+         GROUP BY vr.user_id
+         ORDER BY total_levels DESC, decoration_count DESC
+         LIMIT ?`
+      )
+      .all(limit);
+  }
+}
+
+export const vaultManager = new VaultManager();

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,7 @@
-declare module 'fs-extra';
+declare module 'fs-extra' {
+  const fs: any;
+  export = fs;
+}
 
 declare module 'better-sqlite3' {
   export default class Database {
@@ -15,8 +18,28 @@ declare module 'fast-deep-equal' {
   export default equal;
 }
 
+declare module 'algosdk' {
+  export class Algodv2 {
+    constructor(token: string, server: string, port: string);
+    accountInformation(address: string): { do(): Promise<any> };
+    getAssetByID(assetId: number): { do(): Promise<any> };
+  }
+
+  export class Indexer {
+    constructor(token: string, server: string, port: string);
+    lookupAssetByID(assetId: number): { do(): Promise<any> };
+  }
+
+  export function verifyBytes(message: Uint8Array, signature: Uint8Array, address: string): boolean;
+}
+
 declare module 'nanoid' {
   export function nanoid(size?: number): string;
+}
+
+declare module 'node:crypto' {
+  type RandomBuffer = { toString(encoding?: string): string };
+  export function randomBytes(size: number): RandomBuffer;
 }
 
 declare module 'discord.js' {
@@ -60,7 +83,11 @@ declare module 'discord.js' {
     constructor();
     setCustomId(id: string): this;
     setPlaceholder(text: string): this;
-    addOptions(options: { label: string; value: string; description?: string; emoji?: string }[] | { label: string; value: string; description?: string; emoji?: string }): this;
+    addOptions(
+      options:
+        | { label: string; value: string; description?: string; emoji?: string }[]
+        | { label: string; value: string; description?: string; emoji?: string }
+    ): this;
     [key: string]: any;
   }
 
@@ -74,7 +101,7 @@ declare module 'discord.js' {
     Primary,
     Secondary,
     Success,
-    Danger
+    Danger,
   }
 
   export class TextChannel {
@@ -159,12 +186,12 @@ declare module 'discord.js' {
 
 declare module 'node:path' {
   const path: any;
-  export default path;
+  export = path;
 }
 
 declare module 'node:crypto' {
   const crypto: any;
-  export default crypto;
+  export = crypto;
 }
 
 declare module 'node:http' {
@@ -172,10 +199,6 @@ declare module 'node:http' {
   export type ServerResponse = any;
   export type RequestListener = (req: IncomingMessage, res: ServerResponse) => void;
   export function createServer(listener: RequestListener): any;
-  const http: {
-    createServer: typeof createServer;
-  };
-declare module 'node:http' {
   const http: any;
   export default http;
 }
@@ -196,28 +219,28 @@ declare module 'node:url' {
     pathname: string;
   }
   const url: {
-    URLSearchParams: typeof URLSearchParams;
     URL: typeof URL;
+    URLSearchParams: typeof URLSearchParams;
   };
-
-  const url: any;
   export default url;
 }
 
 declare module 'fs' {
   const fs: any;
-  export default fs;
+  export = fs;
 }
 
 declare module 'path' {
   const path: any;
-  export default path;
+  export = path;
 }
 
 declare const process: {
   env: Record<string, string | undefined>;
   argv: string[];
+  pid: number;
   exit(code?: number): void;
+  on(event: string, listener: (...args: any[]) => void): void;
 };
 
 type Buffer = any;
@@ -226,4 +249,42 @@ declare const Buffer: {
   concat(list: Buffer[]): Buffer;
 };
 
-declare module 'better-sqlite3';
+declare module 'ethers' {
+  export class Interface {
+    constructor(abi: readonly string[]);
+    parseLog(log: { topics: string[]; data: string }): {
+      name?: string;
+      args: Record<string, unknown> | unknown[];
+    };
+  }
+
+  export class JsonRpcProvider {
+    constructor(url: string);
+  }
+
+  export class BrowserProvider {
+    constructor(externalProvider: unknown);
+    getSigner(): Promise<Signer>;
+  }
+
+  export class Wallet {
+    constructor(privateKey: string, provider?: Provider);
+    connect(provider: Provider): Wallet;
+  }
+
+  export class Contract {
+    constructor(address: string, abi: readonly string[], signerOrProvider: Provider | Signer);
+    connect(signer: Signer): Contract;
+    [key: string]: any;
+  }
+
+  export type Provider = unknown;
+  export type Signer = {
+    getAddress(): Promise<string>;
+  } & Record<string, any>;
+
+  export function verifyMessage(message: string, signature: string): string;
+  export function parseEther(value: string): bigint;
+  export function formatEther(value: bigint | number | string): string;
+  export function id(value: string): string;
+}

--- a/src/ui/backpacks.ts
+++ b/src/ui/backpacks.ts
@@ -1,34 +1,19 @@
+import { nanoid } from 'nanoid';
 import db from '../persistence/db.js';
 import { loadDropTable } from '../content/contentLoader.js';
-import { nanoid } from 'nanoid';
+import { DropTable } from '../models.js';
 
-type RarityWeights = Record<string, number>;
+type Rarity = string;
+
+type RarityWeights = Record<Rarity, number>;
 
 interface OpenPackOptions {
+  /** Skip deducting the drop table's listed cost. */
   skipCost?: boolean;
+  /** Override the amount logged to the economy ledger when skipCost is used. */
   spendAmountOverride?: number;
+  /** Force the pack identifier that should be tracked for pity. */
   packIdOverride?: string;
-}
-
-function weightedPick(weights: RarityWeights): string {
-  const total = Object.values(weights).reduce((a, b) => a + b, 0);
-  let r = Math.random() * total;
-  for (const [rarity, weight] of Object.entries(weights)) {
-    r -= weight;
-    if (r <= 0) return rarity;
-  }
-  return Object.keys(weights)[0];
-}
-
-function pityAdjustedRarity(
-  opened: number,
-  weights: RarityWeights,
-  rareAfter = 10,
-  epicAfter = 30
-): string {
-  if (opened >= epicAfter) return 'epic';
-  if (opened >= rareAfter) return 'rare';
-  return weightedPick(weights);
 }
 
 const PACK_FILES: Record<string, string> = {
@@ -44,160 +29,121 @@ const FRAGMENT_VALUES: Record<string, number> = {
   mythic: 100,
 };
 
+function weightedPick(weights: RarityWeights): Rarity {
+  const total = Object.values(weights).reduce((sum, weight) => sum + weight, 0);
+  if (total <= 0) {
+    return Object.keys(weights)[0] ?? 'common';
+  }
+
+  let cursor = Math.random() * total;
+  for (const [rarity, weight] of Object.entries(weights)) {
+    cursor -= weight;
+    if (cursor <= 0) return rarity;
+  }
+  return Object.keys(weights)[0] ?? 'common';
+}
+
+function pityAdjustedRarity(
+  opened: number,
+  weights: RarityWeights,
+  rareAfter = 10,
+  epicAfter = 30
+): Rarity {
+  if (opened >= epicAfter) return 'epic';
+  if (opened >= rareAfter) return 'rare';
+  return weightedPick(weights);
+}
+
+function resolveTableFile(identifier: string): { file: string; inferredId: string } {
+  const isFile = identifier.endsWith('.json');
+  if (isFile) {
+    const inferredId = identifier.replace(/\.json$/i, '');
+    return { file: identifier, inferredId };
+  }
+  const file = PACK_FILES[identifier] ?? 'packs_genesis.json';
+  return { file, inferredId: identifier };
+}
+
+function randomDrop(table: DropTable, rarity: Rarity) {
+  const pool = table.pools[rarity] ?? [];
+  if (!pool.length) {
+    throw new Error(`Drop table ${table.pack_id} is missing entries for rarity ${rarity}`);
+  }
+  return pool[Math.floor(Math.random() * pool.length)];
+}
+
 export function openPack(user_id: string, packIdentifier = 'Genesis', options: OpenPackOptions = {}) {
-  const isFile = packIdentifier.endsWith('.json');
-  const pack_id = options.packIdOverride ?? (isFile ? 'Genesis' : packIdentifier);
-  const tableFile = isFile ? packIdentifier : PACK_FILES[packIdentifier] ?? 'packs_genesis.json';
-  const dt = loadDropTable(tableFile);
+  const { file, inferredId } = resolveTableFile(packIdentifier);
+  const table = loadDropTable(file);
 
-  const costCoins = dt.cost.coins ?? 0;
-  const spendAmount = options.spendAmountOverride ?? costCoins;
+  const packId = options.packIdOverride ?? table.pack_id ?? inferredId;
+  const costCoins = table.cost.coins ?? 0;
+  const costGems = table.cost.gems ?? 0;
 
-  if (!options.skipCost && costCoins > 0) {
-    const prof = db
-      .prepare('SELECT coins FROM profiles WHERE user_id=?')
-      .get(user_id) as { coins?: number } | undefined;
-    if ((prof?.coins ?? 0) < costCoins) throw new Error('Not enough coins');
-    db.prepare('UPDATE profiles SET coins=coins-? WHERE user_id=?').run(costCoins, user_id);
+  if (!options.skipCost && (costCoins > 0 || costGems > 0)) {
+    const profile =
+      (db.prepare('SELECT coins, gems FROM profiles WHERE user_id=?').get(user_id) as
+        | { coins?: number; gems?: number }
+        | undefined) ?? {};
+    const coins = profile.coins ?? 0;
+    const gems = profile.gems ?? 0;
+
+    if (costCoins > 0 && coins < costCoins) throw new Error('Not enough coins');
+    if (costGems > 0 && gems < costGems) throw new Error('Not enough gems');
+
+    if (costCoins > 0) {
+      db.prepare('UPDATE profiles SET coins=coins-? WHERE user_id=?').run(costCoins, user_id);
+      db.prepare(
+        'INSERT INTO economy_ledger (txn_id,user_id,kind,amount,reason,meta_json,ts) VALUES (?,?,?,?,?,?,?)'
+      ).run(
+        `txn_${nanoid(8)}`,
+        user_id,
+        'pack_open',
+        costCoins,
+        'coins_spent',
+        JSON.stringify({ pack_id: packId }),
+        Date.now()
+      );
+    }
+
+    if (costGems > 0) {
+      db.prepare('UPDATE profiles SET gems=gems-? WHERE user_id=?').run(costGems, user_id);
+      db.prepare(
+        'INSERT INTO economy_ledger (txn_id,user_id,kind,amount,reason,meta_json,ts) VALUES (?,?,?,?,?,?,?)'
+      ).run(
+        `txn_${nanoid(8)}`,
+        user_id,
+        'pack_open',
+        costGems,
+        'gems_spent',
+        JSON.stringify({ pack_id: packId }),
+        Date.now()
+      );
+    }
   }
 
   const pityRow = db
     .prepare('SELECT opened, last_rarity FROM pity WHERE user_id=? AND pack_id=?')
-    .get(user_id, pack_id) as { opened?: number; last_rarity?: string } | undefined;
+    .get(user_id, packId) as { opened?: number; last_rarity?: string } | undefined;
 
-  const rarity = pityAdjustedRarity(
-    pityRow?.opened ?? 0,
-    dt.weights,
-    dt.pity?.rare_after,
-    dt.pity?.epic_after
-  );
-  const pool = dt.pools[rarity] ?? [];
-  const pick =
-    pool[Math.floor(Math.random() * pool.length)] ?? ({
-      kind: 'cosmetic',
-      id: 'cosmetic_confetti',
-      rarity,
-    } as { kind: string; id: string; rarity?: string });
-
-  if (spendAmount > 0) {
-    db.prepare(
-      'INSERT INTO economy_ledger (txn_id,user_id,kind,amount,reason,meta_json,ts) VALUES (?,?,?,?,?,?,?)'
-    ).run(
-      `txn_${nanoid(8)}`,
-      user_id,
-      'pack_open',
-      spendAmount,
-      'coins_spent',
-      JSON.stringify({ pack_id }),
-      Date.now()
-    );
-  }
+  const rarity = pityAdjustedRarity(pityRow?.opened ?? 0, table.weights, table.pity?.rare_after, table.pity?.epic_after);
+  const drop = randomDrop(table, rarity);
+  const rarityTag = drop.rarity ?? rarity;
 
   const existing = db
     .prepare('SELECT qty FROM inventories WHERE user_id=? AND item_id=?')
-    .get(user_id, pick.id) as { qty?: number } | undefined;
+    .get(user_id, drop.id) as { qty?: number } | undefined;
 
-
-export function openPack(user_id: string, pack_id = 'Genesis', options: OpenPackOptions = {}) {
-  const dt = loadDropTable('packs_genesis.json');
-  if (dt.pack_id !== pack_id) throw new Error('Unknown pack');
-
-  const costCoins = dt.cost.coins ?? 0;
-  const spendAmount = options.spendAmountOverride ?? costCoins;
-
-  if (!options.skipCost && costCoins > 0) {
-    const prof = db
-      .prepare('SELECT coins FROM profiles WHERE user_id=?')
-      .get(user_id) as { coins?: number } | undefined;
-    if ((prof?.coins ?? 0) < costCoins) throw new Error('Not enough coins');
-    db.prepare('UPDATE profiles SET coins=coins-? WHERE user_id=?').run(costCoins, user_id);
-  }
-
-  const pityRow = db
-    .prepare('SELECT opened, last_rarity FROM pity WHERE user_id=? AND pack_id=?')
-    .get(user_id, pack_id) as { opened?: number; last_rarity?: string } | undefined;
-
-  const rarity = pityAdjustedRarity(
-    pityRow?.opened ?? 0,
-    dt.weights,
-    dt.pity?.rare_after,
-    dt.pity?.epic_after
-  );
-  const pool = dt.pools[rarity] ?? [];
-  const pick =
-    pool[Math.floor(Math.random() * pool.length)] ?? ({
-      kind: 'cosmetic',
-      id: 'cosmetic_confetti',
-      rarity,
-    } as { kind: string; id: string; rarity?: string });
-
-  if (spendAmount > 0) {
-    db.prepare(
-      'INSERT INTO economy_ledger (txn_id,user_id,kind,amount,reason,meta_json,ts) VALUES (?,?,?,?,?,?,?)'
-    ).run(
-      `txn_${nanoid(8)}`,
-      user_id,
-      'pack_open',
-      spendAmount,
-      'coins_spent',
-      JSON.stringify({ pack_id }),
-      Date.now()
-    );
-  }
-
-  const existing = db
-    .prepare('SELECT qty FROM inventories WHERE user_id=? AND item_id=?')
-    .get(user_id, pick.id) as { qty?: number } | undefined;
-
-  const pityRow = db
-    .prepare('SELECT opened, last_rarity FROM pity WHERE user_id=? AND pack_id=?')
-    .get(user_id, pack_id) as { opened?: number; last_rarity?: string } | undefined;
-
-  const rarity = pityAdjustedRarity(
-    pityRow?.opened ?? 0,
-    dt.weights,
-    dt.pity?.rare_after,
-    dt.pity?.epic_after
-  );
-  const pool = dt.pools[rarity] ?? [];
-  const pick =
-    pool[Math.floor(Math.random() * pool.length)] ?? ({
-      kind: 'cosmetic',
-      id: 'cosmetic_confetti',
-      rarity,
-    } as { kind: string; id: string; rarity?: string });
-
-  if (spendAmount > 0) {
-    db.prepare(
-      'INSERT INTO economy_ledger (txn_id,user_id,kind,amount,reason,meta_json,ts) VALUES (?,?,?,?,?,?,?)'
-    ).run(
-      `txn_${nanoid(8)}`,
-      user_id,
-      'pack_open',
-      spendAmount,
-      'coins_spent',
-      JSON.stringify({ pack_id }),
-      Date.now()
-    );
-  }
-
-  const existing = db
-    .prepare('SELECT qty FROM inventories WHERE user_id=? AND item_id=?')
-    .get(user_id, pick.id) as { qty?: number } | undefined;
-
-  let duplicate = false;
-  if (existing?.qty) {
-    duplicate = true;
-    const fragments = FRAGMENT_VALUES[rarity] ?? 5;
+  const duplicate = (existing?.qty ?? 0) > 0;
+  if (duplicate) {
+    const fragments = FRAGMENT_VALUES[rarityTag] ?? FRAGMENT_VALUES[rarity] ?? 5;
     db.prepare('UPDATE profiles SET fragments=fragments+? WHERE user_id=?').run(fragments, user_id);
-  } else {
-    db.prepare(
-      'INSERT INTO inventories (user_id,item_id,kind,rarity,qty,meta_json) VALUES (?,?,?,?,?,?) ON CONFLICT(user_id,item_id) DO UPDATE SET qty=qty+excluded.qty'
-    ).run(user_id, pick.id, pick.kind, rarity, 1, '{}');
   }
+
   db.prepare(
-    'INSERT INTO inventories (user_id,item_id,kind,rarity,qty,meta_json) VALUES (?,?,?,?,?,?) ON CONFLICT(user_id,item_id) DO UPDATE SET qty=qty+excluded.qty'
-  ).run(user_id, pick.id, pick.kind, rarity, 1, '{}');
+    'INSERT INTO inventories (user_id,item_id,kind,rarity,qty,meta_json) VALUES (?,?,?,?,?,?) ' +
+      'ON CONFLICT(user_id,item_id) DO UPDATE SET qty=qty+excluded.qty'
+  ).run(user_id, drop.id, drop.kind, rarityTag, 1, JSON.stringify({ source: 'pack', pack_id: packId }));
 
   db.prepare(
     'INSERT INTO economy_ledger (txn_id,user_id,kind,amount,reason,meta_json,ts) VALUES (?,?,?,?,?,?,?)'
@@ -207,17 +153,16 @@ export function openPack(user_id: string, pack_id = 'Genesis', options: OpenPack
     'drop_grant',
     1,
     'pack_drop',
-    JSON.stringify({ pack_id, rarity, id: pick.id }),
+    JSON.stringify({ pack_id: packId, rarity: rarityTag, id: drop.id }),
     Date.now()
   );
 
-  const newOpened = (pityRow?.opened ?? 0) + 1;
-
+  const opened = (pityRow?.opened ?? 0) + 1;
   db.prepare(
     `INSERT INTO pity (user_id, pack_id, opened, last_rarity)
      VALUES (?,?,?,?)
      ON CONFLICT(user_id,pack_id) DO UPDATE SET opened=excluded.opened, last_rarity=excluded.last_rarity`
-  ).run(user_id, pack_id, newOpened, rarity);
+  ).run(user_id, packId, opened, rarityTag);
 
-  return { rarity, drop: pick, duplicate };
+  return { rarity: rarityTag, drop, duplicate };
 }

--- a/src/ui/equipment.ts
+++ b/src/ui/equipment.ts
@@ -9,22 +9,11 @@ import {
 } from 'discord.js';
 import { EquipmentBonus } from '../models.js';
 import db from '../persistence/db.js';
+import { contentRegistry, ItemDefinition } from '../content/contentRegistry.js';
 
 export type EquipmentSlot = 'weapon' | 'armor' | 'helm' | 'trinket' | 'deck';
 
-interface EquipmentBonus {
-  dcShift?: number;
-  dcOffset?: number;
-  advantageTags?: string[];
-  disadvantageTags?: string[];
-  focusBonus?: number;
-  hpBonus?: number;
-  sleightBonus?: number;
-  rerollFail?: boolean;
-  neutralizeCritFail?: boolean;
-  fragmentsBoost?: number;
-  preventsCoinLoss?: boolean;
-}
+const EQUIPMENT_SLOTS: EquipmentSlot[] = ['weapon', 'armor', 'helm', 'trinket', 'deck'];
 
 interface EquipmentDefinition {
   id: string;
@@ -149,6 +138,48 @@ const EQUIPMENT_SETS: Record<
     },
   },
 };
+
+const dynamicEquipmentIds = new Set<string>();
+
+function isEquipmentSlot(slot?: string): slot is EquipmentSlot {
+  return Boolean(slot && (EQUIPMENT_SLOTS as string[]).includes(slot));
+}
+
+function mapItemToEquipment(item: ItemDefinition): EquipmentDefinition | null {
+  if (!isEquipmentSlot(item.slot) || !item.bonuses) {
+    return null;
+  }
+
+  return {
+    id: item.id,
+    slot: item.slot,
+    name: item.name,
+    rarity: item.rarity,
+    emoji: item.emoji,
+    description: item.description,
+    setKey: item.setKey,
+    bonuses: item.bonuses as EquipmentBonus,
+  };
+}
+
+function hydrateEquipmentRegistry() {
+  for (const id of dynamicEquipmentIds) {
+    delete EQUIPMENT_REGISTRY[id];
+  }
+  dynamicEquipmentIds.clear();
+
+  const items = contentRegistry.getAllItems();
+  for (const item of items) {
+    const mapped = mapItemToEquipment(item);
+    if (mapped) {
+      EQUIPMENT_REGISTRY[mapped.id] = mapped;
+      dynamicEquipmentIds.add(mapped.id);
+    }
+  }
+}
+
+hydrateEquipmentRegistry();
+contentRegistry.onReload(hydrateEquipmentRegistry);
 
 export interface EquippedItem {
   slot: EquipmentSlot;
@@ -293,7 +324,7 @@ export async function renderEquipment(user_id: string) {
   if (equipped.length === 0) {
     embed.addFields({ name: 'Current Equipment', value: 'Nothing equipped yet.', inline: false });
   } else {
-    for (const slot of ['weapon', 'armor', 'helm', 'trinket', 'deck'] as EquipmentSlot[]) {
+    for (const slot of EQUIPMENT_SLOTS) {
       const eq = equipped.find((e) => e.slot === slot);
       if (!eq) {
         embed.addFields({ name: slot.toUpperCase(), value: '_empty_', inline: true });
@@ -313,7 +344,7 @@ export async function renderEquipment(user_id: string) {
     .setCustomId('equipment:slot')
     .setPlaceholder('Choose a slot to equip...')
     .addOptions(
-      ['weapon', 'armor', 'helm', 'trinket', 'deck'].map((slot) => ({
+      EQUIPMENT_SLOTS.map((slot) => ({
         label: slot.toUpperCase(),
         value: slot,
       }))

--- a/src/ui/seasonal.ts
+++ b/src/ui/seasonal.ts
@@ -17,11 +17,14 @@ function seasonsRoot() {
 export function listSeasons(): SeasonInfo[] {
   const root = seasonsRoot();
   if (!fs.existsSync(root)) return [];
+
   const entries = fs.readdirSync(root);
   const seasons: SeasonInfo[] = [];
+
   for (const entry of entries) {
     const manifestPath = path.join(root, entry, 'manifest.json');
     if (!fs.existsSync(manifestPath)) continue;
+
     try {
       const manifest = fs.readJSONSync(manifestPath) as any;
       seasons.push({
@@ -34,18 +37,25 @@ export function listSeasons(): SeasonInfo[] {
       console.warn('Failed to load season manifest', entry, err);
     }
   }
+
   return seasons;
 }
 
-export function startSeasonalRun(user_id: string, guild_id: string, channel_id: string, seasonId: string) {
-export function startSeasonalRun(user_id: string, channel_id: string, seasonId: string) {
+export function startSeasonalRun(
+  user_id: string,
+  guild_id: string,
+  channel_id: string,
+  seasonId: string
+) {
   const seasonPath = path.join('seasons', seasonId);
   const manifestPath = path.join(CFG.contentRoot, seasonPath, 'manifest.json');
   if (!fs.existsSync(manifestPath)) {
     throw new Error('Season not found');
   }
-  const run_id = startRun(guild_id, channel_id, [user_id], seasonPath, '6.1');
-  const run_id = startRun(guild_id, channel_id, [user_id], seasonPath, '6.1')
-  const run_id = startRun('global', channel_id, [user_id], seasonPath, '6.1');
-  return run_id;
+
+  const manifest = fs.readJSONSync(manifestPath) as any;
+  const startingScene: string = manifest?.starting_scene ?? manifest?.scenes?.[0] ?? '6.1';
+
+  const resolvedGuild = guild_id || 'global';
+  return startRun(resolvedGuild, channel_id, [user_id], seasonPath, startingScene);
 }

--- a/src/ui/shop.ts
+++ b/src/ui/shop.ts
@@ -4,9 +4,6 @@ import {
   ButtonInteraction,
   ButtonStyle,
   EmbedBuilder,
-  ButtonStyle,
-  EmbedBuilder,
-  ButtonInteraction,
   StringSelectMenuBuilder,
 } from 'discord.js';
 import { nanoid } from 'nanoid';
@@ -19,18 +16,17 @@ interface ShopPack {
   name: string;
   category: 'normal' | 'era' | 'featured';
   cost: { coins?: number; gems?: number };
-  stock?: number;
   emoji: string;
   dropTable: string;
 }
 
 const SHOP_PACKS: ShopPack[] = [
-  { id: 'genesis_small', name: 'Small', category: 'normal', cost: { coins: 10000 }, emoji: '📦', dropTable: 'packs_genesis.json' },
-  { id: 'genesis_medium', name: 'Medium', category: 'normal', cost: { coins: 20000 }, emoji: '📫', dropTable: 'packs_genesis.json' },
-  { id: 'genesis_large', name: 'Large', category: 'normal', cost: { coins: 40000 }, emoji: '🎁', stock: 5, dropTable: 'packs_genesis.json' },
-  { id: 'classic_era', name: 'Classic Era', category: 'era', cost: { gems: 100 }, emoji: '♦️', dropTable: 'packs_genesis.json' },
-  { id: 'gremlin_era', name: 'Gremlin Era', category: 'era', cost: { gems: 120 }, emoji: '📢', dropTable: 'packs_genesis.json' },
-  { id: 'frost_signal', name: 'Frost Signal', category: 'featured', cost: { coins: 25000 }, emoji: '❄️', dropTable: 'packs_genesis.json' }
+  { id: 'genesis_small', name: 'Small Genesis Pack', category: 'normal', cost: { coins: 10_000 }, emoji: '📦', dropTable: 'packs_genesis.json' },
+  { id: 'genesis_medium', name: 'Medium Genesis Pack', category: 'normal', cost: { coins: 20_000 }, emoji: '📫', dropTable: 'packs_genesis.json' },
+  { id: 'genesis_large', name: 'Large Genesis Pack', category: 'normal', cost: { coins: 40_000 }, emoji: '🎁', dropTable: 'packs_genesis.json' },
+  { id: 'classic_era', name: 'Classic Era Pack', category: 'era', cost: { gems: 100 }, emoji: '♦️', dropTable: 'packs_genesis.json' },
+  { id: 'pirate_era', name: 'Pirate Era Pack', category: 'era', cost: { gems: 100 }, emoji: '🏴\u200d☠️', dropTable: 'packs_genesis.json' },
+  { id: 'featured_frost', name: 'Frost Signal Pack', category: 'featured', cost: { coins: 25_000 }, emoji: '❄️', dropTable: 'packs_genesis.json' },
 ];
 
 interface RotationRecord {
@@ -44,7 +40,7 @@ interface RotationRecord {
 function startOfWeek(now: Date) {
   const copy = new Date(now);
   const day = copy.getUTCDay();
-  const diff = (day + 6) % 7; // Monday start
+  const diff = (day + 6) % 7; // Monday
   copy.setUTCDate(copy.getUTCDate() - diff);
   copy.setUTCHours(0, 0, 0, 0);
   return copy;
@@ -53,8 +49,11 @@ function startOfWeek(now: Date) {
 function ensureWeeklyRotation(force = false): RotationRecord {
   const now = Date.now();
   const row = db
-    .prepare('SELECT * FROM shop_rotations WHERE active_from <= ? AND active_to >= ? ORDER BY active_from DESC LIMIT 1')
-    .get(now, now) as { rotation_id: string; packs_json: string; items_json: string; active_from: number; active_to: number } | undefined;
+    .prepare('SELECT rotation_id, active_from, active_to, packs_json, items_json FROM shop_rotations WHERE active_from <= ? AND active_to >= ? ORDER BY active_from DESC LIMIT 1')
+    .get(now, now) as
+    | { rotation_id: string; active_from: number; active_to: number; packs_json: string; items_json: string }
+    | undefined;
+
   if (row && !force) {
     return {
       rotation_id: row.rotation_id,
@@ -64,19 +63,23 @@ function ensureWeeklyRotation(force = false): RotationRecord {
       active_to: row.active_to,
     };
   }
-  const base = startOfWeek(new Date());
-  const active_from = base.getTime();
+
+  const start = startOfWeek(new Date());
+  const active_from = start.getTime();
   const active_to = active_from + 7 * 24 * 60 * 60 * 1000;
   const rotation_id = `rot_${nanoid(6)}`;
-  const featured = SHOP_PACKS.filter((p) => p.category !== 'normal').map((p) => p.id);
-  const packs = featured.sort(() => Math.random() - 0.5).slice(0, 3);
+
+  const pool = SHOP_PACKS.filter((p) => p.category !== 'normal').map((pack) => pack.id);
+  const packs = pool.sort(() => Math.random() - 0.5).slice(0, 3);
   const items = [
-    { id: 'cosmetic_spark_trail', cost: 180, emoji: '✨' },
-    { id: 'gift_frostsigil', cost: 220, emoji: '❄️' }
+    { id: 'gift_frostsigil', cost: 200, emoji: '❄️' },
+    { id: 'trinket_ledger_amulet', cost: 150, emoji: '🪙' },
   ];
+
   db.prepare(
     'INSERT INTO shop_rotations (rotation_id, active_from, active_to, packs_json, items_json) VALUES (?,?,?,?,?)'
   ).run(rotation_id, active_from, active_to, JSON.stringify(packs), JSON.stringify(items));
+
   return { rotation_id, packs, items, active_from, active_to };
 }
 
@@ -85,766 +88,175 @@ function rotationLabel(rot: RotationRecord) {
 }
 
 function packById(id: string) {
-  return SHOP_PACKS.find((p) => p.id === id);
+  return SHOP_PACKS.find((pack) => pack.id === id);
 }
 
 function pityProgress(user_id: string, pack: ShopPack) {
   const row = db
     .prepare('SELECT opened, last_rarity FROM pity WHERE user_id=? AND pack_id=?')
     .get(user_id, pack.id) as { opened?: number; last_rarity?: string } | undefined;
-  if (!row) return 'Fresh pity track';
-  return `Opened ${row.opened} • Last ${row.last_rarity ?? 'none'}`;
+
+  if (!row) return 'No packs opened yet.';
+  return `Opened ${row.opened} • Last ${row.last_rarity ?? 'unknown'}`;
 }
 
 function purchasePack(user_id: string, pack: ShopPack) {
-  if (pack.stock !== undefined && pack.stock <= 0) {
-    throw new Error('Out of stock');
-  }
-  const prof = db
-    .prepare('SELECT coins, gems FROM profiles WHERE user_id=?')
-    .get(user_id) as { coins?: number; gems?: number } | undefined;
-  const coins = prof?.coins ?? 0;
-  const gems = prof?.gems ?? 0;
-  if (pack.cost.coins && coins < pack.cost.coins) throw new Error(`Need ${pack.cost.coins} coins`);
-  if (pack.cost.gems && gems < pack.cost.gems) throw new Error(`Need ${pack.cost.gems} gems`);
-  if (pack.cost.coins) {
-    db.prepare('UPDATE profiles SET coins=coins-? WHERE user_id=?').run(pack.cost.coins, user_id);
-  }
-  if (pack.cost.gems) {
-    db.prepare('UPDATE profiles SET gems=gems-? WHERE user_id=?').run(pack.cost.gems, user_id);
-  }
-  if (pack.cost.coins || pack.cost.gems) {
-    db.prepare('INSERT INTO economy_ledger (txn_id,user_id,kind,amount,reason,meta_json,ts) VALUES (?,?,?,?,?,?,?)')
-      .run(
-        `txn_${nanoid(8)}`,
-        user_id,
-        'shop_purchase',
-        pack.cost.coins ?? pack.cost.gems ?? 0,
-        'pack_purchase',
-        JSON.stringify({ pack_id: pack.id }),
-        Date.now()
-      );
-  }
-  const { rarity, drop, duplicate } = openPack(user_id, pack.dropTable, {
-    skipCost: true,
-    spendAmountOverride: pack.cost.coins ?? pack.cost.gems ?? 0,
-    packIdOverride: pack.id,
-  });
-  if (pack.stock !== undefined) {
-    db.prepare('UPDATE shop_rotations SET items_json=items_json WHERE rotation_id=?').run('noop'); // noop to ensure row exists
-    pack.stock -= 1;
-  }
-  const pity = pityProgress(user_id, pack);
-  const duplicateNote = duplicate ? ' (duplicate converted to fragments)' : '';
-  return `🎁 ${pack.name} → **[${rarity.toUpperCase()}] ${drop.id}**${duplicateNote}\n${pity}`;
-}
-
-export async function renderEnhancedShop(user_id: string) {
   const profile =
-    (db.prepare('SELECT coins, gems, fragments FROM profiles WHERE user_id=?').get(user_id) as
-      | { coins: number; gems: number; fragments: number }
-      | undefined) ?? { coins: 0, gems: 0, fragments: 0 };
-  const rotation = ensureWeeklyRotation();
-  const embed = new EmbedBuilder()
-    .setTitle('🛒 Black Market')
-    .setColor(0x2b2d31)
-    .setDescription(
-      `**Gold:** 🪙 ${profile.coins.toLocaleString()}\n**Gems:** 💎 ${profile.gems.toLocaleString()}\n**Fragments:** ✨ ${profile.fragments}\n${rotationLabel(
-        rotation
-      )}`
-    );
-
-  const normal = SHOP_PACKS.filter((p) => p.category === 'normal')
-    .map((p) => `${p.emoji} **${p.name}** — ${p.cost.coins?.toLocaleString() ?? p.cost.gems} ${p.cost.coins ? '🪙' : '💎'}`)
-    .join('\n');
-  embed.addFields({ name: 'Normal Backpacks', value: normal || 'None', inline: false });
-
-  const featured = rotation.packs
-    .map((id) => packById(id))
-    .filter(Boolean)
-    .map((pack) => `${pack!.emoji} **${pack!.name}** — ${pityProgress(user_id, pack!)}`)
-    .join('\n');
-  embed.addFields({ name: 'Weekly Featured Packs', value: featured || 'Rotation warming up…', inline: false });
-
-  const limitedItems = rotation.items
-    .map((item) => `${item.emoji} ${item.id} — ${item.cost} fragments`)
-    .join('\n');
-  embed.addFields({ name: 'Limited Stock', value: limitedItems || 'Check back soon!', inline: false });
-
-  const craftables = listCraftables()
-    .map((craft) => `${craft.id} — ${craft.costFragments} fragments`)
-    .join('\n');
-  embed.addFields({ name: 'Crafting', value: craftables || 'No recipes yet.', inline: false });
-
-  const packOptions = new StringSelectMenuBuilder()
-    .setCustomId('shop:select')
-    .setPlaceholder('Open a pack...')
-    .addOptions(
-      rotation.packs
-        .map((id) => packById(id))
-        .filter(Boolean)
-        .map((pack) => ({
-          label: pack!.name,
-          description: `Open ${pack!.name}`,
-          value: pack!.id,
-          emoji: pack!.emoji,
-        }))
-    );
-
-  const craftMenu = new StringSelectMenuBuilder()
-    .setCustomId('shop:craft')
-    .setPlaceholder('Craft gear...')
-    .addOptions(
-      listCraftables().map((craft) => ({
-        label: craft.id,
-        description: craft.description,
-        value: craft.id,
-        emoji: '🛠️',
-      }))
-    );
-
-  const actionRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(packOptions);
-  const craftRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(craftMenu);
-  const buttons = new ActionRowBuilder<ButtonBuilder>().addComponents(
-    new ButtonBuilder().setCustomId('shop:refresh').setLabel('Refresh Rotation').setStyle(ButtonStyle.Secondary),
-    new ButtonBuilder().setCustomId('shop:category:skins').setLabel('Seasonals').setStyle(ButtonStyle.Primary)
-  );
-
-  return { embeds: [embed], components: [actionRow, craftRow, buttons] };
-}
-
-export async function handleEnhancedShopInteraction(customId: string, user_id: string, values?: string[]) {
-
-interface ShopPack {
-  id: string;
-  name: string;
-  category: 'normal' | 'era' | 'featured';
-  cost: { coins?: number; gems?: number };
-  stock?: number;
-  emoji: string;
-  dropTable: string;
-}
-
-const SHOP_PACKS: ShopPack[] = [
-  { id: 'genesis_small', name: 'Small', category: 'normal', cost: { coins: 10000 }, emoji: '📦', dropTable: 'packs_genesis.json' },
-  { id: 'genesis_medium', name: 'Medium', category: 'normal', cost: { coins: 20000 }, emoji: '📫', dropTable: 'packs_genesis.json' },
-  { id: 'genesis_large', name: 'Large', category: 'normal', cost: { coins: 40000 }, emoji: '🎁', stock: 5, dropTable: 'packs_genesis.json' },
-  { id: 'classic_era', name: 'Classic Era', category: 'era', cost: { gems: 100 }, emoji: '♦️', dropTable: 'packs_genesis.json' },
-  { id: 'gremlin_era', name: 'Gremlin Era', category: 'era', cost: { gems: 120 }, emoji: '📢', dropTable: 'packs_genesis.json' },
-  { id: 'frost_signal', name: 'Frost Signal', category: 'featured', cost: { coins: 25000 }, emoji: '❄️', dropTable: 'packs_genesis.json' }
-];
-
-interface RotationRecord {
-  rotation_id: string;
-  packs: string[];
-  items: { id: string; cost: number; emoji: string }[];
-  active_from: number;
-  active_to: number;
-}
-
-function startOfWeek(now: Date) {
-  const copy = new Date(now);
-  const day = copy.getUTCDay();
-  const diff = (day + 6) % 7; // Monday start
-  copy.setUTCDate(copy.getUTCDate() - diff);
-  copy.setUTCHours(0, 0, 0, 0);
-  return copy;
-}
-
-function ensureWeeklyRotation(force = false): RotationRecord {
-  const now = Date.now();
-  const row = db
-    .prepare('SELECT * FROM shop_rotations WHERE active_from <= ? AND active_to >= ? ORDER BY active_from DESC LIMIT 1')
-    .get(now, now) as { rotation_id: string; packs_json: string; items_json: string; active_from: number; active_to: number } | undefined;
-  if (row && !force) {
-    return {
-      rotation_id: row.rotation_id,
-      packs: JSON.parse(row.packs_json || '[]'),
-      items: JSON.parse(row.items_json || '[]'),
-      active_from: row.active_from,
-      active_to: row.active_to,
-    };
-  }
-  const base = startOfWeek(new Date());
-  const active_from = base.getTime();
-  const active_to = active_from + 7 * 24 * 60 * 60 * 1000;
-  const rotation_id = `rot_${nanoid(6)}`;
-  const featured = SHOP_PACKS.filter((p) => p.category !== 'normal').map((p) => p.id);
-  const packs = featured.sort(() => Math.random() - 0.5).slice(0, 3);
-  const items = [
-    { id: 'cosmetic_spark_trail', cost: 180, emoji: '✨' },
-    { id: 'gift_frostsigil', cost: 220, emoji: '❄️' }
-  ];
-  db.prepare(
-    'INSERT INTO shop_rotations (rotation_id, active_from, active_to, packs_json, items_json) VALUES (?,?,?,?,?)'
-  ).run(rotation_id, active_from, active_to, JSON.stringify(packs), JSON.stringify(items));
-  return { rotation_id, packs, items, active_from, active_to };
-}
-
-function rotationLabel(rot: RotationRecord) {
-  return `Rotation ${rot.rotation_id} • Ends <t:${Math.floor(rot.active_to / 1000)}:R>`;
-}
-
-function packById(id: string) {
-  return SHOP_PACKS.find((p) => p.id === id);
-}
-
-function pityProgress(user_id: string, pack: ShopPack) {
-  const row = db
-    .prepare('SELECT opened, last_rarity FROM pity WHERE user_id=? AND pack_id=?')
-    .get(user_id, pack.id) as { opened?: number; last_rarity?: string } | undefined;
-  if (!row) return 'Fresh pity track';
-  return `Opened ${row.opened} • Last ${row.last_rarity ?? 'none'}`;
-}
-
-function purchasePack(user_id: string, pack: ShopPack) {
-  if (pack.stock !== undefined && pack.stock <= 0) {
-    throw new Error('Out of stock');
-  }
-  const prof = db
-    .prepare('SELECT coins, gems FROM profiles WHERE user_id=?')
-    .get(user_id) as { coins?: number; gems?: number } | undefined;
-  const coins = prof?.coins ?? 0;
-  const gems = prof?.gems ?? 0;
-  if (pack.cost.coins && coins < pack.cost.coins) throw new Error(`Need ${pack.cost.coins} coins`);
-  if (pack.cost.gems && gems < pack.cost.gems) throw new Error(`Need ${pack.cost.gems} gems`);
-  if (pack.cost.coins) {
-    db.prepare('UPDATE profiles SET coins=coins-? WHERE user_id=?').run(pack.cost.coins, user_id);
-  }
-  if (pack.cost.gems) {
-    db.prepare('UPDATE profiles SET gems=gems-? WHERE user_id=?').run(pack.cost.gems, user_id);
-  }
-  if (pack.cost.coins || pack.cost.gems) {
-    db.prepare('INSERT INTO economy_ledger (txn_id,user_id,kind,amount,reason,meta_json,ts) VALUES (?,?,?,?,?,?,?)')
-      .run(
-        `txn_${nanoid(8)}`,
-        user_id,
-        'shop_purchase',
-        pack.cost.coins ?? pack.cost.gems ?? 0,
-        'pack_purchase',
-        JSON.stringify({ pack_id: pack.id }),
-        Date.now()
-      );
-  }
-  const { rarity, drop, duplicate } = openPack(user_id, pack.dropTable, {
-    skipCost: true,
-    spendAmountOverride: pack.cost.coins ?? pack.cost.gems ?? 0,
-    packIdOverride: pack.id,
-  });
-  if (pack.stock !== undefined) {
-    db.prepare('UPDATE shop_rotations SET items_json=items_json WHERE rotation_id=?').run('noop'); // noop to ensure row exists
-    pack.stock -= 1;
-  }
-  const pity = pityProgress(user_id, pack);
-  const duplicateNote = duplicate ? ' (duplicate converted to fragments)' : '';
-  return `🎁 ${pack.name} → **[${rarity.toUpperCase()}] ${drop.id}**${duplicateNote}\n${pity}`;
-}
-
-export async function renderEnhancedShop(user_id: string) {
-  const profile =
-    (db.prepare('SELECT coins, gems, fragments FROM profiles WHERE user_id=?').get(user_id) as
-      | { coins: number; gems: number; fragments: number }
-      | undefined) ?? { coins: 0, gems: 0, fragments: 0 };
-  const rotation = ensureWeeklyRotation();
-  const embed = new EmbedBuilder()
-    .setTitle('🛒 Black Market')
-    .setColor(0x2b2d31)
-    .setDescription(
-      `**Gold:** 🪙 ${profile.coins.toLocaleString()}\n**Gems:** 💎 ${profile.gems.toLocaleString()}\n**Fragments:** ✨ ${profile.fragments}\n${rotationLabel(
-        rotation
-      )}`
-    );
-
-  const normal = SHOP_PACKS.filter((p) => p.category === 'normal')
-    .map((p) => `${p.emoji} **${p.name}** — ${p.cost.coins?.toLocaleString() ?? p.cost.gems} ${p.cost.coins ? '🪙' : '💎'}`)
-    .join('\n');
-  embed.addFields({ name: 'Normal Backpacks', value: normal || 'None', inline: false });
-
-  const featured = rotation.packs
-    .map((id) => packById(id))
-    .filter(Boolean)
-    .map((pack) => `${pack!.emoji} **${pack!.name}** — ${pityProgress(user_id, pack!)}`)
-    .join('\n');
-  embed.addFields({ name: 'Weekly Featured Packs', value: featured || 'Rotation warming up…', inline: false });
-
-  const limitedItems = rotation.items
-    .map((item) => `${item.emoji} ${item.id} — ${item.cost} fragments`)
-    .join('\n');
-  embed.addFields({ name: 'Limited Stock', value: limitedItems || 'Check back soon!', inline: false });
-
-  const craftables = listCraftables()
-    .map((craft) => `${craft.id} — ${craft.costFragments} fragments`)
-    .join('\n');
-  embed.addFields({ name: 'Crafting', value: craftables || 'No recipes yet.', inline: false });
-
-  const packOptions = new StringSelectMenuBuilder()
-    .setCustomId('shop:select')
-    .setPlaceholder('Open a pack...')
-    .addOptions(
-      rotation.packs
-        .map((id) => packById(id))
-        .filter(Boolean)
-        .map((pack) => ({
-          label: pack!.name,
-          description: `Open ${pack!.name}`,
-          value: pack!.id,
-          emoji: pack!.emoji,
-        }))
-    );
-
-  const craftMenu = new StringSelectMenuBuilder()
-    .setCustomId('shop:craft')
-    .setPlaceholder('Craft gear...')
-    .addOptions(
-      listCraftables().map((craft) => ({
-        label: craft.id,
-        description: craft.description,
-        value: craft.id,
-        emoji: '🛠️',
-      }))
-    );
-
-  const actionRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(packOptions);
-  const craftRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(craftMenu);
-  const buttons = new ActionRowBuilder<ButtonBuilder>().addComponents(
-    new ButtonBuilder().setCustomId('shop:refresh').setLabel('Refresh Rotation').setStyle(ButtonStyle.Secondary),
-    new ButtonBuilder().setCustomId('shop:category:skins').setLabel('Seasonals').setStyle(ButtonStyle.Primary)
-  );
-
-  return { embeds: [embed], components: [actionRow, craftRow, buttons] };
-}
-
-export async function handleEnhancedShopInteraction(customId: string, user_id: string, values?: string[]) {
-
-interface ShopPack {
-  id: string;
-  name: string;
-  category: 'normal' | 'era' | 'featured';
-  cost: { coins?: number; gems?: number };
-  stock?: number;
-  emoji: string;
-  dropTable: string;
-}
-
-const SHOP_PACKS: ShopPack[] = [
-  { id: 'genesis_small', name: 'Small', category: 'normal', cost: { coins: 10000 }, emoji: '📦', dropTable: 'packs_genesis.json' },
-  { id: 'genesis_medium', name: 'Medium', category: 'normal', cost: { coins: 20000 }, emoji: '📫', dropTable: 'packs_genesis.json' },
-  { id: 'genesis_large', name: 'Large', category: 'normal', cost: { coins: 40000 }, emoji: '🎁', stock: 5, dropTable: 'packs_genesis.json' },
-  { id: 'classic_era', name: 'Classic Era', category: 'era', cost: { gems: 100 }, emoji: '♦️', dropTable: 'packs_genesis.json' },
-  { id: 'gremlin_era', name: 'Gremlin Era', category: 'era', cost: { gems: 120 }, emoji: '📢', dropTable: 'packs_genesis.json' },
-  { id: 'frost_signal', name: 'Frost Signal', category: 'featured', cost: { coins: 25000 }, emoji: '❄️', dropTable: 'packs_genesis.json' }
-];
-
-interface RotationRecord {
-  rotation_id: string;
-  packs: string[];
-  items: { id: string; cost: number; emoji: string }[];
-  active_from: number;
-  active_to: number;
-}
-
-function startOfWeek(now: Date) {
-  const copy = new Date(now);
-  const day = copy.getUTCDay();
-  const diff = (day + 6) % 7; // Monday start
-  copy.setUTCDate(copy.getUTCDate() - diff);
-  copy.setUTCHours(0, 0, 0, 0);
-  return copy;
-}
-
-function ensureWeeklyRotation(force = false): RotationRecord {
-  const now = Date.now();
-  const row = db
-    .prepare('SELECT * FROM shop_rotations WHERE active_from <= ? AND active_to >= ? ORDER BY active_from DESC LIMIT 1')
-    .get(now, now) as { rotation_id: string; packs_json: string; items_json: string; active_from: number; active_to: number } | undefined;
-  if (row && !force) {
-    return {
-      rotation_id: row.rotation_id,
-      packs: JSON.parse(row.packs_json || '[]'),
-      items: JSON.parse(row.items_json || '[]'),
-      active_from: row.active_from,
-      active_to: row.active_to,
-    };
-  }
-  const base = startOfWeek(new Date());
-  const active_from = base.getTime();
-  const active_to = active_from + 7 * 24 * 60 * 60 * 1000;
-  const rotation_id = `rot_${nanoid(6)}`;
-  const featured = SHOP_PACKS.filter((p) => p.category !== 'normal').map((p) => p.id);
-  const packs = featured.sort(() => Math.random() - 0.5).slice(0, 3);
-  const items = [
-    { id: 'cosmetic_spark_trail', cost: 180, emoji: '✨' },
-    { id: 'gift_frostsigil', cost: 220, emoji: '❄️' }
-  ];
-  db.prepare(
-    'INSERT INTO shop_rotations (rotation_id, active_from, active_to, packs_json, items_json) VALUES (?,?,?,?,?)'
-  ).run(rotation_id, active_from, active_to, JSON.stringify(packs), JSON.stringify(items));
-  return { rotation_id, packs, items, active_from, active_to };
-}
-
-function rotationLabel(rot: RotationRecord) {
-  return `Rotation ${rot.rotation_id} • Ends <t:${Math.floor(rot.active_to / 1000)}:R>`;
-}
-
-function packById(id: string) {
-  return SHOP_PACKS.find((p) => p.id === id);
-}
-
-function pityProgress(user_id: string, pack: ShopPack) {
-  const row = db
-    .prepare('SELECT opened, last_rarity FROM pity WHERE user_id=? AND pack_id=?')
-    .get(user_id, pack.id) as { opened?: number; last_rarity?: string } | undefined;
-  if (!row) return 'Fresh pity track';
-  return `Opened ${row.opened} • Last ${row.last_rarity ?? 'none'}`;
-}
-
-function purchasePack(user_id: string, pack: ShopPack) {
-  if (pack.stock !== undefined && pack.stock <= 0) {
-    throw new Error('Out of stock');
-  }
-  const prof = db
-    .prepare('SELECT coins, gems FROM profiles WHERE user_id=?')
-    .get(user_id) as { coins?: number; gems?: number } | undefined;
-  const coins = prof?.coins ?? 0;
-  const gems = prof?.gems ?? 0;
-  if (pack.cost.coins && coins < pack.cost.coins) throw new Error(`Need ${pack.cost.coins} coins`);
-  if (pack.cost.gems && gems < pack.cost.gems) throw new Error(`Need ${pack.cost.gems} gems`);
-  if (pack.cost.coins) {
-    db.prepare('UPDATE profiles SET coins=coins-? WHERE user_id=?').run(pack.cost.coins, user_id);
-  }
-  if (pack.cost.gems) {
-    db.prepare('UPDATE profiles SET gems=gems-? WHERE user_id=?').run(pack.cost.gems, user_id);
-  }
-  if (pack.cost.coins || pack.cost.gems) {
-    db.prepare('INSERT INTO economy_ledger (txn_id,user_id,kind,amount,reason,meta_json,ts) VALUES (?,?,?,?,?,?,?)')
-      .run(
-        `txn_${nanoid(8)}`,
-        user_id,
-        'shop_purchase',
-        pack.cost.coins ?? pack.cost.gems ?? 0,
-        'pack_purchase',
-        JSON.stringify({ pack_id: pack.id }),
-        Date.now()
-      );
-  }
-  const { rarity, drop, duplicate } = openPack(user_id, pack.dropTable, {
-    skipCost: true,
-    spendAmountOverride: pack.cost.coins ?? pack.cost.gems ?? 0,
-    packIdOverride: pack.id,
-  });
-  if (pack.stock !== undefined) {
-    db.prepare('UPDATE shop_rotations SET items_json=items_json WHERE rotation_id=?').run('noop'); // noop to ensure row exists
-    pack.stock -= 1;
-  }
-  const pity = pityProgress(user_id, pack);
-  const duplicateNote = duplicate ? ' (duplicate converted to fragments)' : '';
-  return `🎁 ${pack.name} → **[${rarity.toUpperCase()}] ${drop.id}**${duplicateNote}\n${pity}`;
-}
-
-export async function renderEnhancedShop(user_id: string) {
-  const profile =
-    (db.prepare('SELECT coins, gems, fragments FROM profiles WHERE user_id=?').get(user_id) as
-      | { coins: number; gems: number; fragments: number }
-      | undefined) ?? { coins: 0, gems: 0, fragments: 0 };
-  const rotation = ensureWeeklyRotation();
-  const embed = new EmbedBuilder()
-    .setTitle('🛒 Black Market')
-    .setColor(0x2b2d31)
-    .setDescription(
-      `**Gold:** 🪙 ${profile.coins.toLocaleString()}\n**Gems:** 💎 ${profile.gems.toLocaleString()}\n**Fragments:** ✨ ${profile.fragments}\n${rotationLabel(
-        rotation
-      )}`
-    );
-
-  const normal = SHOP_PACKS.filter((p) => p.category === 'normal')
-    .map((p) => `${p.emoji} **${p.name}** — ${p.cost.coins?.toLocaleString() ?? p.cost.gems} ${p.cost.coins ? '🪙' : '💎'}`)
-    .join('\n');
-  embed.addFields({ name: 'Normal Backpacks', value: normal || 'None', inline: false });
-
-  const featured = rotation.packs
-    .map((id) => packById(id))
-    .filter(Boolean)
-    .map((pack) => `${pack!.emoji} **${pack!.name}** — ${pityProgress(user_id, pack!)}`)
-    .join('\n');
-  embed.addFields({ name: 'Weekly Featured Packs', value: featured || 'Rotation warming up…', inline: false });
-
-  const limitedItems = rotation.items
-    .map((item) => `${item.emoji} ${item.id} — ${item.cost} fragments`)
-    .join('\n');
-  embed.addFields({ name: 'Limited Stock', value: limitedItems || 'Check back soon!', inline: false });
-
-  const craftables = listCraftables()
-    .map((craft) => `${craft.id} — ${craft.costFragments} fragments`)
-    .join('\n');
-  embed.addFields({ name: 'Crafting', value: craftables || 'No recipes yet.', inline: false });
-
-  const packOptions = new StringSelectMenuBuilder()
-    .setCustomId('shop:select')
-    .setPlaceholder('Open a pack...')
-    .addOptions(
-      rotation.packs
-        .map((id) => packById(id))
-        .filter(Boolean)
-        .map((pack) => ({
-          label: pack!.name,
-          description: `Open ${pack!.name}`,
-          value: pack!.id,
-          emoji: pack!.emoji,
-        }))
-    );
-
-  const craftMenu = new StringSelectMenuBuilder()
-    .setCustomId('shop:craft')
-    .setPlaceholder('Craft gear...')
-    .addOptions(
-      listCraftables().map((craft) => ({
-        label: craft.id,
-        description: craft.description,
-        value: craft.id,
-        emoji: '🛠️',
-      }))
-    );
-
-  const actionRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(packOptions);
-  const craftRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(craftMenu);
-  const buttons = new ActionRowBuilder<ButtonBuilder>().addComponents(
-    new ButtonBuilder().setCustomId('shop:refresh').setLabel('Refresh Rotation').setStyle(ButtonStyle.Secondary),
-    new ButtonBuilder().setCustomId('shop:category:skins').setLabel('Seasonals').setStyle(ButtonStyle.Primary)
-  );
-
-  return { embeds: [embed], components: [actionRow, craftRow, buttons] };
-}
-
-export async function handleEnhancedShopInteraction(customId: string, user_id: string, values?: string[]) {
-  category: 'normal' | 'era';
-  cost: { coins?: number; gems?: number };
-  stock?: number;
-  emoji: string;
-}
-
-const SHOP_PACKS: ShopPack[] = [
-  { id: 'small', name: 'Small', category: 'normal', cost: { coins: 10_000 }, emoji: '📦' },
-  { id: 'medium', name: 'Medium', category: 'normal', cost: { coins: 20_000 }, emoji: '📫' },
-  { id: 'big', name: 'Big', category: 'normal', cost: { coins: 40_000 }, stock: 0, emoji: '🎁' },
-  { id: 'classic', name: 'Classic', category: 'era', cost: { gems: 100 }, emoji: '♦️' },
-  { id: 'pirate', name: 'Pirate', category: 'era', cost: { gems: 100 }, emoji: '🏴‍☠️' },
-  { id: 'modern', name: 'Modern', category: 'era', cost: { gems: 100 }, emoji: '🏙️' },
-  { id: 'medieval', name: 'Medieval', category: 'era', cost: { gems: 100 }, emoji: '🏰' },
-  { id: 'samurai', name: 'Samurai', category: 'era', cost: { gems: 100 }, emoji: '⚔️' },
-  { id: 'steampunk', name: 'Steampunk', category: 'era', cost: { gems: 100 }, emoji: '⚙️' },
-  { id: 'magical', name: 'Magical', category: 'era', cost: { gems: 100 }, emoji: '🔮' },
-  { id: 'futuristic', name: 'Futuristic', category: 'era', cost: { gems: 100 }, emoji: '🚀' },
-  { id: 'zombie', name: 'Zombie', category: 'era', cost: { gems: 100 }, emoji: '🧟' },
-  { id: 'egyptian', name: 'Egyptian', category: 'era', cost: { gems: 100 }, emoji: '🏺' },
-  { id: 'jurassic', name: 'Jurassic', category: 'era', cost: { gems: 100 }, emoji: '🦕' },
-];
-
-export async function renderEnhancedShop(user_id: string) {
-  const prof =
     (db.prepare('SELECT coins, gems FROM profiles WHERE user_id=?').get(user_id) as
-      | { coins: number; gems: number }
+      | { coins?: number; gems?: number }
       | undefined) ?? { coins: 0, gems: 0 };
 
-  const inventory = db
-    .prepare('SELECT item_id, qty FROM inventories WHERE user_id=? AND kind LIKE "%pack%"')
-    .all(user_id) as { item_id: string; qty: number }[];
-  const packCounts: Record<string, number> = Object.fromEntries(
-    inventory.map((item) => [item.item_id, item.qty])
-  );
+  const coins = profile.coins ?? 0;
+  const gems = profile.gems ?? 0;
 
+  if (pack.cost.coins && coins < pack.cost.coins) throw new Error(`Need ${pack.cost.coins.toLocaleString()} coins.`);
+  if (pack.cost.gems && gems < pack.cost.gems) throw new Error(`Need ${pack.cost.gems} gems.`);
+
+  if (pack.cost.coins) {
+    db.prepare('UPDATE profiles SET coins=coins-? WHERE user_id=?').run(pack.cost.coins, user_id);
+    db.prepare(
+      'INSERT INTO economy_ledger (txn_id,user_id,kind,amount,reason,meta_json,ts) VALUES (?,?,?,?,?,?,?)'
+    ).run(
+      `txn_${nanoid(8)}`,
+      user_id,
+      'shop_purchase',
+      pack.cost.coins,
+      'coins_spent',
+      JSON.stringify({ pack_id: pack.id }),
+      Date.now()
+    );
+  }
+
+  if (pack.cost.gems) {
+    db.prepare('UPDATE profiles SET gems=gems-? WHERE user_id=?').run(pack.cost.gems, user_id);
+    db.prepare(
+      'INSERT INTO economy_ledger (txn_id,user_id,kind,amount,reason,meta_json,ts) VALUES (?,?,?,?,?,?,?)'
+    ).run(
+      `txn_${nanoid(8)}`,
+      user_id,
+      'shop_purchase',
+      pack.cost.gems,
+      'gems_spent',
+      JSON.stringify({ pack_id: pack.id }),
+      Date.now()
+    );
+  }
+
+  const result = openPack(user_id, pack.dropTable, {
+    skipCost: true,
+    spendAmountOverride: pack.cost.coins ?? pack.cost.gems ?? 0,
+    packIdOverride: pack.id,
+  });
+
+  const pity = pityProgress(user_id, pack);
+  const duplicateSuffix = result.duplicate ? ' (duplicate converted to fragments)' : '';
+  return `🎁 ${pack.name} → **[${result.rarity.toUpperCase()}] ${result.drop.id}**${duplicateSuffix}\n${pity}`;
+}
+
+export async function renderEnhancedShop(user_id: string) {
+  const profile =
+    (db.prepare('SELECT coins, gems, fragments FROM profiles WHERE user_id=?').get(user_id) as
+      | { coins: number; gems: number; fragments: number }
+      | undefined) ?? { coins: 0, gems: 0, fragments: 0 };
+
+  const rotation = ensureWeeklyRotation();
   const embed = new EmbedBuilder()
     .setTitle('🛒 Black Market')
+    .setColor(0x2b2d31)
     .setDescription(
-      `**Gold:** 🪙 ${prof.coins.toLocaleString()}\n**Gems:** 💎 ${prof.gems}\n\nThe shop resets on ${getNextResetTime()}`
-    )
-    .setColor(0x2b2d31);
+      `**Gold:** 🪙 ${profile.coins.toLocaleString()}\n**Gems:** 💎 ${profile.gems.toLocaleString()}\n**Fragments:** ✨ ${profile.fragments}\n${rotationLabel(rotation)}`
+    );
 
-  let normalSection = '**Normal Backpacks**\n';
-  for (const pack of SHOP_PACKS.filter((p) => p.category === 'normal')) {
-    const count = packCounts[pack.id] ?? 0;
-    const isAvailable = pack.stock === undefined || pack.stock > 0;
-    const costStr = pack.cost.coins
-      ? `${pack.cost.coins.toLocaleString()} 🪙`
-      : `${pack.cost.gems?.toLocaleString() ?? 0} 💎`;
-    const stockStr = isAvailable ? '' : ' ❌';
-    normalSection += `${count} ${pack.emoji} **${pack.name}**${stockStr}\nCost: ${costStr}\n\n`;
-  }
+  const normal = SHOP_PACKS.filter((p) => p.category === 'normal')
+    .map((pack) => `${pack.emoji} **${pack.name}** — ${pack.cost.coins?.toLocaleString() ?? pack.cost.gems} ${pack.cost.coins ? '🪙' : '💎'}`)
+    .join('\n');
+  embed.addFields({ name: 'Normal Backpacks', value: normal || 'None', inline: false });
 
-  let eraSection = '**Era Backpacks**\nCost: 100 💎 each\n\n';
-  for (const pack of SHOP_PACKS.filter((p) => p.category === 'era')) {
-    const count = packCounts[pack.id] ?? 0;
-    eraSection += `${count} ${pack.emoji} **${pack.name}**\n`;
-  }
+  const featured = rotation.packs
+    .map((id) => packById(id))
+    .filter((pack): pack is ShopPack => Boolean(pack))
+    .map((pack) => `${pack.emoji} **${pack.name}** — ${pityProgress(user_id, pack)}`)
+    .join('\n');
+  embed.addFields({ name: 'Weekly Featured Packs', value: featured || 'Rotation warming up…', inline: false });
 
-  embed.addFields(
-    { name: '\u200b', value: normalSection, inline: false },
-    { name: '\u200b', value: eraSection, inline: false }
-  );
+  const limitedItems = rotation.items
+    .map((item) => `${item.emoji} ${item.id} — ${item.cost} fragments`)
+    .join('\n');
+  embed.addFields({ name: 'Limited Stock', value: limitedItems || 'Check back soon!', inline: false });
 
-  const availablePacks = SHOP_PACKS.filter((pack) => pack.stock === undefined || pack.stock > 0);
-  const selectMenu = new StringSelectMenuBuilder()
+  const craftables = listCraftables()
+    .map((craft) => `${craft.emoji} ${craft.name} — ${craft.costFragments} fragments`)
+    .join('\n');
+  embed.addFields({ name: 'Crafting', value: craftables || 'No recipes yet.', inline: false });
+
+  const packOptions = new StringSelectMenuBuilder()
     .setCustomId('shop:select')
-    .setPlaceholder('Purchase an item!')
+    .setPlaceholder('Open a pack...')
     .addOptions(
-      availablePacks.map((pack) => ({
-        label: `${pack.name} Backpack`,
-        description: `Purchase a ${pack.name} backpack`,
-        value: pack.id,
-        emoji: pack.emoji,
+      rotation.packs
+        .map((id) => packById(id))
+        .filter((pack): pack is ShopPack => Boolean(pack))
+        .map((pack) => ({
+          label: pack.name,
+          description: `Open ${pack.name}`,
+          value: pack.id,
+          emoji: pack.emoji,
+        }))
+    );
+
+  const craftMenu = new StringSelectMenuBuilder()
+    .setCustomId('shop:craft')
+    .setPlaceholder('Craft gear...')
+    .addOptions(
+      listCraftables().map((craft) => ({
+        label: craft.name,
+        description: craft.description,
+        value: craft.id,
+        emoji: craft.emoji,
       }))
     );
 
-  const row1 = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(selectMenu);
-
-  const row2 = new ActionRowBuilder<ButtonBuilder>().addComponents(
-    new ButtonBuilder().setCustomId('shop:category:backpacks').setLabel('Backpacks').setStyle(ButtonStyle.Success),
-    new ButtonBuilder().setCustomId('shop:category:skins').setLabel('Skins').setStyle(ButtonStyle.Primary),
-    new ButtonBuilder().setCustomId('shop:refresh').setLabel('🔄').setStyle(ButtonStyle.Secondary)
+  const actionRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(packOptions);
+  const craftRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(craftMenu);
+  const buttons = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder().setCustomId('shop:refresh').setLabel('Refresh Rotation').setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder().setCustomId('shop:category:skins').setLabel('Seasonals').setStyle(ButtonStyle.Primary)
   );
 
-  return { embeds: [embed], components: [row1, row2] };
+  return { embeds: [embed], components: [actionRow, craftRow, buttons] };
 }
 
-export async function handleEnhancedShopInteraction(
-  customId: string,
-  user_id: string,
-  values?: string[]
-) {
+export async function handleEnhancedShopInteraction(customId: string, user_id: string, values?: string[]) {
   const parts = customId.split(':');
-
   if (parts[0] !== 'shop') return 'Unknown shop action.';
 
-  if (parts[1] === 'select' && values?.[0]) {
+  const action = parts[1];
+  if (action === 'select' && values?.[0]) {
     const pack = packById(values[0]);
     if (!pack) return '❌ Pack not found.';
     try {
-      const message = purchasePack(user_id, pack);
-      return message;
+      return purchasePack(user_id, pack);
     } catch (err: any) {
       return `❌ ${err.message ?? 'Unable to open pack.'}`;
     }
   }
 
-  if (parts[1] === 'craft' && values?.[0]) {
+  if (action === 'craft' && values?.[0]) {
     const result = craftItem(user_id, values[0]);
     return result.message;
   }
 
-  if (parts[1] === 'category' && parts[2] === 'skins') {
+  if (action === 'category' && parts[2] === 'skins') {
     const rotation = ensureWeeklyRotation();
-    return `🎨 Seasonal stock: ${rotation.items.map((i) => `${i.emoji} ${i.id}`).join(', ')}`;
+    return `🎨 Seasonal stock: ${rotation.items.map((item) => `${item.emoji} ${item.id}`).join(', ') || 'Empty'}`;
   }
 
-  if (parts[1] === 'refresh') {
+  if (action === 'refresh') {
     const rotation = ensureWeeklyRotation(true);
-    return `🔄 Rotation refreshed. New packs: ${rotation.packs.join(', ')}`;
-    }
-  }
-
-  if (parts[1] === 'craft' && values?.[0]) {
-    const result = craftItem(user_id, values[0]);
-    return result.message;
-  }
-
-  if (parts[1] === 'category' && parts[2] === 'skins') {
-    const rotation = ensureWeeklyRotation();
-    return `🎨 Seasonal stock: ${rotation.items.map((i) => `${i.emoji} ${i.id}`).join(', ')}`;
-  }
-
-  if (parts[1] === 'refresh') {
-    const rotation = ensureWeeklyRotation(true);
-    return `🔄 Rotation refreshed. New packs: ${rotation.packs.join(', ')}`;
-    try {
-      const message = purchasePack(user_id, pack);
-      return message;
-    } catch (err: any) {
-      return `❌ ${err.message ?? 'Unable to open pack.'}`;
-    }
-  }
-
-  if (parts[1] === 'craft' && values?.[0]) {
-    const result = craftItem(user_id, values[0]);
-    return result.message;
-  }
-
-  if (parts[1] === 'category' && parts[2] === 'skins') {
-    const rotation = ensureWeeklyRotation();
-    return `🎨 Seasonal stock: ${rotation.items.map((i) => `${i.emoji} ${i.id}`).join(', ')}`;
-  }
-
-  if (parts[1] === 'refresh') {
-    const rotation = ensureWeeklyRotation(true);
-    return `🔄 Rotation refreshed. New packs: ${rotation.packs.join(', ')}`;
-    }
-  }
-
-  if (parts[1] === 'craft' && values?.[0]) {
-    const result = craftItem(user_id, values[0]);
-    return result.message;
-  }
-
-  if (parts[1] === 'category' && parts[2] === 'skins') {
-    const rotation = ensureWeeklyRotation();
-    return `🎨 Seasonal stock: ${rotation.items.map((i) => `${i.emoji} ${i.id}`).join(', ')}`;
-  }
-
-  if (parts[1] === 'refresh') {
-    const rotation = ensureWeeklyRotation(true);
-    return `🔄 Rotation refreshed. New packs: ${rotation.packs.join(', ')}`;
-    const packId = values[0];
-    const pack = SHOP_PACKS.find((p) => p.id === packId);
-    if (!pack) return '❌ Pack not found.';
-
-    try {
-      if (pack.stock !== undefined && pack.stock <= 0) {
-        return '❌ This pack is out of stock.';
-      }
-
-      const prof = db
-        .prepare('SELECT coins, gems FROM profiles WHERE user_id=?')
-        .get(user_id) as { coins?: number; gems?: number } | undefined;
-      const coins = prof?.coins ?? 0;
-      const gems = prof?.gems ?? 0;
-
-      if (pack.cost.coins && coins < pack.cost.coins) {
-        return `❌ Not enough gold. Need ${pack.cost.coins.toLocaleString()} 🪙`;
-      }
-      if (pack.cost.gems && gems < pack.cost.gems) {
-        return `❌ Not enough gems. Need ${pack.cost.gems} 💎`;
-      }
-
-      if (pack.cost.coins) {
-        db.prepare('UPDATE profiles SET coins=coins-? WHERE user_id=?').run(pack.cost.coins, user_id);
-      }
-      if (pack.cost.gems) {
-        db.prepare('UPDATE profiles SET gems=gems-? WHERE user_id=?').run(pack.cost.gems, user_id);
-        db.prepare(
-          'INSERT INTO economy_ledger (txn_id,user_id,kind,amount,reason,meta_json,ts) VALUES (?,?,?,?,?,?,?)'
-        ).run(
-          `txn_${nanoid(8)}`,
-          user_id,
-          'pack_open',
-          pack.cost.gems,
-          'gems_spent',
-          JSON.stringify({ pack_id: pack.id }),
-          Date.now()
-        );
-      }
-
-      const { rarity, drop } = openPackByType(user_id, pack);
-
-      return `🎁 You opened a ${pack.name} Pack and received **[${rarity.toUpperCase()}] ${drop.id}**`;
-    } catch (e: any) {
-      return `❌ ${e.message || 'Could not open pack.'}`;
-    }
-  }
-
-  if (parts[1] === 'category') {
-    return 'Category switching coming soon!';
-  }
-
-  if (parts[1] === 'refresh') {
-    return 'Shop refreshed!';
+    const names = rotation.packs
+      .map((id) => packById(id)?.name ?? id)
+      .join(', ');
+    return `🔄 Rotation refreshed. New packs: ${names || 'None'}`;
   }
 
   return 'Unknown shop action.';
@@ -856,106 +268,13 @@ export async function showShop(i: ButtonInteraction) {
   await i.editReply(view);
 }
 
-export function claimWeeklyReward(user_id: string): { success: boolean; amount?: number; streak?: number } {
-  const lastClaim = db
-    .prepare('SELECT last_weekly_claim, weekly_streak FROM profiles WHERE user_id=?')
-    .get(user_id) as { last_weekly_claim?: number; weekly_streak?: number } | undefined;
-  const now = Date.now();
-  const weekMs = 7 * 24 * 60 * 60 * 1000;
-
-  if (lastClaim?.last_weekly_claim && now - lastClaim.last_weekly_claim < weekMs) {
-    return { success: false };
-  }
-
-  const newStreak = (lastClaim?.weekly_streak ?? 0) + 1;
-  const baseReward = 10000;
-  const streakBonus = Math.min(newStreak * 1000, 10000);
-  const totalReward = baseReward + streakBonus;
-
-  db.prepare('UPDATE profiles SET coins=coins+?, last_weekly_claim=?, weekly_streak=? WHERE user_id=?').run(
-    totalReward,
-    now,
-    newStreak,
-    user_id
-  );
-
-  return { success: true, amount: totalReward, streak: newStreak };
-}
-
-}
-
-}
-
-export function claimWeeklyReward(user_id: string): { success: boolean; amount?: number; streak?: number } {
-  const lastClaim = db
-    .prepare('SELECT last_weekly_claim, weekly_streak FROM profiles WHERE user_id=?')
-    .get(user_id) as { last_weekly_claim?: number; weekly_streak?: number } | undefined;
-  const now = Date.now();
-  const weekMs = 7 * 24 * 60 * 60 * 1000;
-
-  if (lastClaim?.last_weekly_claim && now - lastClaim.last_weekly_claim < weekMs) {
-    return { success: false };
-  }
-
-  const newStreak = (lastClaim?.weekly_streak ?? 0) + 1;
-  const baseReward = 10000;
-  const streakBonus = Math.min(newStreak * 1000, 10000);
-  const totalReward = baseReward + streakBonus;
-
-  db.prepare('UPDATE profiles SET coins=coins+?, last_weekly_claim=?, weekly_streak=? WHERE user_id=?').run(
-    totalReward,
-    now,
-    newStreak,
-    user_id
-  );
-
-  return { success: true, amount: totalReward, streak: newStreak };
-}
-
-}
-
-export function claimWeeklyReward(user_id: string): { success: boolean; amount?: number; streak?: number } {
-  const lastClaim = db
-    .prepare('SELECT last_weekly_claim, weekly_streak FROM profiles WHERE user_id=?')
-    .get(user_id) as { last_weekly_claim?: number; weekly_streak?: number } | undefined;
-  const now = Date.now();
-  const weekMs = 7 * 24 * 60 * 60 * 1000;
-
-  if (lastClaim?.last_weekly_claim && now - lastClaim.last_weekly_claim < weekMs) {
-    return { success: false };
-  }
-
-  const newStreak = (lastClaim?.weekly_streak ?? 0) + 1;
-  const baseReward = 10000;
-  const streakBonus = Math.min(newStreak * 1000, 10000);
-  const totalReward = baseReward + streakBonus;
-
-  db.prepare('UPDATE profiles SET coins=coins+?, last_weekly_claim=?, weekly_streak=? WHERE user_id=?').run(
-    totalReward,
-    now,
-    newStreak,
-    user_id
-  );
-
-  return { success: true, amount: totalReward, streak: newStreak };
-}
-
-function openPackByType(user_id: string, pack: ShopPack) {
-  const spendOverride = pack.cost.coins ?? 0;
-  return openPack(user_id, 'Genesis', { skipCost: true, spendAmountOverride: spendOverride });
-}
-
 function getNextResetTime(): string {
-  const now = new Date();
-  const nextSunday = new Date(now);
-  nextSunday.setDate(now.getDate() + ((7 - now.getDay()) % 7 || 7));
-  nextSunday.setHours(17, 0, 0, 0);
-
-  return nextSunday.toLocaleDateString('en-US', {
+  const rotation = ensureWeeklyRotation();
+  const date = new Date(rotation.active_to);
+  return date.toLocaleString('en-US', {
     weekday: 'long',
     month: 'long',
     day: 'numeric',
-    year: 'numeric',
     hour: 'numeric',
     minute: '2-digit',
     timeZoneName: 'short',
@@ -988,10 +307,4 @@ export function claimWeeklyReward(user_id: string): { success: boolean; amount?:
   return { success: true, amount: totalReward, streak: newStreak };
 }
 
-export async function showShop(i: ButtonInteraction) {
-  await i.deferReply({ ephemeral: true });
-  const view = await renderEnhancedShop(i.user.id);
-  await i.editReply(view);
-}
-
-export { renderEnhancedShop as renderShop, handleEnhancedShopInteraction as handleShopInteraction };
+export { getNextResetTime };


### PR DESCRIPTION
## Summary
- add a filesystem-backed content registry with item, card, and role definitions plus development hot reload support
- hydrate equipment, crafting, shop, role selection, and card systems from the registry while keeping existing fallbacks
- expand local type shims so node:crypto utilities and dynamic content compile cleanly without external packages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d20db510c0833098790a04fa619165