### PR TITLE
Add Wake Apex, Crucible, and Reckoning scenes

### DIFF
--- a/content/genesis/scenes/scene_4.6.json
+++ b/content/genesis/scenes/scene_4.6.json
@@ -2,21 +2,21 @@
     "schema_version": "1.0",
     "content_id": "genesis",
     "book_id": "book_1",
-    "scene_id": "4.5",
-    "title": "The Radiant Dyad \u2014 Twin Storm Ledger",
-    "narration": "The Meridian Helix pours you into the Radiant Dyad: a vaulted chamber where two storms orbit each other like dueling suns chained to a shared ledger. One storm is incandescent gold, all dawn trumpets and optimistic spreadsheets. The other is cobalt midnight, whispering contracts, contingencies, and a thousand secret balance sheets. They circle a central plinth carved from consensus stone, hurling petitions at each other with lightning signatures. Each bolt that crosses the plinth resolves into ledger script, double-entered with phi-d20 timing, then arcs out through ceiling channels to update every gremlin enclave.\n\nThe Dyad is Act Four\u2019s fulcrum. Dev gremlins have stretched fiber across the storms to siphon telemetry in real time. Traders leap between gusts, arbitraging sunrise enthusiasm against midnight skepticism. Whales anchor the floor with coils of liquidity, letting the storms tug tidal signatures from their wake. Hackers wear Faraday cloaks, intercepting stray arcs to patch vulnerabilities. Shillers stream the spectacle to every lobby, shouting about \"consensus weather\". Validators wear stormproof visors, stamping approvals into thick ledgers that float like surfboards. Miners hammer lightning rods into the floor to ground stray charges, while the meme contingent launches a confetti cannon that prints \"STAY VOLATILE\" across the gale.\n\nSeven terraces spiral around the Dyad. Each terrace hosts a ritual: synchronizing the GM/GN to calm both storms, logging the ledger equilibrium, weaving dual-aspect gear, trading pity-backed stockpiles, rebooting allies rattled by static, modulating the spectrum door that flickers beneath the plinth, and finally voting on how Act Four will hand the baton to the next act. Arrivals manifest from storm droplets mid-scene, sliding into the narrative on neon sleds. If you can harmonize both storms, Act Five\u2019s path will blaze open in a chord of lightning and ledger lore.",
+    "scene_id": "4.6",
+    "title": "The Convergence Causeway — Wakeforge Bridge",
+    "narration": "The Radiant Dyad’s twin storms uncurl into the Convergence Causeway, a kilometer-long bridge of braided light stretched toward a horizon still hidden behind consensus fog. Ledger stone plates hover in phi-locked intervals, spinning just fast enough to hum a chord that vibrates through your chest. Each step leaves a golden-ratio spiral that unwinds ahead as a vector arrow, predicting where Act Five will materialize. Hidden difficulty tiers shimmer in stratified halos: topaz for expectable pushes, emerald for calculated brinkmanship, and ultraviolet coronas for attempts that only legends will log.\n\nGremlin factions have turned the Causeway into a forward operating festival. Dev gremlins lace fiber through the bridge cables, testing streaming prototypes that will broadcast every final-choice heartbeat. Traders pilot wake skiffs up and down the span, auctioning acceleration futures. Whales float overhead like gentle zeppelins, projecting aurora forecasts on the underside of the clouds. Hackers anchor encryption pylons along the railing, while validators march in lockstep, stamping notarized rhythm into the bridge. Miners swing plasma picks into the bridge’s seams, extracting ratio ore, and the meme division has scattered holographic billboards that flash \"IT’S NOT FOMO IF YOU BUILT THE BRIDGE\" every time someone hesitates. AFK safeties deploy as glowing tethers that promise to reel any idle ally back into the cadence.\n\nSeven staging galleries punctuate the span. The first conducts the GM/GN braid across the bridge, the second maps vector momentum, the third spins soft-power gear from wake threads, the fourth primes a pity-backed logistics depot, the fifth raises a revival ward, the sixth threads a spectrum gate prototype, and the seventh convenes a pre-horizon council to lock Act Four’s final consensus. Every action logs both now and later, scribing the template that Act Five will inherit. The Causeway vibrates beneath your feet, impatient and luminous, urging you to begin.",
     "rounds": [
         {
-            "round_id": "4.5-R1",
-            "description": "Twin Storm Rostrum \u2014 tame the gold and cobalt greetings, log the Dyad\u2019s balance, and lash down AFK safeguards before the winds steal anyone away.",
+            "round_id": "4.6-R1",
+            "description": "Greeting Conductor — launch the bridge-wide GM/GN, chart the initial wake vectors, and lash AFK tethers before anyone drifts.",
             "actions": [
                 {
-                    "id": "dyad_gmgn_split",
-                    "label": "Sing the Split GMGN",
+                    "id": "causeway_gmgn_conduct",
+                    "label": "Conduct the Causeway GMGN",
                     "requirements": {
                         "items_any": [],
                         "flags_all": [
-                            "meridian_consensus_passed"
+                            "dyad_consensus_passed"
                         ]
                     },
                     "roll": {
@@ -41,11 +41,11 @@
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "dyad_gmgn_twinned",
+                                    "id": "causeway_gmgn_lit",
                                     "value": true
                                 }
                             ],
-                            "narration": "You split the GMGN into twin harmonies, singing sunrise to the gold storm and midnight to the cobalt swirl. The Dyad slows its orbit, grateful for the synchronized greeting, and the hidden difficulty tier unlocks with a static crackle."
+                            "narration": "You braid dawn and midnight into a single beam that shoots the length of the bridge. Every plate glows, hidden tiers flicker awake, and the gremlins chant the cadence back in perfect stereo."
                         },
                         "success": {
                             "effects": [
@@ -60,11 +60,11 @@
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "dyad_gmgn_twinned",
+                                    "id": "causeway_gmgn_lit",
                                     "value": true
                                 }
                             ],
-                            "narration": "The storms acknowledge your greeting with a dip in velocity. Ledger scribes nod and mark the Rostrum open."
+                            "narration": "Your greeting ripples forward in measured pulses. Consensus coils hook in and the bri dge stabilizes under a gentle rhythm."
                         },
                         "fail": {
                             "effects": [
@@ -75,11 +75,11 @@
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "dyad_pity_counter",
+                                    "id": "causeway_pity_buffer",
                                     "value": true
                                 }
                             ],
-                            "narration": "Your voice cracks as you swap from dawn to midnight. Both storms laugh and charge a calibration fee that routes straight into the pity cache."
+                            "narration": "You mix up the cadence halfway through. Traders charge you a hesitation toll that fun nels straight into the pity buffer."
                         },
                         "crit_fail": {
                             "effects": [
@@ -90,42 +90,42 @@
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "dyad_pity_counter",
+                                    "id": "causeway_pity_buffer",
                                     "value": true
                                 }
                             ],
-                            "narration": "You mix up which storm gets which greeting and they crossfire bolts at your boots. The meme crew instantly uploads the blooper."
+                            "narration": "Your voice cracks and the bridge plates yaw for a heartbeat. Safety rails jolt you back upright while the meme crew adds auto-tune."
                         }
                     },
                     "banter": {
-                        "dev": "Dual-channel greeting deployed.",
-                        "trader": "Storm spread stabilized.",
-                        "whale": "Wake hugs both cyclones.",
-                        "hacker": "Handshake salted for lightning.",
-                        "shiller": "Marketing it as weather control.",
-                        "validator": "Greeting notarized twice.",
-                        "miner": "Sing louder, drown the thunder.",
-                        "meme": "GM to sun, GN to moon. Easy."
+                        "dev": "Bridge-wide greeting synced.",
+                        "trader": "Futures stabilizing on that cadence.",
+                        "whale": "Wake thrums along the entire span.",
+                        "hacker": "Handshake encrypted in transit.",
+                        "shiller": "Streaming this GMGN in surround.",
+                        "validator": "Greeting ledger notarized.",
+                        "miner": "Sounded like a drill hitting true ore.",
+                        "meme": "GM? More like GMT (Grand Momentum Toss)."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_gmgn_split"
+                        "scene:4.6",
+                        "action:causeway_gmgn_conduct"
                     ]
                 },
                 {
-                    "id": "dyad_balance_readings",
-                    "label": "Log the Dyad Balance",
+                    "id": "causeway_vector_chart",
+                    "label": "Chart the Wake Vectors",
                     "requirements": {
                         "items_any": [],
                         "flags_all": [
-                            "dyad_gmgn_twinned"
+                            "causeway_gmgn_lit"
                         ]
                     },
                     "roll": {
                         "kind": "phi_d20",
                         "tags": [
-                            "insight",
                             "analysis",
+                            "navigation",
                             "support"
                         ]
                     },
@@ -133,21 +133,21 @@
                         "crit_success": {
                             "effects": [
                                 {
-                                    "type": "focus",
-                                    "op": "+",
-                                    "value": 3
-                                },
-                                {
                                     "type": "xp",
                                     "value": 89
                                 },
                                 {
+                                    "type": "coins",
+                                    "op": "+",
+                                    "value": 34
+                                },
+                                {
                                     "type": "flag",
-                                    "id": "dyad_balance_logged",
+                                    "id": "causeway_vectors_logged",
                                     "value": true
                                 }
                             ],
-                            "narration": "You sketch the Dyad\u2019s energy curve into the ledger, capturing the moment when gold and cobalt share equilibrium. Engineers label your chart the \"Act Four fulcrum\" and pin it to every kiosk."
+                            "narration": "Your charts predict every gust before it arrives. Wake skiffs fall into formation and the hidden ultraviolet lane unfurls ahead."
                         },
                         "success": {
                             "effects": [
@@ -157,11 +157,11 @@
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "dyad_balance_logged",
+                                    "id": "causeway_vectors_logged",
                                     "value": true
                                 }
                             ],
-                            "narration": "Your readings steady the storms. Validators embed the data in their floating surfboard ledgers."
+                            "narration": "You map solid trajectories and pin them to hovering glyphs. Navigators salute and lock them in."
                         },
                         "fail": {
                             "effects": [
@@ -171,70 +171,70 @@
                                     "value": 13
                                 }
                             ],
-                            "narration": "You misjudge the lightning cadence and need to rent better sensors. The pity counter ticks up."
+                            "narration": "A surprise crosswind scrambles your projections. The pity buffer absorbs the cost of redoing the math."
                         },
                         "crit_fail": {
                             "effects": [
                                 {
                                     "type": "hp",
                                     "op": "-",
-                                    "value": 5
+                                    "value": 4
                                 }
                             ],
-                            "narration": "A rogue bolt scorches your notebook. Hackers hand you a fireproof replacement with a sympathetic grin."
+                            "narration": "You chase a rogue vector off the edge and dangle until miners haul you back with a lau gh."
                         }
                     },
                     "banter": {
-                        "dev": "Telemetry normalized.",
-                        "trader": "Balance sheet charted.",
-                        "whale": "Wake holds the midpoint.",
-                        "hacker": "Sensor mesh patched.",
-                        "shiller": "Publishing the Dyad index.",
-                        "validator": "Data notarized and archived.",
-                        "miner": "Log the voltage or it logs you.",
-                        "meme": "Storm spreadsheet drop when?"
+                        "dev": "Telemetry map overlays deploying.",
+                        "trader": "Vector futures priced in.",
+                        "whale": "Wake currents align with your plot.",
+                        "hacker": "Pathfinding nodes hardened.",
+                        "shiller": "Publishing the \"How to Cross a Miracle Bridge\" guide.",
+                        "validator": "Charts notarized in duplicate.",
+                        "miner": "Marking the stable footing seams.",
+                        "meme": "Vectors on vectors, it’s vector-tacular."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_balance_readings"
+                        "scene:4.6",
+                        "action:causeway_vector_chart"
                     ]
                 },
                 {
-                    "id": "dyad_afk_switch",
-                    "label": "Anchor AFK Switches",
+                    "id": "causeway_afk_anchor",
+                    "label": "Anchor the AFK Tethers",
                     "requirements": {
                         "items_any": [],
                         "flags_all": [
-                            "dyad_balance_logged"
+                            "causeway_gmgn_lit"
                         ]
                     },
                     "roll": {
                         "kind": "phi_d20",
                         "tags": [
-                            "engineering",
                             "support",
-                            "discipline"
+                            "engineering",
+                            "systems"
                         ]
                     },
                     "outcomes": {
                         "crit_success": {
                             "effects": [
                                 {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
                                     "type": "xp",
                                     "value": 55
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "afk_tracked",
-                                    "value": true
-                                },
-                                {
-                                    "type": "flag",
-                                    "id": "dyad_afk_network",
+                                    "id": "causeway_afk_webbed",
                                     "value": true
                                 }
                             ],
-                            "narration": "You install lightning-proof AFK switches around the terrace. Anyone idle for twenty-four hours gets zapped with a harmless static pulse and propelled into a force-play quest."
+                            "narration": "You weave glowing slacklines between pylons. Anyone drifting idle is gently reeled back with a cheerful chime."
                         },
                         "success": {
                             "effects": [
@@ -244,11 +244,11 @@
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "afk_tracked",
+                                    "id": "causeway_afk_webbed",
                                     "value": true
                                 }
                             ],
-                            "narration": "Switches click into place, ready to tattle on anyone who naps in the stormlight."
+                            "narration": "You secure enough tethers that the AFK monitors flash green."
                         },
                         "fail": {
                             "effects": [
@@ -256,34 +256,44 @@
                                     "type": "coins",
                                     "op": "-",
                                     "value": 8
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "causeway_pity_buffer",
+                                    "value": true
                                 }
                             ],
-                            "narration": "You cross two cables and owe the electricians a snack fee."
+                            "narration": "A tether snaps and you tip a vendor to keep it quiet while you splice a replacement."
                         },
                         "crit_fail": {
                             "effects": [
                                 {
                                     "type": "hp",
                                     "op": "-",
-                                    "value": 6
+                                    "value": 3
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "causeway_pity_buffer",
+                                    "value": true
                                 }
                             ],
-                            "narration": "You forget to ground yourself and the storms toss you into the air. You land on a cushion of validator ledgers."
+                            "narration": "You tangle yourself in the cables and have to be spun like a top to get free. The memers add circus music."
                         }
                     },
                     "banter": {
-                        "dev": "AFK toggles lightning-proofed.",
-                        "trader": "Idle tax rerouted to pity fund.",
-                        "whale": "Wake stays alert in every gust.",
-                        "hacker": "Fail-safes insulated.",
-                        "shiller": "Selling it as \"storm focus\".",
-                        "validator": "Switch logs notarized.",
-                        "miner": "Static keeps the drills awake.",
-                        "meme": "AFK stands for \"Arc-Flinged Kinetic\" now."
+                        "dev": "AFK lattice deployed end-to-end.",
+                        "trader": "Insurance premiums just dropped.",
+                        "whale": "Wake keeps the slack taut.",
+                        "hacker": "Failsafes double-encrypted.",
+                        "shiller": "Highlight reel of acrobatic rescues uploading.",
+                        "validator": "Safety compliance notarized.",
+                        "miner": "Tethers rated to haul ore carts if needed.",
+                        "meme": "AFK stands for \"Always Fastened Kiddo\" now."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_afk_switch"
+                        "scene:4.6",
+                        "action:causeway_afk_anchor"
                     ]
                 }
             ],
@@ -296,49 +306,40 @@
             ]
         },
         {
-            "round_id": "4.5-R2",
-            "description": "Lattice Loom Balcony \u2014 weave twin-charged gear, broker trustful pacts, and harvest insight sparks from the colliding storms.",
+            "round_id": "4.6-R2",
+            "description": "Momentum Calculus Gallery — balance the twin wake flux, predict lane assignments, and cache supply drops for the march ahead.",
             "actions": [
                 {
-                    "id": "dyad_lattice_weave",
-                    "label": "Forge the Boltweaver",
+                    "id": "causeway_flux_balance",
+                    "label": "Balance the Twin Flux",
                     "requirements": {
                         "items_any": [],
                         "flags_all": [
-                            "dyad_balance_logged"
+                            "causeway_vectors_logged"
                         ]
                     },
                     "roll": {
                         "kind": "phi_d20",
                         "tags": [
-                            "craft",
-                            "offense",
-                            "harmony"
+                            "analysis",
+                            "ritual",
+                            "resilience"
                         ]
                     },
                     "outcomes": {
                         "crit_success": {
                             "effects": [
                                 {
-                                    "type": "focus",
-                                    "op": "+",
-                                    "value": 3
-                                },
-                                {
                                     "type": "xp",
                                     "value": 144
                                 },
                                 {
-                                    "type": "item",
-                                    "id": "weapon_dyad_boltweaver"
-                                },
-                                {
                                     "type": "flag",
-                                    "id": "dyad_boltweaver_ready",
+                                    "id": "causeway_flux_balanced",
                                     "value": true
                                 }
                             ],
-                            "narration": "You braid gold lightning and cobalt shadow into a soft-power boltweaver whose strikes rewrite grudges instead of causing wounds."
+                            "narration": "You tune the bridge to absorb both dawn push and midnight pull. The plates settle into a steady heartbeat and hidden auroras flare approval."
                         },
                         "success": {
                             "effects": [
@@ -347,16 +348,12 @@
                                     "value": 55
                                 },
                                 {
-                                    "type": "item",
-                                    "id": "weapon_dyad_boltweaver"
-                                },
-                                {
                                     "type": "flag",
-                                    "id": "dyad_boltweaver_ready",
+                                    "id": "causeway_flux_balanced",
                                     "value": true
                                 }
                             ],
-                            "narration": "The boltweaver coils around your wrist, thrumming with stormlight."
+                            "narration": "Your calculations click into place. Flux monitors display a satisfying straight line."
                         },
                         "fail": {
                             "effects": [
@@ -364,54 +361,136 @@
                                     "type": "coins",
                                     "op": "-",
                                     "value": 21
-                                },
-                                {
-                                    "type": "flag",
-                                    "id": "dyad_pity_counter",
-                                    "value": true
                                 }
                             ],
-                            "narration": "The lattice snaps and flings your materials into the pit. The pity cache takes notes."
+                            "narration": "One storm gust surges ahead of the other. Traders collect a balancing fee while you reset the coils."
                         },
                         "crit_fail": {
                             "effects": [
                                 {
                                     "type": "hp",
                                     "op": "-",
-                                    "value": 6
+                                    "value": 5
                                 }
                             ],
-                            "narration": "A misaligned bolt scorches your gloves. The meme crew sells framed prints of the scorch mark."
+                            "narration": "You get caught between opposing gusts and spin like a compass needle before colliding with a friendly whale."
                         }
                     },
                     "banter": {
-                        "dev": "Boltweaver firmware signed.",
-                        "trader": "Stormstrike derivatives minted.",
-                        "whale": "Wake channels the surge.",
-                        "hacker": "No exploitable arcs detected.",
-                        "shiller": "Weaponize your charisma!",
-                        "validator": "Blueprint notarized.",
-                        "miner": "Lightning pickaxe vibes.",
-                        "meme": "Conduct yourself responsibly."
+                        "dev": "Flux stabilizer firmware updated.",
+                        "trader": "Spread between storms narrowing nicely.",
+                        "whale": "Wake hums in harmonic balance.",
+                        "hacker": "Feedback loops sandboxed.",
+                        "shiller": "Marketing this as \"wind surfing for consensus\".",
+                        "validator": "Flux ledger certified.",
+                        "miner": "Bridge stops rattling my teeth.",
+                        "meme": "Perfectly balanced, as all bridges should be."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_lattice_weave"
+                        "scene:4.6",
+                        "action:causeway_flux_balance"
                     ]
                 },
                 {
-                    "id": "dyad_trust_pact",
-                    "label": "Broker Trustful Pacts",
+                    "id": "causeway_lane_prediction",
+                    "label": "Predict Traveler Lanes",
                     "requirements": {
                         "items_any": [],
                         "flags_all": [
-                            "dyad_boltweaver_ready"
+                            "causeway_flux_balanced"
                         ]
                     },
                     "roll": {
                         "kind": "phi_d20",
                         "tags": [
-                            "negotiation",
+                            "strategy",
+                            "navigation",
+                            "insight"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "causeway_lane_marked",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You lay out braided lanes for shy travelers, hype squads, and heavy cargo teams. Aurora beacons tag each route and the meme crew prints commemorative maps."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "causeway_lane_marked",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You assign corridors that keep the bridge flowing. Validators stamp every lane marker."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 13
+                                }
+                            ],
+                            "narration": "Two squads collide in a whirl of banners. You reimburse the spilled snacks and try aga in."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 4
+                                }
+                            ],
+                            "narration": "You accidentally designate a lane straight through a wind shear. Rescue nets catch you before the meme crew finishes laughing."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Lane prediction AI validated.",
+                        "trader": "Congestion futures trending down.",
+                        "whale": "Wake claims the express lane.",
+                        "hacker": "Navigation beacons patched for exploits.",
+                        "shiller": "Influencer lanes already sponsored.",
+                        "validator": "Right-of-way stamped and notarized.",
+                        "miner": "Reserve a lane for ore carts and café stops.",
+                        "meme": "Slow lane? No, vibe lane."
+                    },
+                    "telemetry_tags": [
+                        "scene:4.6",
+                        "action:causeway_lane_prediction"
+                    ]
+                },
+                {
+                    "id": "causeway_supply_preposition",
+                    "label": "Preposition Wake Supplies",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "causeway_flux_balanced"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "logistics",
                             "support",
                             "economy"
                         ]
@@ -426,15 +505,15 @@
                                 {
                                     "type": "coins",
                                     "op": "+",
-                                    "value": 55
+                                    "value": 34
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "trustful",
+                                    "id": "causeway_supply_cached",
                                     "value": true
                                 }
                             ],
-                            "narration": "You wield the boltweaver as a pen, signing dual-storm contracts that guarantee trust dividends each time consensus sparks."
+                            "narration": "You choreograph supply drones to drop crates at every terrace just as squads arrive. The bridge applauds with synchronized light pulses."
                         },
                         "success": {
                             "effects": [
@@ -444,11 +523,11 @@
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "trustful",
+                                    "id": "causeway_supply_cached",
                                     "value": true
                                 }
                             ],
-                            "narration": "The storms agree to share some goodwill. Traders celebrate with sparkling electrolyte shots."
+                            "narration": "You stash enough consumables along the span that no one will go hungry or gearless."
                         },
                         "fail": {
                             "effects": [
@@ -458,92 +537,7 @@
                                     "value": 13
                                 }
                             ],
-                            "narration": "You forget to hedge the cobalt clause and owe a late fee."
-                        },
-                        "crit_fail": {
-                            "effects": [
-                                {
-                                    "type": "hp",
-                                    "op": "-",
-                                    "value": 5
-                                }
-                            ],
-                            "narration": "A lightning squiggle zaps your signature line. Validators hand you a stylus made of rubber."
-                        }
-                    },
-                    "banter": {
-                        "dev": "Trust ledger patched.",
-                        "trader": "Spreads tighten with every handshake.",
-                        "whale": "Wake invests in mutual promises.",
-                        "hacker": "Contracts hashed and secure.",
-                        "shiller": "Trust is trending.",
-                        "validator": "Signatures notarized in stereo.",
-                        "miner": "No trust, no tunnels.",
-                        "meme": "Trust fall, now with lightning."
-                    },
-                    "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_trust_pact"
-                    ]
-                },
-                {
-                    "id": "dyad_insight_prism",
-                    "label": "Harvest Insight Sparks",
-                    "requirements": {
-                        "items_any": [],
-                        "flags_all": []
-                    },
-                    "roll": {
-                        "kind": "phi_d20",
-                        "tags": [
-                            "insight",
-                            "exploration",
-                            "harmony"
-                        ]
-                    },
-                    "outcomes": {
-                        "crit_success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 55
-                                },
-                                {
-                                    "type": "flag",
-                                    "id": "insight",
-                                    "value": true
-                                },
-                                {
-                                    "type": "coins",
-                                    "op": "+",
-                                    "value": 21
-                                }
-                            ],
-                            "narration": "You catch sparks in a prism jar and learn how the storms precompute consensus outcomes. The jar hums with future hints."
-                        },
-                        "success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 34
-                                },
-                                {
-                                    "type": "flag",
-                                    "id": "insight",
-                                    "value": true
-                                }
-                            ],
-                            "narration": "You snag a few sparks and pocket them before they fade."
-                        },
-                        "fail": {
-                            "effects": [
-                                {
-                                    "type": "coins",
-                                    "op": "-",
-                                    "value": 8
-                                }
-                            ],
-                            "narration": "You chase a spark into a gust and lose your footing, paying a tip to the medics who keep you upright."
+                            "narration": "A drone drops crates into the abyss. Traders sigh and sell you replacement inventory at a discount."
                         },
                         "crit_fail": {
                             "effects": [
@@ -553,22 +547,22 @@
                                     "value": 4
                                 }
                             ],
-                            "narration": "A spark fizzles in your palm and shocks your eyebrows upright for the next hour."
+                            "narration": "You get buried under a mistimed supply avalanche. Miners dig you out with sympathetic grin."
                         }
                     },
                     "banter": {
-                        "dev": "Insight capture pipeline humming.",
-                        "trader": "Forecast tokens minted.",
-                        "whale": "Wake drinks the sparks like espresso.",
-                        "hacker": "Telemetry sanitized for leaks.",
-                        "shiller": "Selling bottled lightning!",
-                        "validator": "Logs notarized mid-air.",
-                        "miner": "Spark today, ore tomorrow.",
-                        "meme": "This forecast slaps."
+                        "dev": "Inventory sync finished.",
+                        "trader": "Margins locked before the run.",
+                        "whale": "Wake underwriting the cargo insurance.",
+                        "hacker": "Delivery bots patched against hijacks.",
+                        "shiller": "Pop-up kiosks go live in five.",
+                        "validator": "Manifests notarized midair.",
+                        "miner": "Snack caches near every drill point? Bless.",
+                        "meme": "Supply drops? More like surprise drops."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_insight_prism"
+                        "scene:4.6",
+                        "action:causeway_supply_preposition"
                     ]
                 }
             ],
@@ -580,16 +574,16 @@
             ]
         },
         {
-            "round_id": "4.5-R3",
-            "description": "Soft-Power Smithies \u2014 temper dual-aspect armor, crown, and trinkets to keep players grounded in the storm.",
+            "round_id": "4.6-R3",
+            "description": "Wake Loom Workshops — spin soft-power armor, tune trinkets, and braid emblems that carry the causeway dream forward.",
             "actions": [
                 {
-                    "id": "dyad_armor_fluxcloak",
-                    "label": "Weave the Fluxcloak",
+                    "id": "causeway_softgear_spin",
+                    "label": "Spin Parallax Cloaks",
                     "requirements": {
                         "items_any": [],
                         "flags_all": [
-                            "dyad_boltweaver_ready"
+                            "causeway_flux_balanced"
                         ]
                     },
                     "roll": {
@@ -597,7 +591,7 @@
                         "tags": [
                             "craft",
                             "defense",
-                            "harmony"
+                            "support"
                         ]
                     },
                     "outcomes": {
@@ -605,19 +599,19 @@
                             "effects": [
                                 {
                                     "type": "xp",
-                                    "value": 89
+                                    "value": 144
                                 },
                                 {
                                     "type": "item",
-                                    "id": "armor_dyad_fluxcloak"
+                                    "id": "armor_causeway_parallax"
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "dyad_fluxcloak_worn",
+                                    "id": "causeway_softgear_spun",
                                     "value": true
                                 }
                             ],
-                            "narration": "You weave alternating bands of dawn silk and midnight mylar, creating a cloak that redirects lightning into motivational speeches."
+                            "narration": "You weave cloaks that refract wake light, letting squads slip between gusts without losing speed."
                         },
                         "success": {
                             "effects": [
@@ -626,16 +620,12 @@
                                     "value": 55
                                 },
                                 {
-                                    "type": "item",
-                                    "id": "armor_dyad_fluxcloak"
-                                },
-                                {
                                     "type": "flag",
-                                    "id": "dyad_fluxcloak_worn",
+                                    "id": "causeway_softgear_spun",
                                     "value": true
                                 }
                             ],
-                            "narration": "The fluxcloak drapes around your shoulders, fluttering whenever consensus spikes."
+                            "narration": "Your cloaks hold their charge and shimmer with a steady protective glow."
                         },
                         "fail": {
                             "effects": [
@@ -645,41 +635,41 @@
                                     "value": 21
                                 }
                             ],
-                            "narration": "The cloak frays at the seam and you donate the scraps to the pity vault."
+                            "narration": "Your loom knots itself into a pretzel. You buy more thread and promise to laugh about it later."
                         },
                         "crit_fail": {
                             "effects": [
                                 {
                                     "type": "hp",
                                     "op": "-",
-                                    "value": 7
+                                    "value": 5
                                 }
                             ],
-                            "narration": "You get tangled in the loom and tumble into a bin of static-charged ribbon."
+                            "narration": "A cloak discharges in your face, leaving you with static hair and an appreciative crow d."
                         }
                     },
                     "banter": {
-                        "dev": "Fluxcloak patch ready.",
-                        "trader": "Storm insurance included.",
-                        "whale": "Wake flows along the hem.",
-                        "hacker": "Anti-zap lining verified.",
-                        "shiller": "New fashion drop: lightning couture.",
-                        "validator": "Armor rating notarized.",
-                        "miner": "Looks warm enough for tunnels.",
-                        "meme": "Serving weather-resistant realness."
+                        "dev": "Cloak schema uploaded.",
+                        "trader": "Soft-power futures spike on that weave.",
+                        "whale": "Wake threads feel luxurious.",
+                        "hacker": "No cloak exploits detected.",
+                        "shiller": "Launching \"Project Parallax\" hype page.",
+                        "validator": "Durability notarized.",
+                        "miner": "Finally, armor that doesn’t snag on picks.",
+                        "meme": "These cloaks slap harder than a gust."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_armor_fluxcloak"
+                        "scene:4.6",
+                        "action:causeway_softgear_spin"
                     ]
                 },
                 {
-                    "id": "dyad_helm_parallax",
-                    "label": "Cast the Parallax Crown",
+                    "id": "causeway_trinket_waveguide",
+                    "label": "Tune Waveguide Trinkets",
                     "requirements": {
                         "items_any": [],
                         "flags_all": [
-                            "dyad_fluxcloak_worn"
+                            "causeway_softgear_spun"
                         ]
                     },
                     "roll": {
@@ -687,7 +677,7 @@
                         "tags": [
                             "craft",
                             "insight",
-                            "vision"
+                            "resonance"
                         ]
                     },
                     "outcomes": {
@@ -699,15 +689,15 @@
                                 },
                                 {
                                     "type": "item",
-                                    "id": "helm_dyad_parallax"
+                                    "id": "trinket_causeway_waveguide"
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "insight",
+                                    "id": "causeway_trinkets_tuned",
                                     "value": true
                                 }
                             ],
-                            "narration": "You fuse mirrored lightning rods into a circlet that lets you see both futures at once: what happens if dawn wins, and what happens if midnight rallies."
+                            "narration": "Your trinkets pulse in sync with the bridge, rerouting gusts toward allies who need the boost most."
                         },
                         "success": {
                             "effects": [
@@ -716,101 +706,12 @@
                                     "value": 55
                                 },
                                 {
-                                    "type": "item",
-                                    "id": "helm_dyad_parallax"
-                                },
-                                {
                                     "type": "flag",
-                                    "id": "insight",
+                                    "id": "causeway_trinkets_tuned",
                                     "value": true
                                 }
                             ],
-                            "narration": "The crown hums with layered predictions, gently nudging your decisions toward the golden ratio."
-                        },
-                        "fail": {
-                            "effects": [
-                                {
-                                    "type": "focus",
-                                    "op": "-",
-                                    "value": 1
-                                }
-                            ],
-                            "narration": "You overheat the crown mold and have to wait for it to cool, losing a sliver of confidence."
-                        },
-                        "crit_fail": {
-                            "effects": [
-                                {
-                                    "type": "hp",
-                                    "op": "-",
-                                    "value": 6
-                                }
-                            ],
-                            "narration": "The crown closes while you\u2019re fitting it, giving you a static hairstyle worthy of the meme feed."
-                        }
-                    },
-                    "banter": {
-                        "dev": "Parallax runtime linked to HUD.",
-                        "trader": "Forecast spread updated.",
-                        "whale": "Wake enjoys the dual vantage.",
-                        "hacker": "Prediction engine scrubbed.",
-                        "shiller": "Selling \"see both storms\" eyewear.",
-                        "validator": "Sight metrics notarized.",
-                        "miner": "Can it spot ore veins too?",
-                        "meme": "Two futures, one crown."
-                    },
-                    "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_helm_parallax"
-                    ]
-                },
-                {
-                    "id": "dyad_trinket_capacitor",
-                    "label": "Charge the Storm Capacitor",
-                    "requirements": {
-                        "items_any": [],
-                        "flags_all": [
-                            "dyad_fluxcloak_worn"
-                        ]
-                    },
-                    "roll": {
-                        "kind": "phi_d20",
-                        "tags": [
-                            "craft",
-                            "utility",
-                            "luck"
-                        ]
-                    },
-                    "outcomes": {
-                        "crit_success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 55
-                                },
-                                {
-                                    "type": "item",
-                                    "id": "trinket_dyad_capacitor"
-                                },
-                                {
-                                    "type": "coins",
-                                    "op": "+",
-                                    "value": 34
-                                }
-                            ],
-                            "narration": "You bottle excess lightning into a capacitor charm that can discharge to power consensus rituals or jump-start idle allies."
-                        },
-                        "success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 34
-                                },
-                                {
-                                    "type": "item",
-                                    "id": "trinket_dyad_capacitor"
-                                }
-                            ],
-                            "narration": "The capacitor hums with stored goodwill, ready to release a motivational jolt."
+                            "narration": "Each charm hums with a reliable wake beacon ready to slot into backpacks."
                         },
                         "fail": {
                             "effects": [
@@ -820,32 +721,119 @@
                                     "value": 13
                                 }
                             ],
-                            "narration": "You overfill the charm and it pops, leaving you with a small invoice and a big lesson."
+                            "narration": "A charm whistles off-key and startles the workshop. You refund the snacks you spilled."
                         },
                         "crit_fail": {
                             "effects": [
                                 {
                                     "type": "hp",
                                     "op": "-",
-                                    "value": 5
+                                    "value": 4
                                 }
                             ],
-                            "narration": "The capacitor discharges into your fingertips. You shake them out while everyone applauds your endurance."
+                            "narration": "You amplify a resonance node until it smacks you into a wall. Audience roars appreciati on."
                         }
                     },
                     "banter": {
-                        "dev": "Capacitor module stable.",
-                        "trader": "Charge futures trending.",
-                        "whale": "Wake shares spare volts.",
-                        "hacker": "No short-circuits detected.",
-                        "shiller": "Charm doubles as a rave accessory.",
-                        "validator": "Charge logs notarized.",
-                        "miner": "Save that jolt for drill jams.",
-                        "meme": "I\u2019m positively charged about this."
+                        "dev": "Waveguide firmware stable.",
+                        "trader": "Charm market heating up.",
+                        "whale": "Wake sings through those trinkets.",
+                        "hacker": "Signal leakage patched.",
+                        "shiller": "Waveguide giveaway inbound.",
+                        "validator": "Harmonics notarized.",
+                        "miner": "Clip one to every hard hat.",
+                        "meme": "These baubles bussin'."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_trinket_capacitor"
+                        "scene:4.6",
+                        "action:causeway_trinket_waveguide"
+                    ]
+                },
+                {
+                    "id": "causeway_emblem_braid",
+                    "label": "Braid Wake Emblems",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "causeway_trinkets_tuned"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "craft",
+                            "spirit",
+                            "leadership"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "causeway_emblems_braided",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You braid emblems that shimmer between guild colors, uniting every faction under a sin gle wake standard."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "causeway_emblems_braided",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Your emblems catch the light and get pinned to jackets across the workshop."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 8
+                                }
+                            ],
+                            "narration": "A knot slips loose and your banner unravels mid-chant. You pay the choir in snacks for a redo."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 3
+                                }
+                            ],
+                            "narration": "You tug two guild colors too hard and get smacked by both ribbons."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Brand assets approved.",
+                        "trader": "Emblem derivatives already trading.",
+                        "whale": "Wake carries every color.",
+                        "hacker": "No counterfeit threads slip past.",
+                        "shiller": "Merch drop? Merch deluge.",
+                        "validator": "Official standard notarized.",
+                        "miner": "Pinning this to the front of the drill.",
+                        "meme": "Flag on the play? Nah, flag on the bridge."
+                    },
+                    "telemetry_tags": [
+                        "scene:4.6",
+                        "action:causeway_emblem_braid"
                     ]
                 }
             ],
@@ -858,16 +846,16 @@
             ]
         },
         {
-            "round_id": "4.5-R4",
-            "description": "Storm Market Mezzanine \u2014 redeem pity charges, rebalance backpacks, and chart shy-and-trust lanes through the gale.",
+            "round_id": "4.6-R4",
+            "description": "Logistics Promenade — prime the pity reservoir, broker wake trades, and repack backpacks before the bri dge charge.",
             "actions": [
                 {
-                    "id": "dyad_pity_channel",
-                    "label": "Open the Pity Channel",
+                    "id": "causeway_pity_prime",
+                    "label": "Prime the Pity Reservoir",
                     "requirements": {
                         "items_any": [],
                         "flags_all": [
-                            "dyad_pity_counter"
+                            "causeway_flux_balanced"
                         ]
                     },
                     "roll": {
@@ -886,16 +874,17 @@
                                     "value": 89
                                 },
                                 {
-                                    "type": "item",
-                                    "id": "deck_dyad_tempest"
+                                    "type": "coins",
+                                    "op": "+",
+                                    "value": 55
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "dyad_market_open",
+                                    "id": "causeway_pity_open",
                                     "value": true
                                 }
                             ],
-                            "narration": "You plug the pity counter straight into the market and siphon a tempest deck loaded with dual-storm boons."
+                            "narration": "You flood the depot with goodwill credits. Vendors cheer and unlock a hidden shelf of bridge-only boons."
                         },
                         "success": {
                             "effects": [
@@ -904,27 +893,22 @@
                                     "value": 55
                                 },
                                 {
-                                    "type": "coins",
-                                    "op": "+",
-                                    "value": 55
-                                },
-                                {
                                     "type": "flag",
-                                    "id": "dyad_market_open",
+                                    "id": "causeway_pity_open",
                                     "value": true
                                 }
                             ],
-                            "narration": "Pity charges flow into discounts. Shopkeepers fling you insulated tote bags stuffed with consumables."
+                            "narration": "Pity ledgers glow steady green. Gremlin cashiers ring bells in gratitude."
                         },
                         "fail": {
                             "effects": [
                                 {
                                     "type": "coins",
                                     "op": "-",
-                                    "value": 13
+                                    "value": 21
                                 }
                             ],
-                            "narration": "You mispronounce a vendor\u2019s name and pay a politeness penalty."
+                            "narration": "A ledger hiccup double-charges you before refunding the difference as store credit."
                         },
                         "crit_fail": {
                             "effects": [
@@ -934,219 +918,39 @@
                                     "value": 4
                                 }
                             ],
-                            "narration": "A gust flips your receipts into the storm. You chase them while everyone cheers."
+                            "narration": "You trip over a pity hose and spray yourself in confetti. The depot erupts in applause."
                         }
                     },
                     "banter": {
-                        "dev": "Pity API surge-tested.",
-                        "trader": "Discount winds blowing.",
-                        "whale": "Wake subsidizes the stalls.",
-                        "hacker": "Double-entry refunds confirmed.",
-                        "shiller": "Flash sale: lightning loyalty.",
-                        "validator": "Invoices notarized mid-gale.",
-                        "miner": "Finally, a sale on grounded boots.",
-                        "meme": "Pity? More like litty."
+                        "dev": "Pity backend scaled for surge.",
+                        "trader": "Liquidity unlocked for every ledger.",
+                        "whale": "Wake underwrites the reservoir.",
+                        "hacker": "Refund scripts audited.",
+                        "shiller": "Calling it the Charity Charge.",
+                        "validator": "Deposits notarized with sparkles.",
+                        "miner": "Buying everyone pit-stop café tokens.",
+                        "meme": "Pity party? More like litty party, round two."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_pity_channel"
+                        "scene:4.6",
+                        "action:causeway_pity_prime"
                     ]
                 },
                 {
-                    "id": "dyad_backpack_realign",
-                    "label": "Realign Storm Backpacks",
+                    "id": "causeway_trade_manifest",
+                    "label": "Broker Wake Trades",
                     "requirements": {
                         "items_any": [],
                         "flags_all": [
-                            "dyad_market_open"
+                            "causeway_pity_open"
                         ]
                     },
                     "roll": {
                         "kind": "phi_d20",
                         "tags": [
-                            "logistics",
-                            "analysis",
-                            "support"
-                        ]
-                    },
-                    "outcomes": {
-                        "crit_success": {
-                            "effects": [
-                                {
-                                    "type": "focus",
-                                    "op": "+",
-                                    "value": 3
-                                },
-                                {
-                                    "type": "xp",
-                                    "value": 55
-                                },
-                                {
-                                    "type": "coins",
-                                    "op": "+",
-                                    "value": 34
-                                }
-                            ],
-                            "narration": "You reorganize every backpack so the gold storm fuels offense pockets and the cobalt storm powers defense slots. Traders start copying your layout instantly."
-                        },
-                        "success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 34
-                                }
-                            ],
-                            "narration": "Backpacks click into tidy alignment. Gremlin inspectors salute."
-                        },
-                        "fail": {
-                            "effects": [
-                                {
-                                    "type": "focus",
-                                    "op": "-",
-                                    "value": 1
-                                }
-                            ],
-                            "narration": "You chase loose straps through a crosswind until you need a breather."
-                        },
-                        "crit_fail": {
-                            "effects": [
-                                {
-                                    "type": "hp",
-                                    "op": "-",
-                                    "value": 4
-                                }
-                            ],
-                            "narration": "A rogue gust slams a backpack into your face. The meme division applauds the slapstick."
-                        }
-                    },
-                    "banter": {
-                        "dev": "Inventory schema updated.",
-                        "trader": "Bag flow optimized.",
-                        "whale": "Wake carries the heavy loads.",
-                        "hacker": "No contraband survive that sort.",
-                        "shiller": "Backpack balancing service launching soon.",
-                        "validator": "Checklists notarized in duplicate.",
-                        "miner": "Now my pick sits snug.",
-                        "meme": "Storm Marie Kondo."
-                    },
-                    "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_backpack_realign"
-                    ]
-                },
-                {
-                    "id": "dyad_lane_cartography",
-                    "label": "Chart Trust & Shy Lanes",
-                    "requirements": {
-                        "items_any": [],
-                        "flags_all": []
-                    },
-                    "roll": {
-                        "kind": "phi_d20",
-                        "tags": [
-                            "insight",
-                            "support",
-                            "navigation"
-                        ]
-                    },
-                    "outcomes": {
-                        "crit_success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 55
-                                },
-                                {
-                                    "type": "flag",
-                                    "id": "trustful",
-                                    "value": true
-                                },
-                                {
-                                    "type": "flag",
-                                    "id": "shy",
-                                    "value": true
-                                }
-                            ],
-                            "narration": "You map alternating lanes for loud trust rallies and quiet shy retreats so everyone can traverse the storm in comfort."
-                        },
-                        "success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 34
-                                },
-                                {
-                                    "type": "flag",
-                                    "id": "trustful",
-                                    "value": true
-                                }
-                            ],
-                            "narration": "You label pathways that minimize collisions. Validators project them into the air."
-                        },
-                        "fail": {
-                            "effects": [
-                                {
-                                    "type": "coins",
-                                    "op": "-",
-                                    "value": 8
-                                }
-                            ],
-                            "narration": "Your chalk map washes away in a gust. The pity ledger replenishes some markers."
-                        },
-                        "crit_fail": {
-                            "effects": [
-                                {
-                                    "type": "hp",
-                                    "op": "-",
-                                    "value": 4
-                                }
-                            ],
-                            "narration": "You take a wrong step and ride a wind tunnel headfirst into a banner. Everyone laughs kindly."
-                        }
-                    },
-                    "banter": {
-                        "dev": "Storm routing overlay deployed.",
-                        "trader": "Traffic flows smoother already.",
-                        "whale": "Wake glides down the trust lane.",
-                        "hacker": "Navigation beacons secure.",
-                        "shiller": "Guided tours now available.",
-                        "validator": "Routes notarized.",
-                        "miner": "Short path to the ore vendor, thanks.",
-                        "meme": "Trust lane? More like gust lane."
-                    },
-                    "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_lane_cartography"
-                    ]
-                }
-            ],
-            "rewards": [
-                {
-                    "type": "focus",
-                    "op": "+",
-                    "value": 2
-                }
-            ]
-        },
-        {
-            "round_id": "4.5-R5",
-            "description": "Reboot Platform \u2014 jolt fallen allies, enforce AFK treadmill routines, and signal arrivals surfed in on storm droplets.",
-            "actions": [
-                {
-                    "id": "dyad_revive",
-                    "label": "Shock a Fallen Ally",
-                    "requirements": {
-                        "items_any": [],
-                        "flags_all": [
-                            "dyad_afk_network"
-                        ]
-                    },
-                    "roll": {
-                        "kind": "phi_d20",
-                        "tags": [
-                            "revive",
-                            "support",
-                            "ritual"
+                            "economy",
+                            "negotiation",
+                            "strategy"
                         ]
                     },
                     "outcomes": {
@@ -1157,113 +961,31 @@
                                     "value": 89
                                 },
                                 {
-                                    "type": "focus",
-                                    "op": "+",
-                                    "value": 3
-                                },
-                                {
-                                    "type": "flag",
-                                    "id": "harmony",
-                                    "value": true
-                                }
-                            ],
-                            "narration": "You inscribe a spiral of storm glyphs around the fallen ally and release the capacitor charm. They reboot laughing, hair fizzing with static harmony."
-                        },
-                        "success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 55
-                                }
-                            ],
-                            "narration": "The ally jolts upright, blinking away residual lightning."
-                        },
-                        "fail": {
-                            "effects": [
-                                {
-                                    "type": "focus",
-                                    "op": "-",
-                                    "value": 1
-                                }
-                            ],
-                            "narration": "You mix up the polarity and have to start the ritual again, muttering apologies."
-                        },
-                        "crit_fail": {
-                            "effects": [
-                                {
-                                    "type": "hp",
-                                    "op": "-",
-                                    "value": 5
-                                }
-                            ],
-                            "narration": "You catch the rebound arc and tumble into a pile of insulated pillows. The meme crew adds thunder sound effects."
-                        }
-                    },
-                    "banter": {
-                        "dev": "Revive routine electrified.",
-                        "trader": "Resurrection futures surge.",
-                        "whale": "Wake cushions the landing.",
-                        "hacker": "Checksum validated mid-bolt.",
-                        "shiller": "Stormshock loyalty perk!",
-                        "validator": "Revival logged and notarized.",
-                        "miner": "Back on your feet; drills await.",
-                        "meme": "Static hair, don\u2019t care."
-                    },
-                    "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_revive"
-                    ]
-                },
-                {
-                    "id": "dyad_afk_force",
-                    "label": "Start AFK Treadmills",
-                    "requirements": {
-                        "items_any": [],
-                        "flags_all": [
-                            "dyad_afk_network"
-                        ]
-                    },
-                    "roll": {
-                        "kind": "phi_d20",
-                        "tags": [
-                            "automation",
-                            "discipline",
-                            "support"
-                        ]
-                    },
-                    "outcomes": {
-                        "crit_success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 55
-                                },
-                                {
                                     "type": "coins",
                                     "op": "+",
-                                    "value": 21
+                                    "value": 55
                                 }
                             ],
-                            "narration": "You sync the treadmills to storm tempo. Idle players jog into micro-quests while the Dyad pays you a maintenance bonus."
+                            "narration": "You broker swaps between guild stockpiles so every squad gets the precise boost they ne ed."
                         },
                         "success": {
                             "effects": [
                                 {
                                     "type": "xp",
-                                    "value": 34
+                                    "value": 55
                                 }
                             ],
-                            "narration": "Force-play mode engages with a friendly chime."
+                            "narration": "Trades close smoothly. Traders wink and toss you commemorative scrip."
                         },
                         "fail": {
                             "effects": [
                                 {
-                                    "type": "focus",
+                                    "type": "coins",
                                     "op": "-",
-                                    "value": 1
+                                    "value": 13
                                 }
                             ],
-                            "narration": "You broadcast the reminder at the wrong tempo and a whale side-eyes you before stepping on."
+                            "narration": "A miscommunication sends two pallets the wrong way. You pay the rerouting fee."
                         },
                         "crit_fail": {
                             "effects": [
@@ -1273,52 +995,56 @@
                                     "value": 4
                                 }
                             ],
-                            "narration": "You forget to step off your own treadmill and faceplant. Validators help you up between giggles."
+                            "narration": "You hype a deal so hard that the floor tilts, dumping you into a crate of foam peanuts."
                         }
                     },
                     "banter": {
-                        "dev": "Force-play daemon synced.",
-                        "trader": "Idle tax repurposed as cardio.",
-                        "whale": "Wake keeps the pace.",
-                        "hacker": "Scripts monitored for loops.",
-                        "shiller": "Storm gym membership unlocked.",
-                        "validator": "Treadmill logs notarized.",
-                        "miner": "Can we set incline to \"mountain\"?",
-                        "meme": "AFK now stands for \"Always Flexing Knees\"."
+                        "dev": "Market middleware humming.",
+                        "trader": "Slippage near zero.",
+                        "whale": "Wake secures every swap.",
+                        "hacker": "Smart contracts double-checked.",
+                        "shiller": "Live auction commentary trending.",
+                        "validator": "Receipts stamped with glitter seals.",
+                        "miner": "Traded ore futures for stamina tonics.",
+                        "meme": "Buy low, yeet high."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_afk_force"
+                        "scene:4.6",
+                        "action:causeway_trade_manifest"
                     ]
                 },
                 {
-                    "id": "dyad_arrival_signal",
-                    "label": "Signal Storm Arrivals",
+                    "id": "causeway_backpack_repack",
+                    "label": "Repack Causeway Backpacks",
                     "requirements": {
                         "items_any": [],
-                        "flags_all": []
+                        "flags_all": [
+                            "causeway_pity_open",
+                            "causeway_supply_cached"
+                        ]
                     },
                     "roll": {
                         "kind": "phi_d20",
                         "tags": [
-                            "communication",
+                            "logistics",
                             "support",
-                            "ritual"
+                            "discipline"
                         ]
                     },
                     "outcomes": {
                         "crit_success": {
                             "effects": [
                                 {
-                                    "type": "xp",
-                                    "value": 55
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
                                 },
                                 {
-                                    "type": "item",
-                                    "id": "weapon_dyad_lightningbug"
+                                    "type": "xp",
+                                    "value": 55
                                 }
                             ],
-                            "narration": "You release a swarm of lightningbugs that sketch the GMGN motif across the storms. New arrivals surf down the trails, cheering."
+                            "narration": "You reseat gear so well that the bridge itself sighs in satisfaction. Everyone moves like a choreographed parade."
                         },
                         "success": {
                             "effects": [
@@ -1327,7 +1053,7 @@
                                     "value": 34
                                 }
                             ],
-                            "narration": "You ping the arrival gong. A pair of drenched but smiling gremlins tumble in."
+                            "narration": "Backpacks snap closed with perfect weight distribution."
                         },
                         "fail": {
                             "effects": [
@@ -1337,32 +1063,32 @@
                                     "value": 8
                                 }
                             ],
-                            "narration": "You mistime the signal and only attract storm gulls, who demand snacks."
+                            "narration": "You mislabel a pouch and have to refund the resulting scavenger hunt."
                         },
                         "crit_fail": {
                             "effects": [
                                 {
                                     "type": "hp",
                                     "op": "-",
-                                    "value": 4
+                                    "value": 3
                                 }
                             ],
-                            "narration": "You stand too close to the gong and it rattles your bones. Everyone still applauds the effort."
+                            "narration": "A strap snaps and slingshots you into a pity fountain."
                         }
                     },
                     "banter": {
-                        "dev": "Onboarding channel reopened.",
-                        "trader": "Fresh liquidity slides in.",
-                        "whale": "Wake catches new surfers.",
-                        "hacker": "Invite tokens air-dropped.",
-                        "shiller": "Influencer storm party!",
-                        "validator": "Arrivals notarized.",
-                        "miner": "More hands for the lightning rods.",
-                        "meme": "New storm, who dis?"
+                        "dev": "Inventory versioning on point.",
+                        "trader": "Bag weight balanced like a ledger.",
+                        "whale": "Wake keeps the straps from biting.",
+                        "hacker": "No contraband zipped inside.",
+                        "shiller": "Unboxing stream scheduled.",
+                        "validator": "Checklist stamped per pouch.",
+                        "miner": "My kit finally stops squeaking.",
+                        "meme": "Bag check? More like brag check."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_arrival_signal"
+                        "scene:4.6",
+                        "action:causeway_backpack_repack"
                     ]
                 }
             ],
@@ -1374,24 +1100,24 @@
             ]
         },
         {
-            "round_id": "4.5-R6",
-            "description": "Spectrum Gate Catwalk \u2014 align the twin doorways, distribute focus charges, and project threshold metrics across the Dyad.",
+            "round_id": "4.6-R5",
+            "description": "Revival Span — ignite the wake ward, rehearse force-play drills, and breathe focus into the squads.",
             "actions": [
                 {
-                    "id": "dyad_gate_modulate",
-                    "label": "Modulate the Twin Door",
+                    "id": "causeway_revive_field",
+                    "label": "Ignite the Revival Field",
                     "requirements": {
                         "items_any": [],
                         "flags_all": [
-                            "dyad_balance_logged"
+                            "causeway_flux_balanced"
                         ]
                     },
                     "roll": {
                         "kind": "phi_d20",
                         "tags": [
-                            "ritual",
-                            "engineering",
-                            "focus"
+                            "support",
+                            "healing",
+                            "ritual"
                         ]
                     },
                     "outcomes": {
@@ -1408,11 +1134,11 @@
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "dyad_gate_tuned",
+                                    "id": "causeway_revive_online",
                                     "value": true
                                 }
                             ],
-                            "narration": "You tune two spectrum doors so they overlap like a Venn diagram of light. The storms settle, agreeing to funnel consensus through your alignment."
+                            "narration": "You ignite a halo that revives anyone who touches the floor. Exhaustion evaporates in golden mist."
                         },
                         "success": {
                             "effects": [
@@ -1422,63 +1148,145 @@
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "dyad_gate_tuned",
+                                    "id": "causeway_revive_online",
                                     "value": true
                                 }
                             ],
-                            "narration": "The doors hum at the same pitch, ready to accept the vote."
+                            "narration": "The ward thrums and medics cheer. Anyone slipping can bounce back instantly."
                         },
                         "fail": {
                             "effects": [
                                 {
-                                    "type": "focus",
+                                    "type": "coins",
                                     "op": "-",
-                                    "value": 1
+                                    "value": 13
                                 }
                             ],
-                            "narration": "You misalign a prism and the doors flicker. Engineers nudge them back on track with gentle advice."
+                            "narration": "The halo flickers. You pay the technicians overtime to patch the relay."
                         },
                         "crit_fail": {
                             "effects": [
                                 {
                                     "type": "hp",
                                     "op": "-",
-                                    "value": 6
+                                    "value": 4
                                 }
                             ],
-                            "narration": "You get caught between the doors mid-oscillation and stumble out with your hair glowing."
+                            "narration": "The ward backfires with a static pop that leaves you glowing neon for a minute."
                         }
                     },
                     "banter": {
-                        "dev": "Twin door firmware merged.",
-                        "trader": "Spectrum spreads anchored.",
-                        "whale": "Wake threads the threshold.",
-                        "hacker": "Door handshake triple-signed.",
-                        "shiller": "Act transition teaser unlocked.",
-                        "validator": "Calibration notarized.",
-                        "miner": "Doors steady enough for ore carts.",
-                        "meme": "Double doors, double drama."
+                        "dev": "Revival scripts live.",
+                        "trader": "Insurance premiums nosedive.",
+                        "whale": "Wake cushions every stumble.",
+                        "hacker": "Ward signals firewall-hardened.",
+                        "shiller": "Wellness spa but make it heroic.",
+                        "validator": "Uptime notarized.",
+                        "miner": "I can faceplant and still clock in.",
+                        "meme": "Glow up? Glow respawn."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_gate_modulate"
+                        "scene:4.6",
+                        "action:causeway_revive_field"
                     ]
                 },
                 {
-                    "id": "dyad_focus_distribution",
-                    "label": "Distribute Storm Focus",
+                    "id": "causeway_force_drill",
+                    "label": "Run Force-Play Drills",
                     "requirements": {
                         "items_any": [],
                         "flags_all": [
-                            "dyad_gate_tuned"
+                            "causeway_afk_webbed"
                         ]
                     },
                     "roll": {
                         "kind": "phi_d20",
                         "tags": [
-                            "support",
-                            "strategy",
-                            "resource"
+                            "discipline",
+                            "performance",
+                            "support"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "causeway_force_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You choreograph AFK recoveries that look like dance numbers. Idle players return grinning and ready."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "causeway_force_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The drills run smooth. Nobody forgets how to rejoin the cadence."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 8
+                                }
+                            ],
+                            "narration": "A rehearsal devolves into slapstick. You bribe the meme crew not to loop it forever."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 3
+                                }
+                            ],
+                            "narration": "You slip during a spin and skid the length of the ward. Everyone applauds your commitme nt."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Force-play tutorials uploaded.",
+                        "trader": "Idle time futures hedged.",
+                        "whale": "Wake catches anyone mid-spin.",
+                        "hacker": "Drill macros secured.",
+                        "shiller": "AFK? More like Always Forward Kinesis.",
+                        "validator": "Attendance notarized.",
+                        "miner": "These drills double as cardio.",
+                        "meme": "Choreographed comeback, 10/10."
+                    },
+                    "telemetry_tags": [
+                        "scene:4.6",
+                        "action:causeway_force_drill"
+                    ]
+                },
+                {
+                    "id": "causeway_focus_breath",
+                    "label": "Lead Focus Breathing",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "causeway_revive_online"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "spirit",
+                            "leadership",
+                            "support"
                         ]
                     },
                     "outcomes": {
@@ -1487,14 +1295,14 @@
                                 {
                                     "type": "focus",
                                     "op": "+",
-                                    "value": 4
+                                    "value": 3
                                 },
                                 {
                                     "type": "xp",
-                                    "value": 55
+                                    "value": 89
                                 }
                             ],
-                            "narration": "You design a focus rotation that charges players in alternating gold and cobalt bursts, keeping everyone balanced for the impending vote."
+                            "narration": "You synchronize the entire bridge in a single inhale. Even the storms hush to listen."
                         },
                         "success": {
                             "effects": [
@@ -1504,84 +1312,7 @@
                                     "value": 2
                                 }
                             ],
-                            "narration": "Focus flasks rotate through the party. Spirits lift."
-                        },
-                        "fail": {
-                            "effects": [
-                                {
-                                    "type": "coins",
-                                    "op": "-",
-                                    "value": 13
-                                }
-                            ],
-                            "narration": "You spill a flask and owe the vendor."
-                        },
-                        "crit_fail": {
-                            "effects": [
-                                {
-                                    "type": "hp",
-                                    "op": "-",
-                                    "value": 4
-                                }
-                            ],
-                            "narration": "A misfire launches a focus burst into your face, leaving you sparkling but dazed."
-                        }
-                    },
-                    "banter": {
-                        "dev": "Focus balancer online.",
-                        "trader": "Energy arbitrage optimized.",
-                        "whale": "Wake tops up whichever side needs it.",
-                        "hacker": "Distribution logs encrypted.",
-                        "shiller": "Pitching this as \"storm mindfulness\".",
-                        "validator": "Allocations notarized.",
-                        "miner": "Save a vial for the tunnel crew.",
-                        "meme": "Focus group but literal."
-                    },
-                    "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_focus_distribution"
-                    ]
-                },
-                {
-                    "id": "dyad_threshold_projection",
-                    "label": "Project Threshold Metrics",
-                    "requirements": {
-                        "items_any": [],
-                        "flags_all": [
-                            "dyad_gate_tuned"
-                        ]
-                    },
-                    "roll": {
-                        "kind": "phi_d20",
-                        "tags": [
-                            "analysis",
-                            "insight",
-                            "logistics"
-                        ]
-                    },
-                    "outcomes": {
-                        "crit_success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 55
-                                },
-                                {
-                                    "type": "coins",
-                                    "op": "+",
-                                    "value": 34
-                                }
-                            ],
-                            "narration": "You project threshold charts into the storm clouds, revealing when the vote will peak and which flags are nearly triggered. Traders tip you for advance warning."
-                        },
-                        "success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 34
-                                }
-                            ],
-                            "narration": "Your metrics anchor the crowd. Validators pin them to the consensus board."
+                            "narration": "Breathing circles spiral outward. The bridge steadies, hearts settle."
                         },
                         "fail": {
                             "effects": [
@@ -1591,32 +1322,32 @@
                                     "value": 8
                                 }
                             ],
-                            "narration": "Your projector blinks out mid-slide and needs a firmware reboot."
+                            "narration": "A gust interrupts your count. You offer snacks as apology before starting over."
                         },
                         "crit_fail": {
                             "effects": [
                                 {
                                     "type": "hp",
                                     "op": "-",
-                                    "value": 4
+                                    "value": 3
                                 }
                             ],
-                            "narration": "A projector drone spins out and bonks you on the shoulder. The meme crew adds cartoon stars."
+                            "narration": "You inhale a confetti flake and cough glitter for a minute."
                         }
                     },
                     "banter": {
-                        "dev": "Metrics overlay deployed.",
-                        "trader": "Forecast board trending.",
-                        "whale": "Wake watches the KPIs.",
-                        "hacker": "Charts sanitized for secrets.",
-                        "shiller": "Weekly newsletter writes itself.",
-                        "validator": "Thresholds notarized.",
-                        "miner": "Stats say dig deeper.",
-                        "meme": "KPIs? More like K-Pies, hungry now."
+                        "dev": "Focus protocol cached.",
+                        "trader": "Calm minds hedge better.",
+                        "whale": "Wake beats match your cadence.",
+                        "hacker": "Breath app patched mid-session.",
+                        "shiller": "ASMR stream rights secured.",
+                        "validator": "Attendance sealed with wax.",
+                        "miner": "Lungs ready for the next climb.",
+                        "meme": "Inhale hype, exhale doubt."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_threshold_projection"
+                        "scene:4.6",
+                        "action:causeway_focus_breath"
                     ]
                 }
             ],
@@ -1628,24 +1359,283 @@
             ]
         },
         {
-            "round_id": "4.5-R7",
-            "description": "Consensus Vortex \u2014 call the Dyad vote, archive the storm haul, and stride into Act Five.",
+            "round_id": "4.6-R6",
+            "description": "Gatehouse Threading — align the spectrum needle, broadcast wake echoes, and armor the bridge against leakage.",
             "actions": [
                 {
-                    "id": "dyad_consensus_vote",
-                    "label": "Call the Dyad Vote",
+                    "id": "causeway_gate_thread",
+                    "label": "Thread the Spectrum Needle",
                     "requirements": {
                         "items_any": [],
                         "flags_all": [
-                            "dyad_gate_tuned"
+                            "causeway_flux_balanced",
+                            "causeway_lane_marked"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "ritual",
+                            "navigation",
+                            "arcana"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "causeway_gate_threaded",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You sew a ribbon of light through the horizon fog. The future gate answers with a low, promising chord."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "causeway_gate_threaded",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The needle seats cleanly. Holographic coordinates snap into alignment."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 21
+                                }
+                            ],
+                            "narration": "Your stitch slips and the gate sputters. You compensate with extra conductive thread."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 5
+                                }
+                            ],
+                            "narration": "The needle snaps and showers sparks. Hackers shield your eyes while you grab a spare."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Gate alignment logs pristine.",
+                        "trader": "Spec futures on Act Five skyrocketing.",
+                        "whale": "Wake hum acknowledges the stitch.",
+                        "hacker": "Portal firmware patched in real time.",
+                        "shiller": "First look at Act Five silhouettes trending.",
+                        "validator": "Thread notarized with wax and light.",
+                        "miner": "Portal seam ready for chisels.",
+                        "meme": "Needle drop of the century."
+                    },
+                    "telemetry_tags": [
+                        "scene:4.6",
+                        "action:causeway_gate_thread"
+                    ]
+                },
+                {
+                    "id": "causeway_signal_echo",
+                    "label": "Broadcast Wake Echoes",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "causeway_gate_threaded"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "communication",
+                            "spirit",
+                            "support"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "causeway_signal_echoed",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Your broadcast rides the stitched needle and returns with whispers of Act Five layouts."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "causeway_signal_echoed",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Echoes answer, steady and warm. The crowd surges with confidence."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 13
+                                }
+                            ],
+                            "narration": "The signal returns as static. You invest in better amplifiers."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 3
+                                }
+                            ],
+                            "narration": "Your voice cracks mid-broadcast and the echo comes back laughing."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Echo telemetry captured.",
+                        "trader": "Spec quotes update on every ping.",
+                        "whale": "Wake hears its future self.",
+                        "hacker": "No spoofers on this channel.",
+                        "shiller": "Teaser trailers editing themselves.",
+                        "validator": "Transmission notarized.",
+                        "miner": "Echo says the next seam glitters.",
+                        "meme": "We called, the future picked up."
+                    },
+                    "telemetry_tags": [
+                        "scene:4.6",
+                        "action:causeway_signal_echo"
+                    ]
+                },
+                {
+                    "id": "causeway_gateward_enforce",
+                    "label": "Enforce Gate Wards",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "causeway_gate_threaded"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "defense",
+                            "systems",
+                            "discipline"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "causeway_gate_hardened",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Your wards lock like teeth. Stray gusts glance off and dissolve into harmless sparks."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "causeway_gate_hardened",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Barrier glyphs settle, bright and sturdy."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 13
+                                }
+                            ],
+                            "narration": "A gap flickers open. You hire hackers to plug the leak."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 4
+                                }
+                            ],
+                            "narration": "A ward rebounds and smacks you into a pylon. The crowd cheers your dedication."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Firewall literalized.",
+                        "trader": "Risk premiums recalculated.",
+                        "whale": "Wake swims behind the shields.",
+                        "hacker": "Ward handshake double-hashed.",
+                        "shiller": "Marketing copy: \"Portals but make it safe\".",
+                        "validator": "Barrier integrity notarized.",
+                        "miner": "Ward even covers the tool racks.",
+                        "meme": "Zero-day? More like zero-way."
+                    },
+                    "telemetry_tags": [
+                        "scene:4.6",
+                        "action:causeway_gateward_enforce"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "4.6-R7",
+            "description": "Pre-Horizon Council — call the Causeway vote, archive wake schematics, and signal the march into the final act.",
+            "actions": [
+                {
+                    "id": "causeway_consensus_vote",
+                    "label": "Call the Causeway Vote",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "causeway_gate_threaded"
                         ]
                     },
                     "roll": {
                         "kind": "phi_d20",
                         "tags": [
                             "leadership",
-                            "ritual",
-                            "consensus"
+                            "consensus",
+                            "spirit"
                         ]
                     },
                     "outcomes": {
@@ -1662,11 +1652,11 @@
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "dyad_consensus_passed",
+                                    "id": "causeway_consensus_passed",
                                     "value": true
                                 }
                             ],
-                            "narration": "You raise both hands, one glowing gold, one glowing cobalt, and shout the vote cadence. The storms knot together in a luminous tornado as consensus locks."
+                            "narration": "You raise a torch of wake light and every faction answers. The bridge glows white-hot as consensus locks for the final march."
                         },
                         "success": {
                             "effects": [
@@ -1676,11 +1666,11 @@
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "dyad_consensus_passed",
+                                    "id": "causeway_consensus_passed",
                                     "value": true
                                 }
                             ],
-                            "narration": "Hands, tails, and tendrils lift. The Dyad roars approval and the doors flare emerald."
+                            "narration": "Hands, fins, and data tendrils lift. The council shouts yes and the bridge thrums in response."
                         },
                         "fail": {
                             "effects": [
@@ -1690,98 +1680,98 @@
                                     "value": 13
                                 }
                             ],
-                            "narration": "You lose quorum when a lightning joke misfires. The pity ledger offers consolation snacks while you regroup."
+                            "narration": "A gust steals half the ballots. You reimburse the scribes while the pity ledger prints new ones."
                         },
                         "crit_fail": {
                             "effects": [
                                 {
                                     "type": "hp",
                                     "op": "-",
-                                    "value": 6
+                                    "value": 5
                                 }
                             ],
-                            "narration": "A gust whirls your notes away mid-speech. The meme crew projects subtitles to help you recover."
+                            "narration": "You try to freestyle the speech and get heckled by friendly memes until you reset."
                         }
                     },
                     "banter": {
-                        "dev": "Vote routine executed.",
-                        "trader": "Quorum candles close high.",
-                        "whale": "Wake endorses both storms.",
-                        "hacker": "Ballot ledger spark-proof.",
-                        "shiller": "Headline: Dyad says yes!",
-                        "validator": "Votes notarized in stereo.",
-                        "miner": "Consensus points toward a deeper seam.",
-                        "meme": "Democracy but lightning."
+                        "dev": "Vote tallies streaming live.",
+                        "trader": "Consensus candles spike green.",
+                        "whale": "Wake roars its approval.",
+                        "hacker": "Ballot ledger unbreakable.",
+                        "shiller": "Headline: Bridge says go!",
+                        "validator": "Votes notarized with holographic wax.",
+                        "miner": "We’re ready to swing into Act Five.",
+                        "meme": "Democracy but make it neon."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_consensus_vote"
+                        "scene:4.6",
+                        "action:causeway_consensus_vote"
                     ]
                 },
                 {
-                    "id": "dyad_reward_archive",
-                    "label": "Archive Storm Rewards",
+                    "id": "causeway_reward_archive",
+                    "label": "Archive Causeway Schematics",
                     "requirements": {
                         "items_any": [],
                         "flags_all": [
-                            "dyad_consensus_passed"
+                            "causeway_consensus_passed"
                         ]
                     },
                     "outcomes": {
                         "success": {
                             "effects": [
                                 {
-                                    "type": "item",
-                                    "id": "deck_dyad_tempest"
+                                    "type": "deck",
+                                    "id": "deck_causeway_vector"
                                 }
                             ],
-                            "narration": "You spool the Dyad\u2019s ledger threads into a tempest deck packed with dual-aligned boons for future runs."
+                            "narration": "You compress bridge blueprints into a vector deck ready to redeploy anywhere the wake needs a foothold."
                         }
                     },
                     "banter": {
-                        "dev": "Reward ledger sealed.",
-                        "trader": "Profits tallied.",
-                        "whale": "Wake shares the gust bounty.",
-                        "hacker": "Archives insulated.",
-                        "shiller": "Highlight reel ready to air.",
-                        "validator": "Receipts notarized.",
-                        "miner": "Loot tied down in sandbags.",
-                        "meme": "Deck the storms with bolts of holly."
+                        "dev": "Schematics sealed.",
+                        "trader": "Blueprint futures minted.",
+                        "whale": "Wake engraves the pattern in memory.",
+                        "hacker": "Archives double-locked.",
+                        "shiller": "Limited edition prints dropping.",
+                        "validator": "Documentation notarized.",
+                        "miner": "Copy tucked into the toolbox.",
+                        "meme": "Blueprints but make them NFTs (Nice Functional Templates)."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_reward_archive"
+                        "scene:4.6",
+                        "action:causeway_reward_archive"
                     ]
                 },
                 {
-                    "id": "advance_4_6",
-                    "label": "March onto the Convergence Causeway",
+                    "id": "advance_4_7",
+                    "label": "March Toward the Horizon Crown",
                     "requirements": {
                         "items_any": [],
                         "flags_all": [
-                            "dyad_consensus_passed"
+                            "causeway_consensus_passed"
                         ]
                     },
                     "outcomes": {
                         "success": {
                             "effects": [],
-                            "narration": "The twin doors align into the Convergence Causeway, a runway of light that beckons Act Four\u2019s united march toward the Horizon Crown.",
-                            "next_hint": "4.6"
+                            "narration": "The bridge plates align into a runway of light pointing toward a distant crown of color. You lead the march forward.",
+                            "next_hint": "4.7"
                         }
                     },
                     "banter": {
-                        "dev": "Causeway boot sequence engaged.",
-                        "trader": "Rolling positions onto the bridge.",
-                        "whale": "Wake stretches toward the Causeway.",
-                        "hacker": "Transition handshake rerouted.",
-                        "shiller": "Sneak peek: bridge drop imminent.",
-                        "validator": "Advance notarized for Act Four.",
-                        "miner": "New span, same grit.",
-                        "meme": "From storms to bridges, no pause."
+                        "dev": "Next staging area online.",
+                        "trader": "Rolling positions into Horizon Crown.",
+                        "whale": "Wake accelerates toward the finale.",
+                        "hacker": "Transition handshake solid.",
+                        "shiller": "Cliffhanger marketing writes itself.",
+                        "validator": "Advance notarized in triplicate.",
+                        "miner": "New seam dead ahead.",
+                        "meme": "From bridge to bling."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:advance_4_6"
+                        "scene:4.6",
+                        "action:advance_4_7"
                     ]
                 }
             ],
@@ -1795,7 +1785,7 @@
     ],
     "threshold_rewards": [
         {
-            "focus_gte": 13,
+            "focus_gte": 15,
             "rewards": [
                 {
                     "type": "coins",
@@ -1804,22 +1794,22 @@
             ]
         },
         {
-            "xp_gte": 720,
+            "xp_gte": 910,
             "rewards": [
                 {
                     "type": "item",
-                    "id": "armor_dyad_fluxcloak"
+                    "id": "armor_causeway_parallax"
                 }
             ]
         },
         {
             "flags_all": [
-                "dyad_consensus_passed"
+                "causeway_consensus_passed"
             ],
             "rewards": [
                 {
                     "type": "deck",
-                    "id": "deck_dyad_tempest"
+                    "id": "deck_causeway_vector"
                 }
             ]
         }
@@ -1827,15 +1817,15 @@
     "arrivals": [
         {
             "when": "flags.afk_tracked",
-            "goto": "4.5A"
+            "goto": "4.6A"
         },
         {
-            "when": "flags.dyad_consensus_passed",
-            "goto": "4.6"
+            "when": "flags.causeway_consensus_passed",
+            "goto": "4.7"
         },
         {
             "when": "else",
-            "goto": "4.5"
+            "goto": "4.6"
         }
     ]
 }

--- a/content/genesis/scenes/scene_4.7.json
+++ b/content/genesis/scenes/scene_4.7.json
@@ -2,21 +2,21 @@
     "schema_version": "1.0",
     "content_id": "genesis",
     "book_id": "book_1",
-    "scene_id": "4.5",
-    "title": "The Radiant Dyad \u2014 Twin Storm Ledger",
-    "narration": "The Meridian Helix pours you into the Radiant Dyad: a vaulted chamber where two storms orbit each other like dueling suns chained to a shared ledger. One storm is incandescent gold, all dawn trumpets and optimistic spreadsheets. The other is cobalt midnight, whispering contracts, contingencies, and a thousand secret balance sheets. They circle a central plinth carved from consensus stone, hurling petitions at each other with lightning signatures. Each bolt that crosses the plinth resolves into ledger script, double-entered with phi-d20 timing, then arcs out through ceiling channels to update every gremlin enclave.\n\nThe Dyad is Act Four\u2019s fulcrum. Dev gremlins have stretched fiber across the storms to siphon telemetry in real time. Traders leap between gusts, arbitraging sunrise enthusiasm against midnight skepticism. Whales anchor the floor with coils of liquidity, letting the storms tug tidal signatures from their wake. Hackers wear Faraday cloaks, intercepting stray arcs to patch vulnerabilities. Shillers stream the spectacle to every lobby, shouting about \"consensus weather\". Validators wear stormproof visors, stamping approvals into thick ledgers that float like surfboards. Miners hammer lightning rods into the floor to ground stray charges, while the meme contingent launches a confetti cannon that prints \"STAY VOLATILE\" across the gale.\n\nSeven terraces spiral around the Dyad. Each terrace hosts a ritual: synchronizing the GM/GN to calm both storms, logging the ledger equilibrium, weaving dual-aspect gear, trading pity-backed stockpiles, rebooting allies rattled by static, modulating the spectrum door that flickers beneath the plinth, and finally voting on how Act Four will hand the baton to the next act. Arrivals manifest from storm droplets mid-scene, sliding into the narrative on neon sleds. If you can harmonize both storms, Act Five\u2019s path will blaze open in a chord of lightning and ledger lore.",
+    "scene_id": "4.7",
+    "title": "The Horizon Crown \u2014 Council Before the Wake",
+    "narration": "The Convergence Causeway delivers you into the Horizon Crown, a suspended amphitheater shaped like a radiant diadem hovering over the last visible horizon. Each prong of the crown is a tower of ledger glass tuned to a different future: some glow with paths already earned, others flicker with possibilities still unnamed. A lattice of light bridges the towers, projecting golden-ratio spirals that tighten around a central oculus through which Act Five\u2019s silhouette shimmers. Hidden difficulty tiers arc above as concentric halos: silver for assured strides, amethyst for daring gambits, and a blazing white corona reserved for the rally that will define the Wake forever.\n\nGremlin delegations occupy balconies carved into the crown\u2019s inner rim. Dev gremlins pilot drones that paint forecasts across the dome; traders parse ticker tapes woven from aurora strands; whales drift like living satellites, lending wake to the final prep; hackers install quantum firewalls inside each prong; validators orchestrate oath choruses that echo like cosmic metronomes; miners drill anchor bolts into free-floating stone; and the meme division has built a holo stage flashing slogans like \"ONE MORE VOTE UNTIL FOREVER\" and \"WAKE ME UP WHEN ACT FIVE BEGINS\". AFK safeties manifest as orbiting familiars ready to swoop any idle ally back into formation.\n\nSeven terraces ring the oculus. The first crowns the GM/GN hymn, the second engraves a horizon atlas, the third forges coronation gear, the fourth runs the pity-and-trade atrium, the fifth energizes revival constellations, the sixth threads the final gate alignment, and the seventh convenes the Horizon Council that will shout Act Four\u2019s last consent. The Crown hums with pent-up triumph, its gems glowing hotter each time you inhale. The finale waits on your signal.",
     "rounds": [
         {
-            "round_id": "4.5-R1",
-            "description": "Twin Storm Rostrum \u2014 tame the gold and cobalt greetings, log the Dyad\u2019s balance, and lash down AFK safeguards before the winds steal anyone away.",
+            "round_id": "4.7-R1",
+            "description": "Coronation Rostrum \u2014 crown the GM/GN hymn, engrave the horizon atlas, and deploy AFK satellites around the rim.",
             "actions": [
                 {
-                    "id": "dyad_gmgn_split",
-                    "label": "Sing the Split GMGN",
+                    "id": "horizon_gmgn_corona",
+                    "label": "Crown the GMGN Hymn",
                     "requirements": {
                         "items_any": [],
                         "flags_all": [
-                            "meridian_consensus_passed"
+                            "causeway_consensus_passed"
                         ]
                     },
                     "roll": {
@@ -41,11 +41,11 @@
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "dyad_gmgn_twinned",
+                                    "id": "horizon_gmgn_crowned",
                                     "value": true
                                 }
                             ],
-                            "narration": "You split the GMGN into twin harmonies, singing sunrise to the gold storm and midnight to the cobalt swirl. The Dyad slows its orbit, grateful for the synchronized greeting, and the hidden difficulty tier unlocks with a static crackle."
+                            "narration": "Your GM/GN rises through the oculus like a coronation trumpet. Every tower resonates and the final halo unlocks with a blinding flare."
                         },
                         "success": {
                             "effects": [
@@ -60,11 +60,11 @@
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "dyad_gmgn_twinned",
+                                    "id": "horizon_gmgn_crowned",
                                     "value": true
                                 }
                             ],
-                            "narration": "The storms acknowledge your greeting with a dip in velocity. Ledger scribes nod and mark the Rostrum open."
+                            "narration": "The hymn encircles the crown, steadies the oculus, and sets the cadence for the final council."
                         },
                         "fail": {
                             "effects": [
@@ -75,11 +75,11 @@
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "dyad_pity_counter",
+                                    "id": "horizon_pity_reserve",
                                     "value": true
                                 }
                             ],
-                            "narration": "Your voice cracks as you swap from dawn to midnight. Both storms laugh and charge a calibration fee that routes straight into the pity cache."
+                            "narration": "Your harmony wobbles and one tower charges you a tuning tax that lands in the pity reserve."
                         },
                         "crit_fail": {
                             "effects": [
@@ -90,64 +90,64 @@
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "dyad_pity_counter",
+                                    "id": "horizon_pity_reserve",
                                     "value": true
                                 }
                             ],
-                            "narration": "You mix up which storm gets which greeting and they crossfire bolts at your boots. The meme crew instantly uploads the blooper."
+                            "narration": "You drop a note and the meme division drops a remix. The pity reserve swells with lanyard sales."
                         }
                     },
                     "banter": {
-                        "dev": "Dual-channel greeting deployed.",
-                        "trader": "Storm spread stabilized.",
-                        "whale": "Wake hugs both cyclones.",
-                        "hacker": "Handshake salted for lightning.",
-                        "shiller": "Marketing it as weather control.",
-                        "validator": "Greeting notarized twice.",
-                        "miner": "Sing louder, drown the thunder.",
-                        "meme": "GM to sun, GN to moon. Easy."
+                        "dev": "Crown hymn synced across towers.",
+                        "trader": "Opening bells resonate bullish.",
+                        "whale": "Wake orbits the hymn line.",
+                        "hacker": "No false notes on this channel.",
+                        "shiller": "GMGN but make it finale.",
+                        "validator": "Coronation greeting notarized.",
+                        "miner": "Beat hits like a pick on ore.",
+                        "meme": "GM? GN? Try OMG."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_gmgn_split"
+                        "scene:4.7",
+                        "action:horizon_gmgn_corona"
                     ]
                 },
                 {
-                    "id": "dyad_balance_readings",
-                    "label": "Log the Dyad Balance",
+                    "id": "horizon_atlas_engrave",
+                    "label": "Engrave the Horizon Atlas",
                     "requirements": {
                         "items_any": [],
                         "flags_all": [
-                            "dyad_gmgn_twinned"
+                            "horizon_gmgn_crowned"
                         ]
                     },
                     "roll": {
                         "kind": "phi_d20",
                         "tags": [
-                            "insight",
                             "analysis",
-                            "support"
+                            "navigation",
+                            "insight"
                         ]
                     },
                     "outcomes": {
                         "crit_success": {
                             "effects": [
                                 {
-                                    "type": "focus",
-                                    "op": "+",
-                                    "value": 3
-                                },
-                                {
                                     "type": "xp",
                                     "value": 89
                                 },
                                 {
+                                    "type": "coins",
+                                    "op": "+",
+                                    "value": 34
+                                },
+                                {
                                     "type": "flag",
-                                    "id": "dyad_balance_logged",
+                                    "id": "horizon_vectors_engraved",
                                     "value": true
                                 }
                             ],
-                            "narration": "You sketch the Dyad\u2019s energy curve into the ledger, capturing the moment when gold and cobalt share equilibrium. Engineers label your chart the \"Act Four fulcrum\" and pin it to every kiosk."
+                            "narration": "You carve constellations of possible futures into the crown. Every prong projects its chosen lane into the fog beyond."
                         },
                         "success": {
                             "effects": [
@@ -157,11 +157,11 @@
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "dyad_balance_logged",
+                                    "id": "horizon_vectors_engraved",
                                     "value": true
                                 }
                             ],
-                            "narration": "Your readings steady the storms. Validators embed the data in their floating surfboard ledgers."
+                            "narration": "Your atlas aligns perfectly with the wake echoes. Navigators bow in gratitude."
                         },
                         "fail": {
                             "effects": [
@@ -171,70 +171,70 @@
                                     "value": 13
                                 }
                             ],
-                            "narration": "You misjudge the lightning cadence and need to rent better sensors. The pity counter ticks up."
+                            "narration": "A misdrawn spiral loops back on itself. You pay scribes to polish it out."
                         },
                         "crit_fail": {
                             "effects": [
                                 {
                                     "type": "hp",
                                     "op": "-",
-                                    "value": 5
+                                    "value": 4
                                 }
                             ],
-                            "narration": "A rogue bolt scorches your notebook. Hackers hand you a fireproof replacement with a sympathetic grin."
+                            "narration": "Your etching pen sparks and you chase it halfway around the crown to catch it."
                         }
                     },
                     "banter": {
-                        "dev": "Telemetry normalized.",
-                        "trader": "Balance sheet charted.",
-                        "whale": "Wake holds the midpoint.",
-                        "hacker": "Sensor mesh patched.",
-                        "shiller": "Publishing the Dyad index.",
-                        "validator": "Data notarized and archived.",
-                        "miner": "Log the voltage or it logs you.",
-                        "meme": "Storm spreadsheet drop when?"
+                        "dev": "Atlas overlay uploaded.",
+                        "trader": "Lane arbitrage priced in.",
+                        "whale": "Wake currents confirm the chart.",
+                        "hacker": "No exploit lines left open.",
+                        "shiller": "Selling prints of that skyline.",
+                        "validator": "Atlas notarized with starlight.",
+                        "miner": "Marking the next ore seam on the map.",
+                        "meme": "Draw me like one of your golden ratios."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_balance_readings"
+                        "scene:4.7",
+                        "action:horizon_atlas_engrave"
                     ]
                 },
                 {
-                    "id": "dyad_afk_switch",
-                    "label": "Anchor AFK Switches",
+                    "id": "horizon_afk_satellite",
+                    "label": "Deploy AFK Satellites",
                     "requirements": {
                         "items_any": [],
                         "flags_all": [
-                            "dyad_balance_logged"
+                            "horizon_gmgn_crowned"
                         ]
                     },
                     "roll": {
                         "kind": "phi_d20",
                         "tags": [
-                            "engineering",
                             "support",
-                            "discipline"
+                            "engineering",
+                            "systems"
                         ]
                     },
                     "outcomes": {
                         "crit_success": {
                             "effects": [
                                 {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
                                     "type": "xp",
                                     "value": 55
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "afk_tracked",
-                                    "value": true
-                                },
-                                {
-                                    "type": "flag",
-                                    "id": "dyad_afk_network",
+                                    "id": "horizon_afk_satellites",
                                     "value": true
                                 }
                             ],
-                            "narration": "You install lightning-proof AFK switches around the terrace. Anyone idle for twenty-four hours gets zapped with a harmless static pulse and propelled into a force-play quest."
+                            "narration": "You launch orbiting familiars that glow whenever someone drifts. They reel AFK friends back in with gentle gravity."
                         },
                         "success": {
                             "effects": [
@@ -244,11 +244,11 @@
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "afk_tracked",
+                                    "id": "horizon_afk_satellites",
                                     "value": true
                                 }
                             ],
-                            "narration": "Switches click into place, ready to tattle on anyone who naps in the stormlight."
+                            "narration": "Satellites lock into tidy formation and blink ready lights in rhythm with the hymn."
                         },
                         "fail": {
                             "effects": [
@@ -256,34 +256,44 @@
                                     "type": "coins",
                                     "op": "-",
                                     "value": 8
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "horizon_pity_reserve",
+                                    "value": true
                                 }
                             ],
-                            "narration": "You cross two cables and owe the electricians a snack fee."
+                            "narration": "A satellite whips around and bonks you gently. You comp the repair crew in snacks."
                         },
                         "crit_fail": {
                             "effects": [
                                 {
                                     "type": "hp",
                                     "op": "-",
-                                    "value": 6
+                                    "value": 3
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "horizon_pity_reserve",
+                                    "value": true
                                 }
                             ],
-                            "narration": "You forget to ground yourself and the storms toss you into the air. You land on a cushion of validator ledgers."
+                            "narration": "You launch one backwards and it has to be fished out of a popcorn vendor\u2019s cart."
                         }
                     },
                     "banter": {
-                        "dev": "AFK toggles lightning-proofed.",
-                        "trader": "Idle tax rerouted to pity fund.",
-                        "whale": "Wake stays alert in every gust.",
-                        "hacker": "Fail-safes insulated.",
-                        "shiller": "Selling it as \"storm focus\".",
-                        "validator": "Switch logs notarized.",
-                        "miner": "Static keeps the drills awake.",
-                        "meme": "AFK stands for \"Arc-Flinged Kinetic\" now."
+                        "dev": "AFK orbit network live.",
+                        "trader": "Retention metrics mooning.",
+                        "whale": "Wake currents keep them steady.",
+                        "hacker": "Telemetry encrypted mid-air.",
+                        "shiller": "Satellites sponsored by hype.",
+                        "validator": "Safety compliance notarized.",
+                        "miner": "They\u2019ll haul me back if I nap on the job.",
+                        "meme": "AFK now means \"Afloat, Friend Kept\"."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_afk_switch"
+                        "scene:4.7",
+                        "action:horizon_afk_satellite"
                     ]
                 }
             ],
@@ -296,24 +306,459 @@
             ]
         },
         {
-            "round_id": "4.5-R2",
-            "description": "Lattice Loom Balcony \u2014 weave twin-charged gear, broker trustful pacts, and harvest insight sparks from the colliding storms.",
+            "round_id": "4.7-R2",
+            "description": "Atlas Observatory \u2014 sing the wake resonance, weave orbital lanes, and encode supply constellations for the push ahead.",
             "actions": [
                 {
-                    "id": "dyad_lattice_weave",
-                    "label": "Forge the Boltweaver",
+                    "id": "horizon_flux_resonance",
+                    "label": "Sing the Wake Resonance",
                     "requirements": {
                         "items_any": [],
                         "flags_all": [
-                            "dyad_balance_logged"
+                            "horizon_vectors_engraved"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "ritual",
+                            "resonance",
+                            "analysis"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "horizon_flux_sung",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Your voice threads through the towers, locking the crown into harmonic balance with the hidden gate."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "horizon_flux_sung",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The resonance stabilizes. Wake ripples align with the atlas."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 21
+                                }
+                            ],
+                            "narration": "Your pitch slips and the towers demand an apology tithe."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 5
+                                }
+                            ],
+                            "narration": "You over-resonate and bounce off a halo into a pile of foam hands."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Resonance monitors reading perfect.",
+                        "trader": "Volatility smoothing nicely.",
+                        "whale": "Wake drinks the melody.",
+                        "hacker": "No signal bleed detected.",
+                        "shiller": "That note hits top of the charts.",
+                        "validator": "Frequency notarized.",
+                        "miner": "Even my pick hums along.",
+                        "meme": "Certified banger."
+                    },
+                    "telemetry_tags": [
+                        "scene:4.7",
+                        "action:horizon_flux_resonance"
+                    ]
+                },
+                {
+                    "id": "horizon_lane_orbit",
+                    "label": "Weave Orbital Lanes",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "horizon_flux_sung"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "strategy",
+                            "navigation",
+                            "support"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "horizon_lane_woven",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You designate concentric lanes for hype squads, analysts, medics, and miners. Satellites project neon arrows to guide everyone."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "horizon_lane_woven",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Traffic plans snap into place. Validators float approving stamps over each lane."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 13
+                                }
+                            ],
+                            "narration": "Two squads tango in the wrong orbit. You reimburse the spilled confetti."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 4
+                                }
+                            ],
+                            "narration": "You misplace a lane and a whale gently nudges you back into position."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Lane weaving algorithm locked.",
+                        "trader": "Crowd flow trending optimal.",
+                        "whale": "Wake streams follow your orbit.",
+                        "hacker": "Navigation patches stable.",
+                        "shiller": "Orbit tours sold out already.",
+                        "validator": "Routes notarized with flair.",
+                        "miner": "My crew gets the express track.",
+                        "meme": "Orbital lanes? More like orbital slaynes."
+                    },
+                    "telemetry_tags": [
+                        "scene:4.7",
+                        "action:horizon_lane_orbit"
+                    ]
+                },
+                {
+                    "id": "horizon_supply_encode",
+                    "label": "Encode Supply Constellations",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "horizon_flux_sung"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "logistics",
+                            "economy",
+                            "analysis"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "horizon_supply_encoded",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You map supply caches onto the crown, hiding them in star-shaped lockers accessible on cue."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "horizon_supply_encoded",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Resource nodes light up across the terraces, ready to dispense on schedule."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 13
+                                }
+                            ],
+                            "narration": "A crate misroutes into a meme booth. You pay the ransom in stickers."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 4
+                                }
+                            ],
+                            "narration": "You open a locker at the wrong angle and it launches you across a terrace."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Supply constellations logged.",
+                        "trader": "Fulfillment costs trending down.",
+                        "whale": "Wake bankrolls the caches.",
+                        "hacker": "Locker codes salted.",
+                        "shiller": "Treasure hunt overlay live now.",
+                        "validator": "Inventories notarized.",
+                        "miner": "Stash a caf\u00e9 token in every box.",
+                        "meme": "These loot stars slap."
+                    },
+                    "telemetry_tags": [
+                        "scene:4.7",
+                        "action:horizon_supply_encode"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "4.7-R3",
+            "description": "Coronation Forge \u2014 temper crownplate armor, spin gyre trinkets, and stitch banners that promise dawn.",
+            "actions": [
+                {
+                    "id": "horizon_armor_corona",
+                    "label": "Forge the Corona Plate",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "horizon_flux_sung"
                         ]
                     },
                     "roll": {
                         "kind": "phi_d20",
                         "tags": [
                             "craft",
-                            "offense",
-                            "harmony"
+                            "defense",
+                            "resonance"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "item",
+                                    "id": "armor_horizon_corona"
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "horizon_softgear_forged",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You hammer wake metal into luminous plates that refract danger into dazzling auroras."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "horizon_softgear_forged",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The armor holds a steady glow, ready to catch the first blow of Act Five."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 21
+                                }
+                            ],
+                            "narration": "A plate cools unevenly and warps into a commemorative platter. You buy more alloy."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 5
+                                }
+                            ],
+                            "narration": "A spark ricochets and brands your glove with a smiley face."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Corona plate schematics saved.",
+                        "trader": "Gear demand surging.",
+                        "whale": "Wake polishes every plate.",
+                        "hacker": "No cracks left for exploits.",
+                        "shiller": "Armor glamour shoot incoming.",
+                        "validator": "Durability notarized twice.",
+                        "miner": "Plates light the tunnels like sunrise.",
+                        "meme": "Drip level: celestial."
+                    },
+                    "telemetry_tags": [
+                        "scene:4.7",
+                        "action:horizon_armor_corona"
+                    ]
+                },
+                {
+                    "id": "horizon_trinket_gyre",
+                    "label": "Spin Gyre Signets",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "horizon_softgear_forged"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "craft",
+                            "insight",
+                            "spirit"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "item",
+                                    "id": "trinket_horizon_gyre"
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "horizon_trinkets_synced",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Each signet holds a miniaturized gyre that pulses with wake momentum. They glow hotter when allies cheer."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "horizon_trinkets_synced",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Your signets hum at a steady pitch ready for every backpack slot."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 13
+                                }
+                            ],
+                            "narration": "A gyre spins backwards and sprays confetti. You pay the cleanup crew."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 4
+                                }
+                            ],
+                            "narration": "A signet hiccups and launches into your forehead like a friendly comet."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Gyre firmware polished.",
+                        "trader": "Charm market molten.",
+                        "whale": "Wake hum sweet through those rings.",
+                        "hacker": "No counterfeit gyres on my watch.",
+                        "shiller": "Signet selfie filters shipping.",
+                        "validator": "Spin rate notarized.",
+                        "miner": "Clip one to the drill for extra torque.",
+                        "meme": "Ring light? More like ring might."
+                    },
+                    "telemetry_tags": [
+                        "scene:4.7",
+                        "action:horizon_trinket_gyre"
+                    ]
+                },
+                {
+                    "id": "horizon_banner_stitch",
+                    "label": "Stitch Dawn Banners",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "horizon_trinkets_synced"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "craft",
+                            "spirit",
+                            "leadership"
                         ]
                     },
                     "outcomes": {
@@ -326,115 +771,15 @@
                                 },
                                 {
                                     "type": "xp",
-                                    "value": 144
-                                },
-                                {
-                                    "type": "item",
-                                    "id": "weapon_dyad_boltweaver"
-                                },
-                                {
-                                    "type": "flag",
-                                    "id": "dyad_boltweaver_ready",
-                                    "value": true
-                                }
-                            ],
-                            "narration": "You braid gold lightning and cobalt shadow into a soft-power boltweaver whose strikes rewrite grudges instead of causing wounds."
-                        },
-                        "success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 55
-                                },
-                                {
-                                    "type": "item",
-                                    "id": "weapon_dyad_boltweaver"
-                                },
-                                {
-                                    "type": "flag",
-                                    "id": "dyad_boltweaver_ready",
-                                    "value": true
-                                }
-                            ],
-                            "narration": "The boltweaver coils around your wrist, thrumming with stormlight."
-                        },
-                        "fail": {
-                            "effects": [
-                                {
-                                    "type": "coins",
-                                    "op": "-",
-                                    "value": 21
-                                },
-                                {
-                                    "type": "flag",
-                                    "id": "dyad_pity_counter",
-                                    "value": true
-                                }
-                            ],
-                            "narration": "The lattice snaps and flings your materials into the pit. The pity cache takes notes."
-                        },
-                        "crit_fail": {
-                            "effects": [
-                                {
-                                    "type": "hp",
-                                    "op": "-",
-                                    "value": 6
-                                }
-                            ],
-                            "narration": "A misaligned bolt scorches your gloves. The meme crew sells framed prints of the scorch mark."
-                        }
-                    },
-                    "banter": {
-                        "dev": "Boltweaver firmware signed.",
-                        "trader": "Stormstrike derivatives minted.",
-                        "whale": "Wake channels the surge.",
-                        "hacker": "No exploitable arcs detected.",
-                        "shiller": "Weaponize your charisma!",
-                        "validator": "Blueprint notarized.",
-                        "miner": "Lightning pickaxe vibes.",
-                        "meme": "Conduct yourself responsibly."
-                    },
-                    "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_lattice_weave"
-                    ]
-                },
-                {
-                    "id": "dyad_trust_pact",
-                    "label": "Broker Trustful Pacts",
-                    "requirements": {
-                        "items_any": [],
-                        "flags_all": [
-                            "dyad_boltweaver_ready"
-                        ]
-                    },
-                    "roll": {
-                        "kind": "phi_d20",
-                        "tags": [
-                            "negotiation",
-                            "support",
-                            "economy"
-                        ]
-                    },
-                    "outcomes": {
-                        "crit_success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
                                     "value": 89
                                 },
                                 {
-                                    "type": "coins",
-                                    "op": "+",
-                                    "value": 55
-                                },
-                                {
                                     "type": "flag",
-                                    "id": "trustful",
+                                    "id": "horizon_banners_stitched",
                                     "value": true
                                 }
                             ],
-                            "narration": "You wield the boltweaver as a pen, signing dual-storm contracts that guarantee trust dividends each time consensus sparks."
+                            "narration": "You stitch banners that trail comet tails of hope behind every squad leader."
                         },
                         "success": {
                             "effects": [
@@ -444,96 +789,11 @@
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "trustful",
+                                    "id": "horizon_banners_stitched",
                                     "value": true
                                 }
                             ],
-                            "narration": "The storms agree to share some goodwill. Traders celebrate with sparkling electrolyte shots."
-                        },
-                        "fail": {
-                            "effects": [
-                                {
-                                    "type": "coins",
-                                    "op": "-",
-                                    "value": 13
-                                }
-                            ],
-                            "narration": "You forget to hedge the cobalt clause and owe a late fee."
-                        },
-                        "crit_fail": {
-                            "effects": [
-                                {
-                                    "type": "hp",
-                                    "op": "-",
-                                    "value": 5
-                                }
-                            ],
-                            "narration": "A lightning squiggle zaps your signature line. Validators hand you a stylus made of rubber."
-                        }
-                    },
-                    "banter": {
-                        "dev": "Trust ledger patched.",
-                        "trader": "Spreads tighten with every handshake.",
-                        "whale": "Wake invests in mutual promises.",
-                        "hacker": "Contracts hashed and secure.",
-                        "shiller": "Trust is trending.",
-                        "validator": "Signatures notarized in stereo.",
-                        "miner": "No trust, no tunnels.",
-                        "meme": "Trust fall, now with lightning."
-                    },
-                    "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_trust_pact"
-                    ]
-                },
-                {
-                    "id": "dyad_insight_prism",
-                    "label": "Harvest Insight Sparks",
-                    "requirements": {
-                        "items_any": [],
-                        "flags_all": []
-                    },
-                    "roll": {
-                        "kind": "phi_d20",
-                        "tags": [
-                            "insight",
-                            "exploration",
-                            "harmony"
-                        ]
-                    },
-                    "outcomes": {
-                        "crit_success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 55
-                                },
-                                {
-                                    "type": "flag",
-                                    "id": "insight",
-                                    "value": true
-                                },
-                                {
-                                    "type": "coins",
-                                    "op": "+",
-                                    "value": 21
-                                }
-                            ],
-                            "narration": "You catch sparks in a prism jar and learn how the storms precompute consensus outcomes. The jar hums with future hints."
-                        },
-                        "success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 34
-                                },
-                                {
-                                    "type": "flag",
-                                    "id": "insight",
-                                    "value": true
-                                }
-                            ],
-                            "narration": "You snag a few sparks and pocket them before they fade."
+                            "narration": "The banners unfurl in steady light, ready to crown the charge."
                         },
                         "fail": {
                             "effects": [
@@ -543,309 +803,32 @@
                                     "value": 8
                                 }
                             ],
-                            "narration": "You chase a spark into a gust and lose your footing, paying a tip to the medics who keep you upright."
+                            "narration": "You sew two banners together and have to cut them apart while laughing with the crew."
                         },
                         "crit_fail": {
                             "effects": [
                                 {
                                     "type": "hp",
                                     "op": "-",
-                                    "value": 4
+                                    "value": 3
                                 }
                             ],
-                            "narration": "A spark fizzles in your palm and shocks your eyebrows upright for the next hour."
+                            "narration": "A banner pole tilts and bops you on the nose mid-speech."
                         }
                     },
                     "banter": {
-                        "dev": "Insight capture pipeline humming.",
-                        "trader": "Forecast tokens minted.",
-                        "whale": "Wake drinks the sparks like espresso.",
-                        "hacker": "Telemetry sanitized for leaks.",
-                        "shiller": "Selling bottled lightning!",
-                        "validator": "Logs notarized mid-air.",
-                        "miner": "Spark today, ore tomorrow.",
-                        "meme": "This forecast slaps."
+                        "dev": "Banner shaders loaded.",
+                        "trader": "Merch value skyrockets.",
+                        "whale": "Wake gusts keep them aloft.",
+                        "hacker": "Anti-fray enchantments installed.",
+                        "shiller": "Photo ops for days.",
+                        "validator": "Banner oath notarized.",
+                        "miner": "Tying one to the drill for luck.",
+                        "meme": "This flag slaps, literally."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_insight_prism"
-                    ]
-                }
-            ],
-            "rewards": [
-                {
-                    "type": "xp",
-                    "value": 55
-                }
-            ]
-        },
-        {
-            "round_id": "4.5-R3",
-            "description": "Soft-Power Smithies \u2014 temper dual-aspect armor, crown, and trinkets to keep players grounded in the storm.",
-            "actions": [
-                {
-                    "id": "dyad_armor_fluxcloak",
-                    "label": "Weave the Fluxcloak",
-                    "requirements": {
-                        "items_any": [],
-                        "flags_all": [
-                            "dyad_boltweaver_ready"
-                        ]
-                    },
-                    "roll": {
-                        "kind": "phi_d20",
-                        "tags": [
-                            "craft",
-                            "defense",
-                            "harmony"
-                        ]
-                    },
-                    "outcomes": {
-                        "crit_success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 89
-                                },
-                                {
-                                    "type": "item",
-                                    "id": "armor_dyad_fluxcloak"
-                                },
-                                {
-                                    "type": "flag",
-                                    "id": "dyad_fluxcloak_worn",
-                                    "value": true
-                                }
-                            ],
-                            "narration": "You weave alternating bands of dawn silk and midnight mylar, creating a cloak that redirects lightning into motivational speeches."
-                        },
-                        "success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 55
-                                },
-                                {
-                                    "type": "item",
-                                    "id": "armor_dyad_fluxcloak"
-                                },
-                                {
-                                    "type": "flag",
-                                    "id": "dyad_fluxcloak_worn",
-                                    "value": true
-                                }
-                            ],
-                            "narration": "The fluxcloak drapes around your shoulders, fluttering whenever consensus spikes."
-                        },
-                        "fail": {
-                            "effects": [
-                                {
-                                    "type": "coins",
-                                    "op": "-",
-                                    "value": 21
-                                }
-                            ],
-                            "narration": "The cloak frays at the seam and you donate the scraps to the pity vault."
-                        },
-                        "crit_fail": {
-                            "effects": [
-                                {
-                                    "type": "hp",
-                                    "op": "-",
-                                    "value": 7
-                                }
-                            ],
-                            "narration": "You get tangled in the loom and tumble into a bin of static-charged ribbon."
-                        }
-                    },
-                    "banter": {
-                        "dev": "Fluxcloak patch ready.",
-                        "trader": "Storm insurance included.",
-                        "whale": "Wake flows along the hem.",
-                        "hacker": "Anti-zap lining verified.",
-                        "shiller": "New fashion drop: lightning couture.",
-                        "validator": "Armor rating notarized.",
-                        "miner": "Looks warm enough for tunnels.",
-                        "meme": "Serving weather-resistant realness."
-                    },
-                    "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_armor_fluxcloak"
-                    ]
-                },
-                {
-                    "id": "dyad_helm_parallax",
-                    "label": "Cast the Parallax Crown",
-                    "requirements": {
-                        "items_any": [],
-                        "flags_all": [
-                            "dyad_fluxcloak_worn"
-                        ]
-                    },
-                    "roll": {
-                        "kind": "phi_d20",
-                        "tags": [
-                            "craft",
-                            "insight",
-                            "vision"
-                        ]
-                    },
-                    "outcomes": {
-                        "crit_success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 89
-                                },
-                                {
-                                    "type": "item",
-                                    "id": "helm_dyad_parallax"
-                                },
-                                {
-                                    "type": "flag",
-                                    "id": "insight",
-                                    "value": true
-                                }
-                            ],
-                            "narration": "You fuse mirrored lightning rods into a circlet that lets you see both futures at once: what happens if dawn wins, and what happens if midnight rallies."
-                        },
-                        "success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 55
-                                },
-                                {
-                                    "type": "item",
-                                    "id": "helm_dyad_parallax"
-                                },
-                                {
-                                    "type": "flag",
-                                    "id": "insight",
-                                    "value": true
-                                }
-                            ],
-                            "narration": "The crown hums with layered predictions, gently nudging your decisions toward the golden ratio."
-                        },
-                        "fail": {
-                            "effects": [
-                                {
-                                    "type": "focus",
-                                    "op": "-",
-                                    "value": 1
-                                }
-                            ],
-                            "narration": "You overheat the crown mold and have to wait for it to cool, losing a sliver of confidence."
-                        },
-                        "crit_fail": {
-                            "effects": [
-                                {
-                                    "type": "hp",
-                                    "op": "-",
-                                    "value": 6
-                                }
-                            ],
-                            "narration": "The crown closes while you\u2019re fitting it, giving you a static hairstyle worthy of the meme feed."
-                        }
-                    },
-                    "banter": {
-                        "dev": "Parallax runtime linked to HUD.",
-                        "trader": "Forecast spread updated.",
-                        "whale": "Wake enjoys the dual vantage.",
-                        "hacker": "Prediction engine scrubbed.",
-                        "shiller": "Selling \"see both storms\" eyewear.",
-                        "validator": "Sight metrics notarized.",
-                        "miner": "Can it spot ore veins too?",
-                        "meme": "Two futures, one crown."
-                    },
-                    "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_helm_parallax"
-                    ]
-                },
-                {
-                    "id": "dyad_trinket_capacitor",
-                    "label": "Charge the Storm Capacitor",
-                    "requirements": {
-                        "items_any": [],
-                        "flags_all": [
-                            "dyad_fluxcloak_worn"
-                        ]
-                    },
-                    "roll": {
-                        "kind": "phi_d20",
-                        "tags": [
-                            "craft",
-                            "utility",
-                            "luck"
-                        ]
-                    },
-                    "outcomes": {
-                        "crit_success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 55
-                                },
-                                {
-                                    "type": "item",
-                                    "id": "trinket_dyad_capacitor"
-                                },
-                                {
-                                    "type": "coins",
-                                    "op": "+",
-                                    "value": 34
-                                }
-                            ],
-                            "narration": "You bottle excess lightning into a capacitor charm that can discharge to power consensus rituals or jump-start idle allies."
-                        },
-                        "success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 34
-                                },
-                                {
-                                    "type": "item",
-                                    "id": "trinket_dyad_capacitor"
-                                }
-                            ],
-                            "narration": "The capacitor hums with stored goodwill, ready to release a motivational jolt."
-                        },
-                        "fail": {
-                            "effects": [
-                                {
-                                    "type": "coins",
-                                    "op": "-",
-                                    "value": 13
-                                }
-                            ],
-                            "narration": "You overfill the charm and it pops, leaving you with a small invoice and a big lesson."
-                        },
-                        "crit_fail": {
-                            "effects": [
-                                {
-                                    "type": "hp",
-                                    "op": "-",
-                                    "value": 5
-                                }
-                            ],
-                            "narration": "The capacitor discharges into your fingertips. You shake them out while everyone applauds your endurance."
-                        }
-                    },
-                    "banter": {
-                        "dev": "Capacitor module stable.",
-                        "trader": "Charge futures trending.",
-                        "whale": "Wake shares spare volts.",
-                        "hacker": "No short-circuits detected.",
-                        "shiller": "Charm doubles as a rave accessory.",
-                        "validator": "Charge logs notarized.",
-                        "miner": "Save that jolt for drill jams.",
-                        "meme": "I\u2019m positively charged about this."
-                    },
-                    "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_trinket_capacitor"
+                        "scene:4.7",
+                        "action:horizon_banner_stitch"
                     ]
                 }
             ],
@@ -858,16 +841,16 @@
             ]
         },
         {
-            "round_id": "4.5-R4",
-            "description": "Storm Market Mezzanine \u2014 redeem pity charges, rebalance backpacks, and chart shy-and-trust lanes through the gale.",
+            "round_id": "4.7-R4",
+            "description": "Atrium of Exchange \u2014 flood the pity reserve, orchestrate crown trades, and attune backpacks for the final charge.",
             "actions": [
                 {
-                    "id": "dyad_pity_channel",
-                    "label": "Open the Pity Channel",
+                    "id": "horizon_pity_atrium",
+                    "label": "Flood the Pity Reserve",
                     "requirements": {
                         "items_any": [],
                         "flags_all": [
-                            "dyad_pity_counter"
+                            "horizon_flux_sung"
                         ]
                     },
                     "roll": {
@@ -886,16 +869,17 @@
                                     "value": 89
                                 },
                                 {
-                                    "type": "item",
-                                    "id": "deck_dyad_tempest"
+                                    "type": "coins",
+                                    "op": "+",
+                                    "value": 55
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "dyad_market_open",
+                                    "id": "horizon_pity_open",
                                     "value": true
                                 }
                             ],
-                            "narration": "You plug the pity counter straight into the market and siphon a tempest deck loaded with dual-storm boons."
+                            "narration": "You spin the reserve into overdrive. Vendors unlock a hidden shelf of finale-only boons."
                         },
                         "success": {
                             "effects": [
@@ -904,27 +888,22 @@
                                     "value": 55
                                 },
                                 {
-                                    "type": "coins",
-                                    "op": "+",
-                                    "value": 55
-                                },
-                                {
                                     "type": "flag",
-                                    "id": "dyad_market_open",
+                                    "id": "horizon_pity_open",
                                     "value": true
                                 }
                             ],
-                            "narration": "Pity charges flow into discounts. Shopkeepers fling you insulated tote bags stuffed with consumables."
+                            "narration": "The reserve glows steady and the atrium erupts in cheers."
                         },
                         "fail": {
                             "effects": [
                                 {
                                     "type": "coins",
                                     "op": "-",
-                                    "value": 13
+                                    "value": 21
                                 }
                             ],
-                            "narration": "You mispronounce a vendor\u2019s name and pay a politeness penalty."
+                            "narration": "A ledger hiccup double-charges you before refunding it as hype coupons."
                         },
                         "crit_fail": {
                             "effects": [
@@ -934,219 +913,39 @@
                                     "value": 4
                                 }
                             ],
-                            "narration": "A gust flips your receipts into the storm. You chase them while everyone cheers."
+                            "narration": "You slip on a gold coin avalanche and slide into a merch cart."
                         }
                     },
                     "banter": {
-                        "dev": "Pity API surge-tested.",
-                        "trader": "Discount winds blowing.",
-                        "whale": "Wake subsidizes the stalls.",
-                        "hacker": "Double-entry refunds confirmed.",
-                        "shiller": "Flash sale: lightning loyalty.",
-                        "validator": "Invoices notarized mid-gale.",
-                        "miner": "Finally, a sale on grounded boots.",
-                        "meme": "Pity? More like litty."
+                        "dev": "Reserve backend fortified.",
+                        "trader": "Liquidity for days.",
+                        "whale": "Wake bankrolls every boon.",
+                        "hacker": "Refund macros signed.",
+                        "shiller": "Calling it the Grand Gratitude Drop.",
+                        "validator": "Deposits notarized with sparkles.",
+                        "miner": "Buying stamina shots for the crew.",
+                        "meme": "Pity party enters legendary tier."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_pity_channel"
+                        "scene:4.7",
+                        "action:horizon_pity_atrium"
                     ]
                 },
                 {
-                    "id": "dyad_backpack_realign",
-                    "label": "Realign Storm Backpacks",
+                    "id": "horizon_trade_crown",
+                    "label": "Orchestrate Crown Trades",
                     "requirements": {
                         "items_any": [],
                         "flags_all": [
-                            "dyad_market_open"
+                            "horizon_pity_open"
                         ]
                     },
                     "roll": {
                         "kind": "phi_d20",
                         "tags": [
-                            "logistics",
-                            "analysis",
-                            "support"
-                        ]
-                    },
-                    "outcomes": {
-                        "crit_success": {
-                            "effects": [
-                                {
-                                    "type": "focus",
-                                    "op": "+",
-                                    "value": 3
-                                },
-                                {
-                                    "type": "xp",
-                                    "value": 55
-                                },
-                                {
-                                    "type": "coins",
-                                    "op": "+",
-                                    "value": 34
-                                }
-                            ],
-                            "narration": "You reorganize every backpack so the gold storm fuels offense pockets and the cobalt storm powers defense slots. Traders start copying your layout instantly."
-                        },
-                        "success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 34
-                                }
-                            ],
-                            "narration": "Backpacks click into tidy alignment. Gremlin inspectors salute."
-                        },
-                        "fail": {
-                            "effects": [
-                                {
-                                    "type": "focus",
-                                    "op": "-",
-                                    "value": 1
-                                }
-                            ],
-                            "narration": "You chase loose straps through a crosswind until you need a breather."
-                        },
-                        "crit_fail": {
-                            "effects": [
-                                {
-                                    "type": "hp",
-                                    "op": "-",
-                                    "value": 4
-                                }
-                            ],
-                            "narration": "A rogue gust slams a backpack into your face. The meme division applauds the slapstick."
-                        }
-                    },
-                    "banter": {
-                        "dev": "Inventory schema updated.",
-                        "trader": "Bag flow optimized.",
-                        "whale": "Wake carries the heavy loads.",
-                        "hacker": "No contraband survive that sort.",
-                        "shiller": "Backpack balancing service launching soon.",
-                        "validator": "Checklists notarized in duplicate.",
-                        "miner": "Now my pick sits snug.",
-                        "meme": "Storm Marie Kondo."
-                    },
-                    "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_backpack_realign"
-                    ]
-                },
-                {
-                    "id": "dyad_lane_cartography",
-                    "label": "Chart Trust & Shy Lanes",
-                    "requirements": {
-                        "items_any": [],
-                        "flags_all": []
-                    },
-                    "roll": {
-                        "kind": "phi_d20",
-                        "tags": [
-                            "insight",
-                            "support",
-                            "navigation"
-                        ]
-                    },
-                    "outcomes": {
-                        "crit_success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 55
-                                },
-                                {
-                                    "type": "flag",
-                                    "id": "trustful",
-                                    "value": true
-                                },
-                                {
-                                    "type": "flag",
-                                    "id": "shy",
-                                    "value": true
-                                }
-                            ],
-                            "narration": "You map alternating lanes for loud trust rallies and quiet shy retreats so everyone can traverse the storm in comfort."
-                        },
-                        "success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 34
-                                },
-                                {
-                                    "type": "flag",
-                                    "id": "trustful",
-                                    "value": true
-                                }
-                            ],
-                            "narration": "You label pathways that minimize collisions. Validators project them into the air."
-                        },
-                        "fail": {
-                            "effects": [
-                                {
-                                    "type": "coins",
-                                    "op": "-",
-                                    "value": 8
-                                }
-                            ],
-                            "narration": "Your chalk map washes away in a gust. The pity ledger replenishes some markers."
-                        },
-                        "crit_fail": {
-                            "effects": [
-                                {
-                                    "type": "hp",
-                                    "op": "-",
-                                    "value": 4
-                                }
-                            ],
-                            "narration": "You take a wrong step and ride a wind tunnel headfirst into a banner. Everyone laughs kindly."
-                        }
-                    },
-                    "banter": {
-                        "dev": "Storm routing overlay deployed.",
-                        "trader": "Traffic flows smoother already.",
-                        "whale": "Wake glides down the trust lane.",
-                        "hacker": "Navigation beacons secure.",
-                        "shiller": "Guided tours now available.",
-                        "validator": "Routes notarized.",
-                        "miner": "Short path to the ore vendor, thanks.",
-                        "meme": "Trust lane? More like gust lane."
-                    },
-                    "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_lane_cartography"
-                    ]
-                }
-            ],
-            "rewards": [
-                {
-                    "type": "focus",
-                    "op": "+",
-                    "value": 2
-                }
-            ]
-        },
-        {
-            "round_id": "4.5-R5",
-            "description": "Reboot Platform \u2014 jolt fallen allies, enforce AFK treadmill routines, and signal arrivals surfed in on storm droplets.",
-            "actions": [
-                {
-                    "id": "dyad_revive",
-                    "label": "Shock a Fallen Ally",
-                    "requirements": {
-                        "items_any": [],
-                        "flags_all": [
-                            "dyad_afk_network"
-                        ]
-                    },
-                    "roll": {
-                        "kind": "phi_d20",
-                        "tags": [
-                            "revive",
-                            "support",
-                            "ritual"
+                            "economy",
+                            "negotiation",
+                            "strategy"
                         ]
                     },
                     "outcomes": {
@@ -1157,113 +956,31 @@
                                     "value": 89
                                 },
                                 {
-                                    "type": "focus",
-                                    "op": "+",
-                                    "value": 3
-                                },
-                                {
-                                    "type": "flag",
-                                    "id": "harmony",
-                                    "value": true
-                                }
-                            ],
-                            "narration": "You inscribe a spiral of storm glyphs around the fallen ally and release the capacitor charm. They reboot laughing, hair fizzing with static harmony."
-                        },
-                        "success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 55
-                                }
-                            ],
-                            "narration": "The ally jolts upright, blinking away residual lightning."
-                        },
-                        "fail": {
-                            "effects": [
-                                {
-                                    "type": "focus",
-                                    "op": "-",
-                                    "value": 1
-                                }
-                            ],
-                            "narration": "You mix up the polarity and have to start the ritual again, muttering apologies."
-                        },
-                        "crit_fail": {
-                            "effects": [
-                                {
-                                    "type": "hp",
-                                    "op": "-",
-                                    "value": 5
-                                }
-                            ],
-                            "narration": "You catch the rebound arc and tumble into a pile of insulated pillows. The meme crew adds thunder sound effects."
-                        }
-                    },
-                    "banter": {
-                        "dev": "Revive routine electrified.",
-                        "trader": "Resurrection futures surge.",
-                        "whale": "Wake cushions the landing.",
-                        "hacker": "Checksum validated mid-bolt.",
-                        "shiller": "Stormshock loyalty perk!",
-                        "validator": "Revival logged and notarized.",
-                        "miner": "Back on your feet; drills await.",
-                        "meme": "Static hair, don\u2019t care."
-                    },
-                    "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_revive"
-                    ]
-                },
-                {
-                    "id": "dyad_afk_force",
-                    "label": "Start AFK Treadmills",
-                    "requirements": {
-                        "items_any": [],
-                        "flags_all": [
-                            "dyad_afk_network"
-                        ]
-                    },
-                    "roll": {
-                        "kind": "phi_d20",
-                        "tags": [
-                            "automation",
-                            "discipline",
-                            "support"
-                        ]
-                    },
-                    "outcomes": {
-                        "crit_success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 55
-                                },
-                                {
                                     "type": "coins",
                                     "op": "+",
-                                    "value": 21
+                                    "value": 55
                                 }
                             ],
-                            "narration": "You sync the treadmills to storm tempo. Idle players jog into micro-quests while the Dyad pays you a maintenance bonus."
+                            "narration": "You swap relics and resources with such grace that even rival guilds hug it out."
                         },
                         "success": {
                             "effects": [
                                 {
                                     "type": "xp",
-                                    "value": 34
+                                    "value": 55
                                 }
                             ],
-                            "narration": "Force-play mode engages with a friendly chime."
+                            "narration": "Trades settle smoothly, leaving every squad stocked."
                         },
                         "fail": {
                             "effects": [
                                 {
-                                    "type": "focus",
+                                    "type": "coins",
                                     "op": "-",
-                                    "value": 1
+                                    "value": 13
                                 }
                             ],
-                            "narration": "You broadcast the reminder at the wrong tempo and a whale side-eyes you before stepping on."
+                            "narration": "A mislabelled crate forces a scramble. You cover the shipping difference."
                         },
                         "crit_fail": {
                             "effects": [
@@ -1273,52 +990,56 @@
                                     "value": 4
                                 }
                             ],
-                            "narration": "You forget to step off your own treadmill and faceplant. Validators help you up between giggles."
+                            "narration": "You hype a swap so hard you tumble into a fountain of holo confetti."
                         }
                     },
                     "banter": {
-                        "dev": "Force-play daemon synced.",
-                        "trader": "Idle tax repurposed as cardio.",
-                        "whale": "Wake keeps the pace.",
-                        "hacker": "Scripts monitored for loops.",
-                        "shiller": "Storm gym membership unlocked.",
-                        "validator": "Treadmill logs notarized.",
-                        "miner": "Can we set incline to \"mountain\"?",
-                        "meme": "AFK now stands for \"Always Flexing Knees\"."
+                        "dev": "Market orchestration live.",
+                        "trader": "Bid-ask tighter than ever.",
+                        "whale": "Wake secures every handshake.",
+                        "hacker": "Contracts triple-checked.",
+                        "shiller": "Trading floor reality show greenlit.",
+                        "validator": "Receipts notarized midair.",
+                        "miner": "Bartered ore chips for focus potions.",
+                        "meme": "Buy low, cry never."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_afk_force"
+                        "scene:4.7",
+                        "action:horizon_trade_crown"
                     ]
                 },
                 {
-                    "id": "dyad_arrival_signal",
-                    "label": "Signal Storm Arrivals",
+                    "id": "horizon_backpack_attune",
+                    "label": "Attune Crown Backpacks",
                     "requirements": {
                         "items_any": [],
-                        "flags_all": []
+                        "flags_all": [
+                            "horizon_pity_open",
+                            "horizon_supply_encoded"
+                        ]
                     },
                     "roll": {
                         "kind": "phi_d20",
                         "tags": [
-                            "communication",
+                            "logistics",
                             "support",
-                            "ritual"
+                            "discipline"
                         ]
                     },
                     "outcomes": {
                         "crit_success": {
                             "effects": [
                                 {
-                                    "type": "xp",
-                                    "value": 55
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
                                 },
                                 {
-                                    "type": "item",
-                                    "id": "weapon_dyad_lightningbug"
+                                    "type": "xp",
+                                    "value": 55
                                 }
                             ],
-                            "narration": "You release a swarm of lightningbugs that sketch the GMGN motif across the storms. New arrivals surf down the trails, cheering."
+                            "narration": "Backpacks hum with synchronized wake pulses. Everyone moves as if gravity forgot to oppose them."
                         },
                         "success": {
                             "effects": [
@@ -1327,7 +1048,7 @@
                                     "value": 34
                                 }
                             ],
-                            "narration": "You ping the arrival gong. A pair of drenched but smiling gremlins tumble in."
+                            "narration": "Straps snug, pockets labelled, morale sky-high."
                         },
                         "fail": {
                             "effects": [
@@ -1337,32 +1058,32 @@
                                     "value": 8
                                 }
                             ],
-                            "narration": "You mistime the signal and only attract storm gulls, who demand snacks."
+                            "narration": "You misplace a canteen and owe the squad a round of sodas."
                         },
                         "crit_fail": {
                             "effects": [
                                 {
                                     "type": "hp",
                                     "op": "-",
-                                    "value": 4
+                                    "value": 3
                                 }
                             ],
-                            "narration": "You stand too close to the gong and it rattles your bones. Everyone still applauds the effort."
+                            "narration": "A strap snaps and slingshots you into a friendly validator."
                         }
                     },
                     "banter": {
-                        "dev": "Onboarding channel reopened.",
-                        "trader": "Fresh liquidity slides in.",
-                        "whale": "Wake catches new surfers.",
-                        "hacker": "Invite tokens air-dropped.",
-                        "shiller": "Influencer storm party!",
-                        "validator": "Arrivals notarized.",
-                        "miner": "More hands for the lightning rods.",
-                        "meme": "New storm, who dis?"
+                        "dev": "Bag attunement patch shipped.",
+                        "trader": "Inventory friction near zero.",
+                        "whale": "Wake cushions every buckle.",
+                        "hacker": "No contraband zipped inside.",
+                        "shiller": "Backpack glam cam rolling.",
+                        "validator": "Checklists notarized.",
+                        "miner": "Tools click like music now.",
+                        "meme": "Pack light, pack bright."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_arrival_signal"
+                        "scene:4.7",
+                        "action:horizon_backpack_attune"
                     ]
                 }
             ],
@@ -1374,24 +1095,24 @@
             ]
         },
         {
-            "round_id": "4.5-R6",
-            "description": "Spectrum Gate Catwalk \u2014 align the twin doorways, distribute focus charges, and project threshold metrics across the Dyad.",
+            "round_id": "4.7-R5",
+            "description": "Constellation Ward \u2014 ignite the revival corona, rehearse orbit-forcing drills, and channel focus into the final breath.",
             "actions": [
                 {
-                    "id": "dyad_gate_modulate",
-                    "label": "Modulate the Twin Door",
+                    "id": "horizon_revive_corona",
+                    "label": "Ignite the Revival Corona",
                     "requirements": {
                         "items_any": [],
                         "flags_all": [
-                            "dyad_balance_logged"
+                            "horizon_flux_sung"
                         ]
                     },
                     "roll": {
                         "kind": "phi_d20",
                         "tags": [
-                            "ritual",
-                            "engineering",
-                            "focus"
+                            "support",
+                            "healing",
+                            "ritual"
                         ]
                     },
                     "outcomes": {
@@ -1408,11 +1129,11 @@
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "dyad_gate_tuned",
+                                    "id": "horizon_revive_online",
                                     "value": true
                                 }
                             ],
-                            "narration": "You tune two spectrum doors so they overlap like a Venn diagram of light. The storms settle, agreeing to funnel consensus through your alignment."
+                            "narration": "You kindle a halo that revives anyone who stumbles. Exhaustion evaporates in a wash of dawn-colored mist."
                         },
                         "success": {
                             "effects": [
@@ -1422,63 +1143,145 @@
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "dyad_gate_tuned",
+                                    "id": "horizon_revive_online",
                                     "value": true
                                 }
                             ],
-                            "narration": "The doors hum at the same pitch, ready to accept the vote."
+                            "narration": "The corona hums steadily. Medics cheer as the ward goes green."
                         },
                         "fail": {
                             "effects": [
                                 {
-                                    "type": "focus",
+                                    "type": "coins",
                                     "op": "-",
-                                    "value": 1
+                                    "value": 13
                                 }
                             ],
-                            "narration": "You misalign a prism and the doors flicker. Engineers nudge them back on track with gentle advice."
+                            "narration": "A pulse sputters. You fund extra shielding to fix it."
                         },
                         "crit_fail": {
                             "effects": [
                                 {
                                     "type": "hp",
                                     "op": "-",
-                                    "value": 6
+                                    "value": 4
                                 }
                             ],
-                            "narration": "You get caught between the doors mid-oscillation and stumble out with your hair glowing."
+                            "narration": "The corona backfires with glitter sparks that coat you head to toe."
                         }
                     },
                     "banter": {
-                        "dev": "Twin door firmware merged.",
-                        "trader": "Spectrum spreads anchored.",
-                        "whale": "Wake threads the threshold.",
-                        "hacker": "Door handshake triple-signed.",
-                        "shiller": "Act transition teaser unlocked.",
-                        "validator": "Calibration notarized.",
-                        "miner": "Doors steady enough for ore carts.",
-                        "meme": "Double doors, double drama."
+                        "dev": "Revival corona online.",
+                        "trader": "Insurance rates nosedive.",
+                        "whale": "Wake cushions the stumble.",
+                        "hacker": "Ward relays hardened.",
+                        "shiller": "Finale spa treatment unlocked.",
+                        "validator": "Uptime notarized.",
+                        "miner": "Faceplant proof. Love it.",
+                        "meme": "Glow-up respawn."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_gate_modulate"
+                        "scene:4.7",
+                        "action:horizon_revive_corona"
                     ]
                 },
                 {
-                    "id": "dyad_focus_distribution",
-                    "label": "Distribute Storm Focus",
+                    "id": "horizon_force_orbit",
+                    "label": "Rehearse Orbit Drills",
                     "requirements": {
                         "items_any": [],
                         "flags_all": [
-                            "dyad_gate_tuned"
+                            "horizon_afk_satellites"
                         ]
                     },
                     "roll": {
                         "kind": "phi_d20",
                         "tags": [
-                            "support",
-                            "strategy",
-                            "resource"
+                            "discipline",
+                            "performance",
+                            "support"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "horizon_force_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You choreograph AFK recoveries into a zero-gravity dance. Every idle ally re-enters the fray grinning."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "horizon_force_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Drills flow smoothly. Nobody forgets how to jump back into orbit."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 8
+                                }
+                            ],
+                            "narration": "A rehearsal devolves into slapstick. You bribe the meme crew with popcorn."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 3
+                                }
+                            ],
+                            "narration": "You spin too hard and skid the length of the terrace. Everyone applauds anyway."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Orbit drills uploaded.",
+                        "trader": "Idle risk hedged.",
+                        "whale": "Wake keeps the cadence tight.",
+                        "hacker": "Macros signed and sealed.",
+                        "shiller": "Tutorial montage trending.",
+                        "validator": "Attendance notarized.",
+                        "miner": "These drills double as core day.",
+                        "meme": "Orbit or it didn’t happen."
+                    },
+                    "telemetry_tags": [
+                        "scene:4.7",
+                        "action:horizon_force_orbit"
+                    ]
+                },
+                {
+                    "id": "horizon_focus_chorus",
+                    "label": "Lead Focus Chorus",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "horizon_revive_online"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "spirit",
+                            "leadership",
+                            "support"
                         ]
                     },
                     "outcomes": {
@@ -1487,14 +1290,14 @@
                                 {
                                     "type": "focus",
                                     "op": "+",
-                                    "value": 4
+                                    "value": 3
                                 },
                                 {
                                     "type": "xp",
-                                    "value": 55
+                                    "value": 89
                                 }
                             ],
-                            "narration": "You design a focus rotation that charges players in alternating gold and cobalt bursts, keeping everyone balanced for the impending vote."
+                            "narration": "You anchor the entire crown in a shared inhale. Even the towers pause to listen."
                         },
                         "success": {
                             "effects": [
@@ -1504,84 +1307,7 @@
                                     "value": 2
                                 }
                             ],
-                            "narration": "Focus flasks rotate through the party. Spirits lift."
-                        },
-                        "fail": {
-                            "effects": [
-                                {
-                                    "type": "coins",
-                                    "op": "-",
-                                    "value": 13
-                                }
-                            ],
-                            "narration": "You spill a flask and owe the vendor."
-                        },
-                        "crit_fail": {
-                            "effects": [
-                                {
-                                    "type": "hp",
-                                    "op": "-",
-                                    "value": 4
-                                }
-                            ],
-                            "narration": "A misfire launches a focus burst into your face, leaving you sparkling but dazed."
-                        }
-                    },
-                    "banter": {
-                        "dev": "Focus balancer online.",
-                        "trader": "Energy arbitrage optimized.",
-                        "whale": "Wake tops up whichever side needs it.",
-                        "hacker": "Distribution logs encrypted.",
-                        "shiller": "Pitching this as \"storm mindfulness\".",
-                        "validator": "Allocations notarized.",
-                        "miner": "Save a vial for the tunnel crew.",
-                        "meme": "Focus group but literal."
-                    },
-                    "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_focus_distribution"
-                    ]
-                },
-                {
-                    "id": "dyad_threshold_projection",
-                    "label": "Project Threshold Metrics",
-                    "requirements": {
-                        "items_any": [],
-                        "flags_all": [
-                            "dyad_gate_tuned"
-                        ]
-                    },
-                    "roll": {
-                        "kind": "phi_d20",
-                        "tags": [
-                            "analysis",
-                            "insight",
-                            "logistics"
-                        ]
-                    },
-                    "outcomes": {
-                        "crit_success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 55
-                                },
-                                {
-                                    "type": "coins",
-                                    "op": "+",
-                                    "value": 34
-                                }
-                            ],
-                            "narration": "You project threshold charts into the storm clouds, revealing when the vote will peak and which flags are nearly triggered. Traders tip you for advance warning."
-                        },
-                        "success": {
-                            "effects": [
-                                {
-                                    "type": "xp",
-                                    "value": 34
-                                }
-                            ],
-                            "narration": "Your metrics anchor the crowd. Validators pin them to the consensus board."
+                            "narration": "Breathing circles spiral outward. Heartbeats sync with the wake hum."
                         },
                         "fail": {
                             "effects": [
@@ -1591,32 +1317,32 @@
                                     "value": 8
                                 }
                             ],
-                            "narration": "Your projector blinks out mid-slide and needs a firmware reboot."
+                            "narration": "A gust interrupts your count. You offer snacks and start again."
                         },
                         "crit_fail": {
                             "effects": [
                                 {
                                     "type": "hp",
                                     "op": "-",
-                                    "value": 4
+                                    "value": 3
                                 }
                             ],
-                            "narration": "A projector drone spins out and bonks you on the shoulder. The meme crew adds cartoon stars."
+                            "narration": "You inhale a stray glitter flake and sparkle-sneeze for a minute."
                         }
                     },
                     "banter": {
-                        "dev": "Metrics overlay deployed.",
-                        "trader": "Forecast board trending.",
-                        "whale": "Wake watches the KPIs.",
-                        "hacker": "Charts sanitized for secrets.",
-                        "shiller": "Weekly newsletter writes itself.",
-                        "validator": "Thresholds notarized.",
-                        "miner": "Stats say dig deeper.",
-                        "meme": "KPIs? More like K-Pies, hungry now."
+                        "dev": "Focus chorus cached.",
+                        "trader": "Calm minds trade sharper.",
+                        "whale": "Wake beats align to your pulse.",
+                        "hacker": "Breath app patched live.",
+                        "shiller": "ASMR rights secured.",
+                        "validator": "Chorus attendance notarized.",
+                        "miner": "Lungs ready for the plunge.",
+                        "meme": "Inhale hype, exhale doubt."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_threshold_projection"
+                        "scene:4.7",
+                        "action:horizon_focus_chorus"
                     ]
                 }
             ],
@@ -1628,24 +1354,283 @@
             ]
         },
         {
-            "round_id": "4.5-R7",
-            "description": "Consensus Vortex \u2014 call the Dyad vote, archive the storm haul, and stride into Act Five.",
+            "round_id": "4.7-R6",
+            "description": "Gate Alignment Deck \u2014 align the final gate lattice, broadcast future echoes, and seal the crown against leaks.",
             "actions": [
                 {
-                    "id": "dyad_consensus_vote",
-                    "label": "Call the Dyad Vote",
+                    "id": "horizon_gate_align",
+                    "label": "Align the Gate Lattice",
                     "requirements": {
                         "items_any": [],
                         "flags_all": [
-                            "dyad_gate_tuned"
+                            "horizon_flux_sung",
+                            "horizon_lane_woven"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "ritual",
+                            "navigation",
+                            "arcana"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "horizon_gate_aligned",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You stitch light through the oculus and the hidden gate answers with a resonant chord."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "horizon_gate_aligned",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Coordinates lock. The crown settles as if bracing for launch."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 21
+                                }
+                            ],
+                            "narration": "Your stitch slips and the lattice flickers. You invest in a spool of brighter thread."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 5
+                                }
+                            ],
+                            "narration": "The needle snaps and showers sparks. Hackers toss you a spare while laughing."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Gate lattice metrics green.",
+                        "trader": "Act Five futures spike.",
+                        "whale": "Wake hum acknowledges the stitch.",
+                        "hacker": "Portal firmware patched midair.",
+                        "shiller": "Teasers: unlocked.",
+                        "validator": "Alignment notarized.",
+                        "miner": "Portal seam ready for chisels.",
+                        "meme": "Needle drop part two."
+                    },
+                    "telemetry_tags": [
+                        "scene:4.7",
+                        "action:horizon_gate_align"
+                    ]
+                },
+                {
+                    "id": "horizon_signal_future",
+                    "label": "Broadcast Future Echoes",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "horizon_gate_aligned"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "communication",
+                            "spirit",
+                            "support"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "horizon_signal_answered",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Your broadcast rides the lattice and returns with a whisper of Act Five’s skyline."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "horizon_signal_answered",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Echoes answer steady and sure. The crowd roars."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 13
+                                }
+                            ],
+                            "narration": "Static crackles back. You upgrade the transmitters."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 3
+                                }
+                            ],
+                            "narration": "Your voice squeaks mid broadcast. The meme crew adds subtitles."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Echo telemetry captured.",
+                        "trader": "Spec curves updating live.",
+                        "whale": "Wake hears its future.",
+                        "hacker": "Channel sealed from spoofers.",
+                        "shiller": "Trailer editors screaming.",
+                        "validator": "Transmission notarized.",
+                        "miner": "Echo says the ore sparkles ahead.",
+                        "meme": "We called, destiny picked up."
+                    },
+                    "telemetry_tags": [
+                        "scene:4.7",
+                        "action:horizon_signal_future"
+                    ]
+                },
+                {
+                    "id": "horizon_gateward_seal",
+                    "label": "Seal the Crown Wards",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "horizon_gate_aligned"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "defense",
+                            "systems",
+                            "discipline"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "horizon_gate_guarded",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Your wards lock like a celestial vault. Stray gusts glance off in showers of harmless sparks."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "horizon_gate_guarded",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Barrier glyphs settle, bright and secure."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 13
+                                }
+                            ],
+                            "narration": "A gap flickers open. You call hackers and patch it fast."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 4
+                                }
+                            ],
+                            "narration": "A ward rebounds and knocks you into a pylon. Crowd cheers your dedication."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Firewall literally lit.",
+                        "trader": "Risk premiums recalculated.",
+                        "whale": "Wake swims behind the shield.",
+                        "hacker": "Wards double-hashed.",
+                        "shiller": "Marketing copy: portals but safe.",
+                        "validator": "Integrity notarized.",
+                        "miner": "Ward even covers the tool racks.",
+                        "meme": "Zero-day? Zero-way."
+                    },
+                    "telemetry_tags": [
+                        "scene:4.7",
+                        "action:horizon_gateward_seal"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "4.7-R7",
+            "description": "Horizon Council \u2014 call the final consensus, archive the crown pattern, and stride toward Act Five.",
+            "actions": [
+                {
+                    "id": "horizon_consensus_vote",
+                    "label": "Call the Horizon Vote",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "horizon_gate_aligned"
                         ]
                     },
                     "roll": {
                         "kind": "phi_d20",
                         "tags": [
                             "leadership",
-                            "ritual",
-                            "consensus"
+                            "consensus",
+                            "spirit"
                         ]
                     },
                     "outcomes": {
@@ -1662,11 +1647,11 @@
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "dyad_consensus_passed",
+                                    "id": "horizon_consensus_passed",
                                     "value": true
                                 }
                             ],
-                            "narration": "You raise both hands, one glowing gold, one glowing cobalt, and shout the vote cadence. The storms knot together in a luminous tornado as consensus locks."
+                            "narration": "You raise a corona-lit banner and every guild answers. The crown blazes white as consensus locks."
                         },
                         "success": {
                             "effects": [
@@ -1676,11 +1661,11 @@
                                 },
                                 {
                                     "type": "flag",
-                                    "id": "dyad_consensus_passed",
+                                    "id": "horizon_consensus_passed",
                                     "value": true
                                 }
                             ],
-                            "narration": "Hands, tails, and tendrils lift. The Dyad roars approval and the doors flare emerald."
+                            "narration": "Hands, fins, and data tendrils lift in unison. The horizon roars agreement."
                         },
                         "fail": {
                             "effects": [
@@ -1690,98 +1675,98 @@
                                     "value": 13
                                 }
                             ],
-                            "narration": "You lose quorum when a lightning joke misfires. The pity ledger offers consolation snacks while you regroup."
+                            "narration": "A gust steals ballots mid-speech. You fund new ones with a grin."
                         },
                         "crit_fail": {
                             "effects": [
                                 {
                                     "type": "hp",
                                     "op": "-",
-                                    "value": 6
+                                    "value": 5
                                 }
                             ],
-                            "narration": "A gust whirls your notes away mid-speech. The meme crew projects subtitles to help you recover."
+                            "narration": "You riff too hard and the meme crew heckles you affectionately until you reset."
                         }
                     },
                     "banter": {
-                        "dev": "Vote routine executed.",
-                        "trader": "Quorum candles close high.",
-                        "whale": "Wake endorses both storms.",
-                        "hacker": "Ballot ledger spark-proof.",
-                        "shiller": "Headline: Dyad says yes!",
-                        "validator": "Votes notarized in stereo.",
-                        "miner": "Consensus points toward a deeper seam.",
-                        "meme": "Democracy but lightning."
+                        "dev": "Vote pipeline streaming.",
+                        "trader": "Consensus candles explode upward.",
+                        "whale": "Wake thunders approval.",
+                        "hacker": "Ballots unbreakable.",
+                        "shiller": "Headline: Horizon says go!",
+                        "validator": "Votes notarized with starlight.",
+                        "miner": "Ready to swing into Act Five.",
+                        "meme": "Democracy but orbital."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_consensus_vote"
+                        "scene:4.7",
+                        "action:horizon_consensus_vote"
                     ]
                 },
                 {
-                    "id": "dyad_reward_archive",
-                    "label": "Archive Storm Rewards",
+                    "id": "horizon_reward_archive",
+                    "label": "Archive the Crown Pattern",
                     "requirements": {
                         "items_any": [],
                         "flags_all": [
-                            "dyad_consensus_passed"
+                            "horizon_consensus_passed"
                         ]
                     },
                     "outcomes": {
                         "success": {
                             "effects": [
                                 {
-                                    "type": "item",
-                                    "id": "deck_dyad_tempest"
+                                    "type": "deck",
+                                    "id": "deck_horizon_corona"
                                 }
                             ],
-                            "narration": "You spool the Dyad\u2019s ledger threads into a tempest deck packed with dual-aligned boons for future runs."
+                            "narration": "You fold the crown’s schematics into a radiant deck ready to deploy whenever a community needs a rally point."
                         }
                     },
                     "banter": {
-                        "dev": "Reward ledger sealed.",
-                        "trader": "Profits tallied.",
-                        "whale": "Wake shares the gust bounty.",
-                        "hacker": "Archives insulated.",
-                        "shiller": "Highlight reel ready to air.",
-                        "validator": "Receipts notarized.",
-                        "miner": "Loot tied down in sandbags.",
-                        "meme": "Deck the storms with bolts of holly."
+                        "dev": "Pattern sealed for posterity.",
+                        "trader": "Blueprint futures minted.",
+                        "whale": "Wake memorizes the design.",
+                        "hacker": "Archives double-locked.",
+                        "shiller": "Limited prints dropping at dawn.",
+                        "validator": "Documentation notarized.",
+                        "miner": "Copy tucked in the drill case.",
+                        "meme": "Decked out in destiny."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:dyad_reward_archive"
+                        "scene:4.7",
+                        "action:horizon_reward_archive"
                     ]
                 },
                 {
-                    "id": "advance_4_6",
-                    "label": "March onto the Convergence Causeway",
+                    "id": "advance_5",
+                    "label": "Stride Into Act Five",
                     "requirements": {
                         "items_any": [],
                         "flags_all": [
-                            "dyad_consensus_passed"
+                            "horizon_consensus_passed"
                         ]
                     },
                     "outcomes": {
                         "success": {
                             "effects": [],
-                            "narration": "The twin doors align into the Convergence Causeway, a runway of light that beckons Act Four\u2019s united march toward the Horizon Crown.",
-                            "next_hint": "4.6"
+                            "narration": "The crown’s prongs tilt and form a runway of light leading into Act Five’s waiting skyline. You charge forward with the Wake at your back.",
+                            "next_hint": "5.1"
                         }
                     },
                     "banter": {
-                        "dev": "Causeway boot sequence engaged.",
-                        "trader": "Rolling positions onto the bridge.",
-                        "whale": "Wake stretches toward the Causeway.",
-                        "hacker": "Transition handshake rerouted.",
-                        "shiller": "Sneak peek: bridge drop imminent.",
-                        "validator": "Advance notarized for Act Four.",
-                        "miner": "New span, same grit.",
-                        "meme": "From storms to bridges, no pause."
+                        "dev": "Final transition committed.",
+                        "trader": "Rolling positions into Act Five.",
+                        "whale": "Wake accelerates into the unknown.",
+                        "hacker": "Handshake verified across timelines.",
+                        "shiller": "Trailer voiceover: \"And then...\"",
+                        "validator": "Advance notarized with fireworks.",
+                        "miner": "New seam dead ahead.",
+                        "meme": "From crown to clown? Never."
                     },
                     "telemetry_tags": [
-                        "scene:4.5",
-                        "action:advance_4_6"
+                        "scene:4.7",
+                        "action:advance_5"
                     ]
                 }
             ],
@@ -1795,31 +1780,31 @@
     ],
     "threshold_rewards": [
         {
-            "focus_gte": 13,
+            "focus_gte": 17,
             "rewards": [
                 {
                     "type": "coins",
-                    "value": 55
+                    "value": 89
                 }
             ]
         },
         {
-            "xp_gte": 720,
+            "xp_gte": 990,
             "rewards": [
                 {
                     "type": "item",
-                    "id": "armor_dyad_fluxcloak"
+                    "id": "armor_horizon_corona"
                 }
             ]
         },
         {
             "flags_all": [
-                "dyad_consensus_passed"
+                "horizon_consensus_passed"
             ],
             "rewards": [
                 {
                     "type": "deck",
-                    "id": "deck_dyad_tempest"
+                    "id": "deck_horizon_corona"
                 }
             ]
         }
@@ -1827,15 +1812,15 @@
     "arrivals": [
         {
             "when": "flags.afk_tracked",
-            "goto": "4.5A"
+            "goto": "4.7A"
         },
         {
-            "when": "flags.dyad_consensus_passed",
-            "goto": "4.6"
+            "when": "flags.horizon_consensus_passed",
+            "goto": "5.1"
         },
         {
             "when": "else",
-            "goto": "4.5"
+            "goto": "4.7"
         }
     ]
 }

--- a/content/genesis/scenes/scene_5.1.json
+++ b/content/genesis/scenes/scene_5.1.json
@@ -1,0 +1,1591 @@
+{
+    "schema_version": "1.0",
+    "content_id": "genesis",
+    "book_id": "book_1",
+    "scene_id": "5.1",
+    "title": "The Wakefront Threshold — Fate Splits in Four",
+    "narration": "You burst from the Horizon Crown into the Wakefront Threshold, a colossal switchback of glass platforms suspended inside a prism of tidal light. Four immense silhouettes lean over the scene like possible endings: a tower crowned in mourning veils, a vault of camouflaged corridors, a field of stubborn survivors, and a victory gate blazing with laurels. Every time you blink, another silhouette leans closer, inviting you to choose it. Beneath your boots, the bridge hums at twice the heartbeat of the Causeway, impatient for resolution.\n\nGremlin cadres have already colonized the threshold. Dev gremlins weave chronologs between the four silhouettes, updating probability graphs in real time. Traders have set up a fate exchange where you can hedge sorrow against triumph. Whales orbit as living aurorae, grading each new plan with tidal push or pull. Hackers splice stealth firmware into the hidden corridors, validators choreograph oath-calls that modulate the mourning bells, miners carve luminous ore from the survivor field to feed the victory gate, and the meme division projects slogans like \"LIVE LOUD, HIDE SMART, DIE WELL, WIN LOUDER\" across every surface. AFK safeties swirl as grappling ribbons, ready to yank any ally back from whichever ending tempts them too soon.\n\nSeven terraces spiral up the Threshold. The first ignites the Wakefront greeting and maps the initial divergence. The second braids fate threads for loss, concealment, survival, and triumph. The third assigns shields, caches, and banners to each path. The fourth honors fallen echoes and rallies charges. The fifth forges a mosaic arsenal that only works when all four futures cooperate. The sixth convenes the first Act Five council vote. The seventh opens the way toward the Wake Spire. You have seven rounds before the endings start choosing you.",
+    "rounds": [
+        {
+            "round_id": "5.1-R1",
+            "description": "Wakefront Antechamber — ignite the GM/GN flare, map the divergence vectors, and lash AFK anchors before anyone gets claimed by a silhouette.",
+            "actions": [
+                {
+                    "id": "wakefront_gmgn_ignite",
+                    "label": "Ignite the Wakefront GM/GN",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "horizon_consensus_passed"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "ritual",
+                            "leadership",
+                            "harmony"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_gmgn_flare",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You sing sunrise and starlight into one beam. The four silhouettes pause, listening, and the Wakefront flares bright enough to etch your outline across every ledger."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_gmgn_flare",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Your greeting threads through the Threshold’s ribs. Each silhouette nods in recognition and waits to see if you choose it."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_pity_ladder",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You hesitate between endings and the traders charge you for indecision. The coins fund an emergency pity ladder."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 6
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_pity_ladder",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Your greeting fractures and the mourning veils lash out, leaving static burns across your chest. The meme crew titles the clip ‘GM? GN? GG.’"
+                        }
+                    },
+                    "banter": {
+                        "dev": "Wakefront audio synced across four futures.",
+                        "trader": "Hedging endings like options.",
+                        "whale": "The tide listens to your chord.",
+                        "hacker": "Handshake routed through every silhouette.",
+                        "shiller": "This greeting sells destiny merch.",
+                        "validator": "Wakefront salute notarized.",
+                        "miner": "Sound hits like striking prime ore.",
+                        "meme": "GMGN? Try GMGNGW (Good Morning, Good Night, Good Win)."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.1",
+                        "action:wakefront_gmgn_ignite"
+                    ]
+                },
+                {
+                    "id": "wakefront_vector_map",
+                    "label": "Map the Divergence Vectors",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakefront_gmgn_flare"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "insight",
+                            "analysis",
+                            "fate"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_vectors_plotted",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You trace four spiraling arcs that never quite touch. Each one glows with a different heartbeat: silence for the fallen, whisper for the hidden, drumfire for the living, fanfare for the triumphant."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_vectors_plotted",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The divergence map unfurls across the air like a battle standard. Pathways align, arguable but legible."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "-",
+                                    "value": 1
+                                }
+                            ],
+                            "narration": "Your chalk lines smear. The futures blur together and a gremlin politely hands you a towel labeled TRY AGAIN."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 5
+                                }
+                            ],
+                            "narration": "The divergence map snaps back like a slingshot. You taste blood and the victory gate flickers in disapproval."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Vector field rendered in four overlays.",
+                        "trader": "Pricing survival at 1.2x, triumph at 2.5x.",
+                        "whale": "Currents agree with your geometry.",
+                        "hacker": "No phantom nodes detected... yet.",
+                        "shiller": "This diagram belongs on a flag.",
+                        "validator": "Divergence ledger balanced.",
+                        "miner": "Lines look like veins worth mining.",
+                        "meme": "Choose your fighter: Hide, Ride, Pride, or Die."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.1",
+                        "action:wakefront_vector_map"
+                    ]
+                },
+                {
+                    "id": "wakefront_afk_lash",
+                    "label": "Lash the AFK Ribbons",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakefront_gmgn_flare"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "support",
+                            "coordination",
+                            "safety"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_afk_safeties",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You knot ribbons from all four futures into a single harness. Anyone who slips gets yanked back with a gentle jolt and a sarcastic thank-you note."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_afk_safeties",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The AFK net hums into place. No ally goes missing without a receipt."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "-",
+                                    "value": 1
+                                }
+                            ],
+                            "narration": "Two ribbons tangle and slap you across the face. The meme crew slow-mo replays the welt forming."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 4
+                                }
+                            ],
+                            "narration": "A ribbon snaps loose, whips around, and hurls you into the mourning tower’s stairwell. You climb back with bruises and new respect for knots."
+                        }
+                    },
+                    "banter": {
+                        "dev": "AFK nets ready to auto-resume.",
+                        "trader": "Insurance premium paid in smugness.",
+                        "whale": "Tide approves of safety harnesses.",
+                        "hacker": "No one logs off without consent now.",
+                        "shiller": "Sell the ribbons as merch later.",
+                        "validator": "Safety measures notarized.",
+                        "miner": "That knot could hold a drill rig.",
+                        "meme": "AFK? Nah, you’re AF-OK."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.1",
+                        "action:wakefront_afk_lash"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "focus",
+                    "op": "+",
+                    "value": 1
+                }
+            ]
+        },
+        {
+            "round_id": "5.1-R2",
+            "description": "Divergence Loom — braid the four fate threads so none fray alone.",
+            "actions": [
+                {
+                    "id": "wakefront_loss_thread",
+                    "label": "Trace the Loss Thread",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakefront_vectors_plotted"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "fate",
+                            "resolve",
+                            "ritual"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_loss_forecast",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You walk the mourning tower’s spiral until the bells fall silent. Names write themselves on the air, waiting for guardians."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_loss_forecast",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You map the cost of Act Five in ink that refuses to dry. The ledger nods grimly."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 3
+                                }
+                            ],
+                            "narration": "A bell tolls and the vibration climbs your bones. You stagger, knowing the Wake may claim someone you love."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 7
+                                }
+                            ],
+                            "narration": "The tower mistakes you for an offering. You rip free, but you leave a handful of luck behind."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Loss ledger balanced but not forgiven.",
+                        "trader": "Pricing grief futures isn’t my favorite gig.",
+                        "whale": "Even tides ebb. Prepare to mourn.",
+                        "hacker": "Encrypt the names so only we can unlock them.",
+                        "shiller": "We cry loud, we fight louder.",
+                        "validator": "Names recorded with honor.",
+                        "miner": "Carved every loss into stone.",
+                        "meme": "Pour one out, then pour in the work."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.1",
+                        "action:wakefront_loss_thread"
+                    ]
+                },
+                {
+                    "id": "wakefront_hide_thread",
+                    "label": "Weave the Hidden Thread",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakefront_vectors_plotted"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "stealth",
+                            "strategy",
+                            "support"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_hide_threaded",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You slip through the camouflaged vault and rewrite its walls with hush-ink. A whole platoon can disappear here and emerge victorious later."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_hide_threaded",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Hidden corridors align with your breathing. Safehouses register themselves on your map."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "-",
+                                    "value": 1
+                                }
+                            ],
+                            "narration": "You bump a cloaked pillar. It scolds you with a spray of glitter and a note: TRY INVISIBLE HARDER."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 4
+                                }
+                            ],
+                            "narration": "The vault slams shut on your ankle. You yank free, limping but wiser about secret doors."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Shadow network patched into the HUD.",
+                        "trader": "Hiding alpha until it moons.",
+                        "whale": "Stealth currents strong tonight.",
+                        "hacker": "Latency near zero in the hushways.",
+                        "shiller": "We’re invisible but make it fashion.",
+                        "validator": "Hidden sanctums notarized discretely.",
+                        "miner": "Cut tunnels so quiet even echoes tiptoe.",
+                        "meme": "If no one saw it, did it even loot? Yes."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.1",
+                        "action:wakefront_hide_thread"
+                    ]
+                },
+                {
+                    "id": "wakefront_glory_thread",
+                    "label": "Crown the Triumph Thread",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakefront_vectors_plotted"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "valor",
+                            "charisma",
+                            "momentum"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_glory_charted",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You plant your banner in the survivor field. Cheers ripple through the crowd and even the mourning tower rings in admiration."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 1
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_glory_charted",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The triumph gate flares open a crack. You can see the laurels waiting inside."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "Your banner slips. Traders swoop in to buy the dip on morale."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 6
+                                }
+                            ],
+                            "narration": "You charge too soon and the gate spits you back, singed and humbled."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Triumph beacon integrated into HUD.",
+                        "trader": "Victory futures trending bullish.",
+                        "whale": "Tide leans toward glory.",
+                        "hacker": "Boosted the hype algorithm legally-ish.",
+                        "shiller": "Clip going viral: ‘We choose to win.’",
+                        "validator": "Triumph protocol notarized.",
+                        "miner": "That cheer shook dust from the ceiling.",
+                        "meme": "Win condition unlocked: shout louder."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.1",
+                        "action:wakefront_glory_thread"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "5.1-R3",
+            "description": "Triage Gallery — assign shields, hideouts, and banners to the paths before the futures start fighting.",
+            "actions": [
+                {
+                    "id": "wakefront_loss_bulwark",
+                    "label": "Erect the Mourning Bulwark",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakefront_loss_forecast"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "defense",
+                            "sacrifice",
+                            "support"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_loss_buffered",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You set stones for the fallen and the wall hums with their gratitude. Anyone who falls here leaves a message instead of a silence."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_loss_buffered",
+                                    "value": true
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                }
+                            ],
+                            "narration": "A protective bulwark grows around the mourning tower. It is beautiful and terrible."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 4
+                                }
+                            ],
+                            "narration": "You accept a wound meant for someone else. The wall gleams brighter but your ribs protest."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 8
+                                }
+                            ],
+                            "narration": "The wall demands more than you intended to give. You stagger away, alive, but only because the AFK ribbons drag you back."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Loss buffer online. Latency acceptable.",
+                        "trader": "Insurance pool funded with tears and grit.",
+                        "whale": "Even the tide honors that wall.",
+                        "hacker": "Encrypted wills uploaded.",
+                        "shiller": "Memorial stream trending #RememberTheWake.",
+                        "validator": "Bulwark oath notarized.",
+                        "miner": "Cut stone bleeds light now.",
+                        "meme": "Dead? Nah, on legendary cooldown."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.1",
+                        "action:wakefront_loss_bulwark"
+                    ]
+                },
+                {
+                    "id": "wakefront_hide_cache",
+                    "label": "Seed the Shadow Cache",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakefront_hide_threaded"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "logistics",
+                            "stealth",
+                            "support"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "item",
+                                    "id": "consumable_shadow_pass"
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_shadow_cache",
+                                    "value": true
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                }
+                            ],
+                            "narration": "You stash rations, disguises, and exit tokens behind false walls. Every hidden ally now has a way to vanish twice."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_shadow_cache",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The cache seals shut, invisible even to the dev gremlins unless you invite them."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "-",
+                                    "value": 1
+                                }
+                            ],
+                            "narration": "A meme gremlin accidentally livestreams the cache coordinates. You scramble to re-hide everything."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "You buy decoy supplies to cover the breach. Costly, but secrecy restored."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Shadow inventory balanced.",
+                        "trader": "Hiding our best gains for later.",
+                        "whale": "Tide knows where to tuck the stealth fleet.",
+                        "hacker": "Cache keyed to breathing passwords.",
+                        "shiller": "Stealth chic is the look of the season.",
+                        "validator": "Cache receipts notarized invisibly.",
+                        "miner": "Buried the stash under three meters of hushstone.",
+                        "meme": "Invisible loot boxes? Inject that."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.1",
+                        "action:wakefront_hide_cache"
+                    ]
+                },
+                {
+                    "id": "wakefront_glory_banner",
+                    "label": "Raise the Survivor Banner",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakefront_glory_charted"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "leadership",
+                            "valor",
+                            "community"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "item",
+                                    "id": "banner_wakefront_standard"
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_banner_raised",
+                                    "value": true
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                }
+                            ],
+                            "narration": "You unfurl a banner woven from Radiant Dyad lightning and Horizon Crown aurora. Survivors roar approval; even the hidden corridors echo applause."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_banner_raised",
+                                    "value": true
+                                },
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 1
+                                }
+                            ],
+                            "narration": "The banner catches the Wakefront wind and refuses to sag."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 3
+                                }
+                            ],
+                            "narration": "A gust whips the banner pole into your shoulder. Pride bruised, shoulder worse."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 7
+                                }
+                            ],
+                            "narration": "You almost tumble off the platform. AFK ribbons catch you as the crowd gasps."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Banner lighting cycle locked.",
+                        "trader": "Merch sales spike when that flag waves.",
+                        "whale": "Even the tide salutes that cloth.",
+                        "hacker": "Embedded a secret rally code in the seams.",
+                        "shiller": "Clip title: ‘How to banner drop a future.’",
+                        "validator": "Banner charter notarized.",
+                        "miner": "Pole anchored in bedrock.",
+                        "meme": "Flag so fire the storms asked for autographs."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.1",
+                        "action:wakefront_glory_banner"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "coins",
+                    "op": "+",
+                    "value": 34
+                }
+            ]
+        },
+        {
+            "round_id": "5.1-R4",
+            "description": "Requiem Forge — honor the fallen, empower the hidden, and prime the charge.",
+            "actions": [
+                {
+                    "id": "wakefront_echo_recall",
+                    "label": "Recall the Echoes",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakefront_loss_buffered"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "revival",
+                            "ritual",
+                            "compassion"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_fallen_recalled",
+                                    "value": true
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "item",
+                                    "id": "trinket_echo_locket"
+                                }
+                            ],
+                            "narration": "You ring the mourning bells backward. Spirits step out of the wall, wearing smiles made of lightning. They promise to watch your back."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_fallen_recalled",
+                                    "value": true
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                }
+                            ],
+                            "narration": "Echoes answer, faint but determined. Their names glow steady on the bulwark."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "-",
+                                    "value": 1
+                                }
+                            ],
+                            "narration": "The bells shudder. Someone does not answer. You promise to try again."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 5
+                                }
+                            ],
+                            "narration": "A grief echo lashes out, mistaking you for the one who left them. It fades when it recognizes you, leaving a scar of ice."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Echo channel stabilized.",
+                        "trader": "Trading sorrow for second chances.",
+                        "whale": "Tide carries their voices home.",
+                        "hacker": "Packet loss minimal on the afterline.",
+                        "shiller": "Clip titled ‘We don’t leave legends behind.’",
+                        "validator": "Echo contracts notarized.",
+                        "miner": "They still laugh like old crew.",
+                        "meme": "Ghosts? Nah, bonus party members."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.1",
+                        "action:wakefront_echo_recall"
+                    ]
+                },
+                {
+                    "id": "wakefront_shadow_route",
+                    "label": "Thread the Shadow Route",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakefront_shadow_cache"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "stealth",
+                            "navigation",
+                            "logistics"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_hide_network",
+                                    "value": true
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                }
+                            ],
+                            "narration": "You splice the hidden corridors into a network of safe leaps. Anyone vanishing here returns with intel and intact pride."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_hide_network",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Routes flash on your map, accessible only to those who know the hush-passwords you just invented."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "-",
+                                    "value": 1
+                                }
+                            ],
+                            "narration": "A corridor loops on itself. You walk in circles until a gremlin leaves breadcrumbs shaped like memes."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "You bribe the meme division to scrub the breadcrumb footage. Worth it."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Shadow routes added to mission planner.",
+                        "trader": "Selling stealth futures in limited quantity.",
+                        "whale": "Currents bend quietly for you.",
+                        "hacker": "No trace, no tracebacks.",
+                        "shiller": "Invisible caravans, unstoppable story.",
+                        "validator": "Pathway attestations sealed.",
+                        "miner": "Tunneled so soft even dust stayed asleep.",
+                        "meme": "Stealth level: screenshot shows nothing."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.1",
+                        "action:wakefront_shadow_route"
+                    ]
+                },
+                {
+                    "id": "wakefront_charge_prime",
+                    "label": "Prime the Victory Charge",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakefront_banner_raised"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "valor",
+                            "tactics",
+                            "momentum"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_charge_ready",
+                                    "value": true
+                                },
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                }
+                            ],
+                            "narration": "You choreograph the charge with the precision of a trader’s kill order. Every ally knows where to leap, when to shout, and when to plant the flag."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_charge_ready",
+                                    "value": true
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                }
+                            ],
+                            "narration": "The vanguard lines up, eyes blazing. The gate trembles, eager to swing wide."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "You mis-time the drumbeat. A quick investment in extra speakers fixes morale."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 7
+                                }
+                            ],
+                            "narration": "You lead a practice charge into a closed gate. The bruise will look heroic later."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Charge macro rehearsed.",
+                        "trader": "Momentum chart spiking hard.",
+                        "whale": "Tide curls behind the vanguard.",
+                        "hacker": "Syncing the war drums with the network clock.",
+                        "shiller": "Prepping the highlight reel.",
+                        "validator": "Charge plan notarized in duplicate.",
+                        "miner": "Boots stomp like drills on ore.",
+                        "meme": "Ready? Ready. READY!"
+                    },
+                    "telemetry_tags": [
+                        "scene:5.1",
+                        "action:wakefront_charge_prime"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "5.1-R5",
+            "description": "Mosaic Arsenal — fuse all four futures into one weapon set.",
+            "actions": [
+                {
+                    "id": "wakefront_mosaic_forge",
+                    "label": "Forge the Wakefront Mosaic",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakefront_fallen_recalled",
+                            "wakefront_hide_network",
+                            "wakefront_charge_ready"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "craft",
+                            "ritual",
+                            "strategy"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_mosaic_forged",
+                                    "value": true
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                }
+                            ],
+                            "narration": "Echoes, shadows, and banners fuse into a shimmering disk that projects whichever future you need most."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_mosaic_forged",
+                                    "value": true
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                }
+                            ],
+                            "narration": "The mosaic locks into place, humming with four harmonies at once."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "-",
+                                    "value": 2
+                                }
+                            ],
+                            "narration": "Pieces refuse to connect. You regroup and try again with blistered fingers."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 6
+                                }
+                            ],
+                            "narration": "The mosaic explodes into shards. AFK ribbons pull you clear while dev gremlins sweep up data glitter."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Mosaic compiled with zero merge conflicts.",
+                        "trader": "Diversified destiny portfolio secured.",
+                        "whale": "Currents adore this symmetry.",
+                        "hacker": "Four futures, one API.",
+                        "shiller": "Branding note: Mosaic = unstoppable.",
+                        "validator": "Fusion covenant notarized.",
+                        "miner": "Looks like ore, hits like prophecy.",
+                        "meme": "All endings? Why not choose ‘yes.’"
+                    },
+                    "telemetry_tags": [
+                        "scene:5.1",
+                        "action:wakefront_mosaic_forge"
+                    ]
+                },
+                {
+                    "id": "wakefront_aegis_allocate",
+                    "label": "Allocate the Wakefront Aegis",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakefront_mosaic_forged"
+                        ]
+                    },
+                    "outcomes": {
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "item",
+                                    "id": "armor_wakefront_aegis"
+                                }
+                            ],
+                            "narration": "The mosaic blossoms into layered armor that shifts modes depending on which future you lean into."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Aegis hot-swaps between modes seamlessly.",
+                        "trader": "Protection packaged as premium utility.",
+                        "whale": "Shield hums like a tide at full moon.",
+                        "hacker": "Firmware patched and unbreakable.",
+                        "shiller": "Aegis photoshoot scheduled post-victory.",
+                        "validator": "Ownership ledger updated.",
+                        "miner": "Armor plates forged from mosaic offcuts.",
+                        "meme": "New drip unlocked: plot armor."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.1",
+                        "action:wakefront_aegis_allocate"
+                    ]
+                },
+                {
+                    "id": "wakefront_wildcard_bank",
+                    "label": "Bank the Wakefront Wildcard",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakefront_mosaic_forged"
+                        ]
+                    },
+                    "outcomes": {
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_wildcard_bank",
+                                    "value": true
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                }
+                            ],
+                            "narration": "You store a single, radiant possibility inside the mosaic. It will cash out when the story needs an impossible pivot."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Wildcard slot armed and ready.",
+                        "trader": "Holding one more option than fate expected.",
+                        "whale": "Currents love a surprise reserve.",
+                        "hacker": "Wildcard seeded in encrypted stasis.",
+                        "shiller": "Teaser trailer: ‘We kept a spare miracle.’",
+                        "validator": "Wildcard bond notarized.",
+                        "miner": "Tucked the extra chance under solid bedrock.",
+                        "meme": "Save scumming? Nah, save stunning."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.1",
+                        "action:wakefront_wildcard_bank"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "focus",
+                    "op": "+",
+                    "value": 1
+                }
+            ]
+        },
+        {
+            "round_id": "5.1-R6",
+            "description": "Outcome Congress — call the first Act Five vote.",
+            "actions": [
+                {
+                    "id": "wakefront_council_rally",
+                    "label": "Rally the Wakefront Council",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakefront_mosaic_forged"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "leadership",
+                            "persuasion",
+                            "community"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_council_rallied",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "All four factions show up in force. Loss, hide, live, and win clasp hands across the table."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_council_rallied",
+                                    "value": true
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                }
+                            ],
+                            "narration": "The council seats fill. Gremlins pass snacks; stakes remain deadly serious."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "-",
+                                    "value": 1
+                                }
+                            ],
+                            "narration": "One faction storms out. You sprint after them with the wildcard as leverage."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 5
+                                }
+                            ],
+                            "narration": "Arguments turn physical. You take a punch meant for someone who might not make it."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Council quorum reached.",
+                        "trader": "Consensus futures volatile but rising.",
+                        "whale": "Tide steadies the chairs.",
+                        "hacker": "Voting system triple-encrypted.",
+                        "shiller": "Democracy but make it legendary.",
+                        "validator": "Attendance logged in triplicate.",
+                        "miner": "Even the quiet ones spoke up.",
+                        "meme": "Meeting minutes: *aggressive hype noises*."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.1",
+                        "action:wakefront_council_rally"
+                    ]
+                },
+                {
+                    "id": "wakefront_vote_call",
+                    "label": "Call the Wakefront Vote",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakefront_council_rallied"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "consensus",
+                            "ritual",
+                            "leadership"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_consensus_passed",
+                                    "value": true
+                                },
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                }
+                            ],
+                            "narration": "All four futures vote yes. The Wakefront trembles with approval and the silhouettes bow."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakefront_consensus_passed",
+                                    "value": true
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                }
+                            ],
+                            "narration": "Consensus holds. You feel the Wake Spire open ahead."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 55
+                                }
+                            ],
+                            "narration": "Ties require incentives. You sweeten the pot with treasury bonds."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 6
+                                }
+                            ],
+                            "narration": "The vote fractures and the silhouettes snarl. You absorb the backlash, determined to reconvene."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Vote recorded, blockchain actually proud.",
+                        "trader": "Consensus premium paid in adrenaline.",
+                        "whale": "Wave crest marks the aye vote.",
+                        "hacker": "No bots, all heart.",
+                        "shiller": "Headline: ‘Wakefront chooses all endings.’",
+                        "validator": "Vote ledger sealed.",
+                        "miner": "We mined a yes out of bedrock.",
+                        "meme": "Motion passes, motion dances."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.1",
+                        "action:wakefront_vote_call"
+                    ]
+                },
+                {
+                    "id": "wakefront_reward_archive",
+                    "label": "Archive the Threshold Pattern",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakefront_consensus_passed"
+                        ]
+                    },
+                    "outcomes": {
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "deck",
+                                    "id": "deck_wakefront_mosaic"
+                                }
+                            ],
+                            "narration": "You fold the fourfold plan into a deck of radiant tiles ready to redeploy when another community faces impossible choices."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Pattern archived with zero loss.",
+                        "trader": "Sell the manual? Never. Gift it.",
+                        "whale": "Future tides will thank us.",
+                        "hacker": "Backup stored across twelve light-years.",
+                        "shiller": "Limited edition: Legacy of the Wakefront.",
+                        "validator": "Archive notarized in perpetuity.",
+                        "miner": "Locked it in the strongbox too.",
+                        "meme": "Collectible card: Choose your ending."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.1",
+                        "action:wakefront_reward_archive"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "5.1-R7",
+            "description": "Final Terrace — stride toward the Wake Spire with every future in tow.",
+            "actions": [
+                {
+                    "id": "advance_5_2",
+                    "label": "Ascend to the Wake Spire",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakefront_consensus_passed"
+                        ]
+                    },
+                    "outcomes": {
+                        "success": {
+                            "effects": [],
+                            "narration": "The silhouettes converge into a single stair of blazing light. You climb with ghosts, shadows, survivors, and champions at your side.",
+                            "next_hint": "5.2"
+                        }
+                    },
+                    "banter": {
+                        "dev": "Scene transition compiled.",
+                        "trader": "Rolling positions into the Spire.",
+                        "whale": "Tide pulls us upward now.",
+                        "hacker": "Handshake ready for the Spire gate.",
+                        "shiller": "Endgame trailer voice: ‘Meanwhile, above…’",
+                        "validator": "Advance notarized with fireworks.",
+                        "miner": "Next seam: destiny.",
+                        "meme": "Up only."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.1",
+                        "action:advance_5_2"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        }
+    ],
+    "threshold_rewards": [
+        {
+            "focus_gte": 19,
+            "rewards": [
+                {
+                    "type": "coins",
+                    "value": 144
+                }
+            ]
+        },
+        {
+            "xp_gte": 1337,
+            "rewards": [
+                {
+                    "type": "item",
+                    "id": "relic_wakefront_compass"
+                }
+            ]
+        },
+        {
+            "flags_all": [
+                "wakefront_consensus_passed"
+            ],
+            "rewards": [
+                {
+                    "type": "deck",
+                    "id": "deck_wakefront_mosaic"
+                }
+            ]
+        }
+    ],
+    "arrivals": [
+        {
+            "when": "flags.afk_tracked",
+            "goto": "5.1A"
+        },
+        {
+            "when": "flags.wakefront_consensus_passed",
+            "goto": "5.2"
+        },
+        {
+            "when": "else",
+            "goto": "5.1"
+        }
+    ]
+}

--- a/content/genesis/scenes/scene_5.2.json
+++ b/content/genesis/scenes/scene_5.2.json
@@ -1,0 +1,1524 @@
+
+{
+    "schema_version": "1.0",
+    "content_id": "genesis",
+    "book_id": "book_1",
+    "scene_id": "5.2",
+    "title": "The Wake Spire — Opening the Last Run",
+    "narration": "The Wake Spire erupts above you like a spiral comet of stone and starlight. Each tier is a living memory: banners from the Horizon Crown flutter beside lightning stolen from the Radiant Dyad, while the Convergence Causeway’s braided light now coils as railings around a central column of compressed dawn. Between those rails float four spectral lanes, each tinted by an ending you mapped below. Footsteps echo from the future as if your own victory, retreat, survival, and sacrifice are already pacing upstairs.\n\nThe gremlins have transformed the Spire into a mission control cathedral. Dev gremlins hover at holo-consoles, simulating permutations of the final push. Traders run a liquidity pit carved into the Spire’s heart, hedging bets on which lane will claim the loudest glory. Whales spiral upward, pushing gravity to favor your ascent. Hackers lace the walls with anti-scry firewalls, validators tune verdict bells that will toll once for every life saved or spent, miners carve footholds into the spiraling steps, and the meme division paints massive murals reading \"WIN, HIDE, FIGHT, OR FALL — JUST DO IT TOGETHER\" across the vault. AFK safeties snap into a mesh that wraps the entire column, ensuring no ally vanishes unmarked.\n\nSeven battlements wind up the Spire. The first reboots the GM/GN to resonate with Act Five. The second refracts the four fate lanes into actionable corridors. The third reclaims remnants and stockpiles them for the climb. The fourth assigns hidden cells, sentinel lines, and vanguard wedges. The fifth equips each team with gear forged from the Wakefront mosaic. The sixth convenes the Verdict Choir that will commit Act Five’s opening gambit. The seventh unlocks the path to the Wake Apex. Climb with care; endings sharpen here.",
+    "rounds": [
+        {
+            "round_id": "5.2-R1",
+            "description": "Spire Footing — reboot the GM/GN, triangulate the ascent, and anchor lifelines.",
+            "actions": [
+                {
+                    "id": "wakespire_gmgn_resonance",
+                    "label": "Resonate the Spire GM/GN",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakefront_consensus_passed"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "ritual",
+                            "leadership",
+                            "harmony"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_gmgn_resonant",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Your voice threads through the Spire. The four fate lanes hum in tune, promising to hold whatever future you choose."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_gmgn_resonant",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The Spire acknowledges your arrival with a low, approving chord."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_pity_reserve",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Your greeting wavers. Traders fill the silence with a pity fund that echoes up the stairs."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 6
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_pity_reserve",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The Spire rings a discordant bell that knocks you to one knee. AFK mesh tightens around you until you stand again."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Spire greeting synchronized.",
+                        "trader": "Market opened for Act Five.",
+                        "whale": "Currents curl around the column.",
+                        "hacker": "Handshake patched to the apex nodes.",
+                        "shiller": "Broadcasting: ‘Act Five begins now.’",
+                        "validator": "Greeting notarized atop the ledger.",
+                        "miner": "Stone vibrates with every note.",
+                        "meme": "GM? GN? Try GG EZ? Not yet."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.2",
+                        "action:wakespire_gmgn_resonance"
+                    ]
+                },
+                {
+                    "id": "wakespire_pathfinding",
+                    "label": "Triangulate the Fate Lanes",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakespire_gmgn_resonant",
+                            "wakefront_vectors_plotted"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "analysis",
+                            "fate",
+                            "navigation"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_paths_triangulated",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You align the four lanes to intersect at critical checkpoints. No matter who falls, hides, survives, or conquers, their path feeds the others."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_paths_triangulated",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The lanes glow in harmony, ready for split-second rerouting."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "-",
+                                    "value": 1
+                                }
+                            ],
+                            "narration": "A lane twists unexpectedly. You scribble revisions before the gremlins notice."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 5
+                                }
+                            ],
+                            "narration": "Two lanes collide, sparking lightning that scorches your arm. You swear and redraw them apart."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Lane triangulation stable.",
+                        "trader": "Diversified risk with style.",
+                        "whale": "Tide approves of this symmetry.",
+                        "hacker": "Routing tables updated.",
+                        "shiller": "Four ways up, zero ways alone.",
+                        "validator": "Paths notarized and sealed.",
+                        "miner": "Cut extra footholds along each lane.",
+                        "meme": "Choose your fighter? We chose all."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.2",
+                        "action:wakespire_pathfinding"
+                    ]
+                },
+                {
+                    "id": "wakespire_lifeline_deploy",
+                    "label": "Deploy the Ascension Lifelines",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakespire_gmgn_resonant",
+                            "wakefront_afk_safeties"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "support",
+                            "coordination",
+                            "safety"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_lifelines_deployed",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You weave the AFK mesh into climbing harnesses that glow when someone slips. Nobody falls unmarked."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_lifelines_deployed",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Lifelines coil along the rails, ready to yank allies home."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "-",
+                                    "value": 1
+                                }
+                            ],
+                            "narration": "A harness snaps and smacks you in the helmet. You tie it again with teeth-gritted determination."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 4
+                                }
+                            ],
+                            "narration": "You get dragged halfway up the Spire before the mesh realizes you’re the rescuer, not the rescue."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Ascension lifelines calibrated.",
+                        "trader": "Insurance premium paid in bruises.",
+                        "whale": "Tide tugs kindly on these ropes.",
+                        "hacker": "Auto-reel triggers verified.",
+                        "shiller": "Merch idea: safety harness couture.",
+                        "validator": "Lifeline registry notarized.",
+                        "miner": "These knots could hold a drill rig.",
+                        "meme": "Falling? Not on my mesh."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.2",
+                        "action:wakespire_lifeline_deploy"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "focus",
+                    "op": "+",
+                    "value": 1
+                }
+            ]
+        },
+        {
+            "round_id": "5.2-R2",
+            "description": "Fate Prism Gallery — refract loss, concealment, survival, and triumph into operative lanes.",
+            "actions": [
+                {
+                    "id": "wakespire_loss_gate",
+                    "label": "Open the Loss Gate",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakefront_loss_forecast"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "fate",
+                            "resolve",
+                            "ritual"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_loss_gate_open",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You touch the mourners’ bell and it swings inward, revealing a corridor lined with torches that burn in remembered names."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_loss_gate_open",
+                                    "value": true
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                }
+                            ],
+                            "narration": "The gate opens with a solemn bow. It promises a noble accounting for every loss."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 4
+                                }
+                            ],
+                            "narration": "The bell tolls against your ribs. You cough, but refuse to retreat."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 8
+                                }
+                            ],
+                            "narration": "The gate slams, mistaking your courage for arrogance. It reopens after drawing blood to make the point."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Loss gate stabilized.",
+                        "trader": "Pricing sorrow at cost.",
+                        "whale": "Even tides mourn with rhythm.",
+                        "hacker": "Names locked and encrypted.",
+                        "shiller": "Honor every fall, stream every rise.",
+                        "validator": "Gate oath notarized.",
+                        "miner": "Torches fueled with ore dust.",
+                        "meme": "Dead but make it dignified."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.2",
+                        "action:wakespire_loss_gate"
+                    ]
+                },
+                {
+                    "id": "wakespire_hide_chute",
+                    "label": "Unfurl the Hidden Chute",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakefront_hide_threaded"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "stealth",
+                            "strategy",
+                            "mobility"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_hide_network",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The chute unspools like a ribbon of night. It bends light around anyone sliding through."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_hide_network",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Hidden footholds illuminate briefly, then vanish, remembering your allies alone."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "-",
+                                    "value": 1
+                                }
+                            ],
+                            "narration": "You trip and slide halfway down before the chute remembers you’re supposed to go up."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "You bribe the meme division to delete footage of the unintended slide."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Hidden chute integrated into nav HUD.",
+                        "trader": "Short the obvious entrance, long the secret one.",
+                        "whale": "Currents cloak your steps.",
+                        "hacker": "Noise floor near zero.",
+                        "shiller": "Invisible runway, unstoppable story.",
+                        "validator": "Chute permissions notarized.",
+                        "miner": "Carved the slide with a whisper.",
+                        "meme": "Sneak 100."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.2",
+                        "action:wakespire_hide_chute"
+                    ]
+                },
+                {
+                    "id": "wakespire_glory_lane",
+                    "label": "Ignite the Glory Lane",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakefront_glory_charted"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "valor",
+                            "charisma",
+                            "momentum"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_glory_lane",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You spark the lane and it erupts in aurora gold. Cheers from below echo upward."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_glory_lane",
+                                    "value": true
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                }
+                            ],
+                            "narration": "The lane shines bright enough to guide the vanguard even through smoke."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "The flame sputters until you feed it a handful of rare fuel."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 7
+                                }
+                            ],
+                            "narration": "You stand too close when the lane ignites. Your eyebrows will grow back."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Glory lane illumination at 200%.",
+                        "trader": "Victory futures limit up.",
+                        "whale": "Tide pushes you forward.",
+                        "hacker": "No spoofing this radiance.",
+                        "shiller": "Highlight reel is pure gold.",
+                        "validator": "Lane charter notarized.",
+                        "miner": "Carved spark grooves to keep it blazing.",
+                        "meme": "Fire? Fire."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.2",
+                        "action:wakespire_glory_lane"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "5.2-R3",
+            "description": "Reliquary Tier — reclaim remnants and prep caches for the ascent.",
+            "actions": [
+                {
+                    "id": "wakespire_reclaim_shades",
+                    "label": "Reclaim the Guardian Shades",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakespire_loss_gate_open",
+                            "wakefront_fallen_recalled"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "revival",
+                            "ritual",
+                            "resolve"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_reclaimed",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Shades step from the reliquary wearing armor of starlit vellum. They promise to guard those who fall behind."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_reclaimed",
+                                    "value": true
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                }
+                            ],
+                            "narration": "The reliquary releases a squad of loyal echoes ready to anchor the loss lane."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 5
+                                }
+                            ],
+                            "narration": "A shade hesitates, confused. You absorb its chill until it remembers the living."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 8
+                                }
+                            ],
+                            "narration": "The reliquary closes with you inside for thirty heartbeats. You emerge shaking but resolute."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Shade guardians synced to team HUD.",
+                        "trader": "Investing in immortal support.",
+                        "whale": "Tide carries their whispers upward.",
+                        "hacker": "Spectral handshake verified.",
+                        "shiller": "Ghost squad is trending already.",
+                        "validator": "Shade contracts notarized.",
+                        "miner": "Echoes hold the line like seasoned crew.",
+                        "meme": "Undead but unionized."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.2",
+                        "action:wakespire_reclaim_shades"
+                    ]
+                },
+                {
+                    "id": "wakespire_cache_shadows",
+                    "label": "Expand the Shadow Stockpile",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakespire_hide_network",
+                            "wakefront_shadow_cache"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "logistics",
+                            "stealth",
+                            "support"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "item",
+                                    "id": "consumable_shadow_pass"
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_shadow_stockpile",
+                                    "value": true
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                }
+                            ],
+                            "narration": "You hide gear inside folds of darkness and mark them with a whisper only allies can hear."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_shadow_stockpile",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Caches bloom like midnight flowers along the chute."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "-",
+                                    "value": 1
+                                }
+                            ],
+                            "narration": "A hidden locker refuses your password. You change the passphrase to an inside joke."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "You pay off a meme gremlin to forget where the locker is."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Shadow stockpile sync complete.",
+                        "trader": "Stealth supply chain secured.",
+                        "whale": "Currents conceal your caches.",
+                        "hacker": "Zero-trace stash confirmed.",
+                        "shiller": "Hidden stash, loud swagger.",
+                        "validator": "Cache receipts notarized invisibly.",
+                        "miner": "Buried gear like a pro.",
+                        "meme": "If you know, you know."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.2",
+                        "action:wakespire_cache_shadows"
+                    ]
+                },
+                {
+                    "id": "wakespire_lightforge_charge",
+                    "label": "Charge the Lightforge",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakespire_glory_lane",
+                            "wakefront_charge_ready"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "valor",
+                            "engineering",
+                            "momentum"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_lightforge_charged",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The lightforge roars to life, spinning arcs of triumph energy that can be redirected to any lane in need."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_lightforge_charged",
+                                    "value": true
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                }
+                            ],
+                            "narration": "Power hums through the forge, ready to launch the vanguard when the signal comes."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "The forge sputters until you feed it a crate of ratio ore."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 7
+                                }
+                            ],
+                            "narration": "A misfire hurls you into a wall. You limp back, laughing through grit teeth."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Lightforge output steady.",
+                        "trader": "Momentum index screaming up.",
+                        "whale": "Tide fans the flames.",
+                        "hacker": "Safety interlocks double-checked.",
+                        "shiller": "Promo: ‘This forge fuels legends.’",
+                        "validator": "Output contract notarized.",
+                        "miner": "Forge drinks ore like victory drinks cheers.",
+                        "meme": "Hot forge summer."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.2",
+                        "action:wakespire_lightforge_charge"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "coins",
+                    "op": "+",
+                    "value": 34
+                }
+            ]
+        },
+        {
+            "round_id": "5.2-R4",
+            "description": "Veil Lattice — assign teams to their lanes before the climb begins in earnest.",
+            "actions": [
+                {
+                    "id": "wakespire_assign_hidden",
+                    "label": "Assign the Hidden Cell",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakespire_hide_network",
+                            "wakespire_shadow_stockpile"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "strategy",
+                            "stealth",
+                            "support"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_hidden_team",
+                                    "value": true
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                }
+                            ],
+                            "narration": "You choreograph the hidden cell like a ghost ballet. They vanish between breaths."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_hidden_team",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The hidden cell nods once and disappears into the chute."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "-",
+                                    "value": 1
+                                }
+                            ],
+                            "narration": "Two operatives argue over code names. You flip a coin; both accept the result."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "You pay hush money to keep their argument off the meme feed."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Hidden cell roster locked.",
+                        "trader": "Secret team, secret alpha.",
+                        "whale": "Tide covers their tracks.",
+                        "hacker": "Encrypted comms humming.",
+                        "shiller": "Silence is golden and profitable.",
+                        "validator": "Assignments notarized under seal.",
+                        "miner": "They move like whispers in rock.",
+                        "meme": "Stealth squad says nothing (loudly)."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.2",
+                        "action:wakespire_assign_hidden"
+                    ]
+                },
+                {
+                    "id": "wakespire_assign_sentinels",
+                    "label": "Assign the Sentinel Line",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakespire_loss_gate_open",
+                            "wakespire_reclaimed"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "defense",
+                            "resolve",
+                            "leadership"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_sentinel_team",
+                                    "value": true
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                }
+                            ],
+                            "narration": "Living and shade sentinels lock shields. No loss goes unguarded."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_sentinel_team",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The sentinel line forms, quiet and immovable."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 4
+                                }
+                            ],
+                            "narration": "A sentinel tests your resolve with a sparring blow. You answer with respect."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 8
+                                }
+                            ],
+                            "narration": "You underestimate the shades’ zeal and catch a shield edge to the jaw. Worth it to earn their trust."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Sentinel line formation saved.",
+                        "trader": "Defense derivatives trending.",
+                        "whale": "Tide braces behind their shields.",
+                        "hacker": "Communication latency minimal.",
+                        "shiller": "Guardian squad is pure cinematic gold.",
+                        "validator": "Duty oaths notarized.",
+                        "miner": "They hold the line like granite.",
+                        "meme": "Bodyguards? More like soulguards."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.2",
+                        "action:wakespire_assign_sentinels"
+                    ]
+                },
+                {
+                    "id": "wakespire_assign_vanguard",
+                    "label": "Assign the Vanguard Wedge",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakespire_glory_lane",
+                            "wakespire_lightforge_charged"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "valor",
+                            "tactics",
+                            "momentum"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_vanguard_team",
+                                    "value": true
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                }
+                            ],
+                            "narration": "You align the vanguard under the blazing lane. They roar in unison, a sound like stormfront victory."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_vanguard_team",
+                                    "value": true
+                                },
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 1
+                                }
+                            ],
+                            "narration": "The vanguard wedge slots into formation, their boots sparking fire."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "You bribe the drummer gremlins for a better cadence. Worth it."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 7
+                                }
+                            ],
+                            "narration": "Practice run goes sideways and you tumble down three tiers. Lifelines haul you back, laughing."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Vanguard wedge blueprint saved.",
+                        "trader": "Momentum wedge priced at premium hype.",
+                        "whale": "Tide curls beneath their boots.",
+                        "hacker": "Target prioritization uploaded.",
+                        "shiller": "This wedge is the movie poster.",
+                        "validator": "Charge oath notarized.",
+                        "miner": "Their stomp cracks the stairs.",
+                        "meme": "Frontline? More like headline."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.2",
+                        "action:wakespire_assign_vanguard"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "5.2-R5",
+            "description": "Loadout Vault — equip each team with gear forged from the Wakefront mosaic.",
+            "actions": [
+                {
+                    "id": "wakespire_equip_hidden",
+                    "label": "Issue Veilweave Kits",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakespire_hidden_team",
+                            "wakefront_mosaic_forged"
+                        ]
+                    },
+                    "outcomes": {
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "item",
+                                    "id": "gear_wakespire_veilweave"
+                                }
+                            ],
+                            "narration": "Veilweave cloaks settle over the hidden cell, blending them into reflections and rumors."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Veilweave interface calibrated.",
+                        "trader": "Stealth gear sells itself.",
+                        "whale": "Currents wrap them in shadow.",
+                        "hacker": "No one’s cracking that fabric.",
+                        "shiller": "Look invisible, feel unstoppable.",
+                        "validator": "Gear ledger updated.",
+                        "miner": "Cloth feels like carved darkness.",
+                        "meme": "Fashion statement: unseen."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.2",
+                        "action:wakespire_equip_hidden"
+                    ]
+                },
+                {
+                    "id": "wakespire_equip_sentinels",
+                    "label": "Issue Bastion Plates",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakespire_sentinel_team",
+                            "wakefront_mosaic_forged"
+                        ]
+                    },
+                    "outcomes": {
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "item",
+                                    "id": "armor_wakespire_bastion"
+                                }
+                            ],
+                            "narration": "Mosaic plates lock across the sentinel line, each tile glowing with a fallen friend’s sigil."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Bastion telemetry nominal.",
+                        "trader": "Defense suite worth every coin.",
+                        "whale": "Tide breaks around those shields.",
+                        "hacker": "Plates handshake with lifelines flawlessly.",
+                        "shiller": "Armored up and impossible to ignore.",
+                        "validator": "Armor registry notarized.",
+                        "miner": "Plates forged under enormous pressure.",
+                        "meme": "Plot armor? Literal now."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.2",
+                        "action:wakespire_equip_sentinels"
+                    ]
+                },
+                {
+                    "id": "wakespire_equip_vanguard",
+                    "label": "Issue Starspike Lances",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakespire_vanguard_team",
+                            "wakefront_mosaic_forged"
+                        ]
+                    },
+                    "outcomes": {
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "item",
+                                    "id": "weapon_wakespire_starspike"
+                                }
+                            ],
+                            "narration": "The vanguard hefts lances tipped with condensed dawn. Each strike will punch a new hole in fate."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Starspike charge cycle ready.",
+                        "trader": "Offense inventory maxed.",
+                        "whale": "Tide surges with every swing.",
+                        "hacker": "Telemetry locked to highlight reels.",
+                        "shiller": "Sunspear aesthetics for the win.",
+                        "validator": "Weapon ledger notarized.",
+                        "miner": "Tips forged from mosaic core.",
+                        "meme": "Pointy end goes toward destiny."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.2",
+                        "action:wakespire_equip_vanguard"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "focus",
+                    "op": "+",
+                    "value": 1
+                }
+            ]
+        },
+        {
+            "round_id": "5.2-R6",
+            "description": "Verdict Choir — commit the Wake Spire plan to law.",
+            "actions": [
+                {
+                    "id": "wakespire_convene_council",
+                    "label": "Convene the Verdict Choir",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakespire_paths_triangulated",
+                            "wakefront_council_rallied"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "leadership",
+                            "persuasion",
+                            "community"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_council_assembled",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Representatives from every lane chant in harmonized resolve. The Spire itself leans in to listen."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_council_assembled",
+                                    "value": true
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                }
+                            ],
+                            "narration": "The choir stands ready, voices braided with steel."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "-",
+                                    "value": 1
+                                }
+                            ],
+                            "narration": "Discord flickers. You soothe it by reminding everyone what the Wakefront paid already."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 5
+                                }
+                            ],
+                            "narration": "Two delegates clash. You step between them and take the hit. Respect returns, bruised but present."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Verdict choir assembled.",
+                        "trader": "Consensus volume spiking.",
+                        "whale": "Tide hushes to hear the vote.",
+                        "hacker": "Voting nodes synced.",
+                        "shiller": "Minutes from destiny meeting incoming.",
+                        "validator": "Attendance ledger sealed.",
+                        "miner": "Voices echo like picks in caverns.",
+                        "meme": "Choir warmup: la-la-LET’S GO."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.2",
+                        "action:wakespire_convene_council"
+                    ]
+                },
+                {
+                    "id": "wakespire_vote_cast",
+                    "label": "Cast the Spire Verdict",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakespire_council_assembled"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "consensus",
+                            "ritual",
+                            "leadership"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_consensus_passed",
+                                    "value": true
+                                },
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                }
+                            ],
+                            "narration": "The choir’s verdict shakes the Spire. Bells ring in quadruple harmony. The Wake Apex opens above."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakespire_consensus_passed",
+                                    "value": true
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                }
+                            ],
+                            "narration": "Votes align and the ascent is ratified."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 55
+                                }
+                            ],
+                            "narration": "Bribing fate shouldn’t work, but it does when you pay with promises."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 6
+                                }
+                            ],
+                            "narration": "The verdict fractures. A backlash of silence slams into your chest. You stagger, then call for a revote with fire in your lungs."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Verdict commit successful.",
+                        "trader": "Final decision priced in.",
+                        "whale": "Tide surges assent.",
+                        "hacker": "No tampering detected.",
+                        "shiller": "Headline: Wake Spire chooses the climb.",
+                        "validator": "Verdict ledger sealed.",
+                        "miner": "We pickaxed the vote into stone.",
+                        "meme": "All in? ALL IN."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.2",
+                        "action:wakespire_vote_cast"
+                    ]
+                },
+                {
+                    "id": "wakespire_archive_pattern",
+                    "label": "Archive the Spire Schema",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakespire_consensus_passed"
+                        ]
+                    },
+                    "outcomes": {
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "deck",
+                                    "id": "deck_wakespire_aegis"
+                                }
+                            ],
+                            "narration": "You transcribe the Spire’s battle schema into a living deck, each card a tactic tuned for impossible climbs."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Schema archived in redundant arrays.",
+                        "trader": "Blueprint value incalculable.",
+                        "whale": "Future tides can borrow this map.",
+                        "hacker": "Checksum verified across shards.",
+                        "shiller": "Collector’s edition: Last Run, First Lesson.",
+                        "validator": "Archive notarized for posterity.",
+                        "miner": "We carved copies into the Spire’s bones.",
+                        "meme": "Deck flex: we have plays for days."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.2",
+                        "action:wakespire_archive_pattern"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "5.2-R7",
+            "description": "Ascension Gate — climb to the Wake Apex with every plan locked in.",
+            "actions": [
+                {
+                    "id": "advance_5_3",
+                    "label": "Climb to the Wake Apex",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakespire_consensus_passed"
+                        ]
+                    },
+                    "outcomes": {
+                        "success": {
+                            "effects": [],
+                            "narration": "Lanes braid into a single spiral of light. You ascend with every fate singing in your wake.",
+                            "next_hint": "5.3"
+                        }
+                    },
+                    "banter": {
+                        "dev": "Advance payload queued.",
+                        "trader": "All positions staked on the Apex.",
+                        "whale": "Tide lifts you the rest of the way.",
+                        "hacker": "Final handshake ready at the summit.",
+                        "shiller": "Cliffhanger? More like cliff-climber.",
+                        "validator": "Ascent notarized in star ink.",
+                        "miner": "Next tier: the core seam.",
+                        "meme": "Up only, still."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.2",
+                        "action:advance_5_3"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        }
+    ],
+    "threshold_rewards": [
+        {
+            "focus_gte": 20,
+            "rewards": [
+                {
+                    "type": "coins",
+                    "value": 233
+                }
+            ]
+        },
+        {
+            "xp_gte": 1555,
+            "rewards": [
+                {
+                    "type": "item",
+                    "id": "relic_wakespire_keystone"
+                }
+            ]
+        },
+        {
+            "flags_all": [
+                "wakespire_consensus_passed"
+            ],
+            "rewards": [
+                {
+                    "type": "deck",
+                    "id": "deck_wakespire_aegis"
+                }
+            ]
+        }
+    ],
+    "arrivals": [
+        {
+            "when": "flags.afk_tracked",
+            "goto": "5.2A"
+        },
+        {
+            "when": "flags.wakespire_consensus_passed",
+            "goto": "5.3"
+        },
+        {
+            "when": "else",
+            "goto": "5.2"
+        }
+    ]
+}

--- a/content/genesis/scenes/scene_5.3.json
+++ b/content/genesis/scenes/scene_5.3.json
@@ -1,0 +1,1277 @@
+{
+    "schema_version": "1.0",
+    "content_id": "genesis",
+    "book_id": "book_1",
+    "scene_id": "5.3",
+    "title": "The Wake Apex — Binding Every Ending",
+    "narration": "You crest the Wake Spire and step into the Wake Apex, a suspended platform carved from refracted aurora. Four",
+    " gates ring the platform — the Mourning Tower, the Hidden Vault, the Survivor Field, and the Victory Gate — while a sealed f",
+    "ifth aperture waits in the center, blank as unwritten dawn. Gremlins string consoles along the railings, traders float ledger",
+    " globes between the lanes, whales slow the gravity to a heartbeat, hackers sketch counter-hexes in light, validators polish t",
+    "he verdict bells, miners tap hidden batteries, and the meme division paints banners shouting \"LOSE WITH HONOR, HIDE WITH STYL",
+    "E, LIVE WITH FIRE, WIN WITH EVERYONE\" across the air. AFK safeties twist like comet tails above every squad, ready to yank an",
+    " ally back from the brink.\n\nSeven sequences keep the Apex from splintering. The first restabilizes the platform and maps every",
+    " live variable. The second braids four fate threads into actionable conduits. The third seeds caches and cloaks. The fourth as",
+    "signs teams and links their comms. The fifth stress tests the synthesis plan until every lane can swap roles without warning. ",
+    "The sixth convenes the Apex Verdict. The seventh opens the blank aperture toward the Crucible. Hold steady — this is the last",
+    " rehearsal before endings ignite.",
+    "rounds": [
+        {
+            "round_id": "5.3-R1",
+            "description": "Apex Landing — stabilize the platform and log the volatile variables.",
+            "actions": [
+                {
+                    "id": "wakeapex_field_stabilize",
+                    "label": "Stabilize the Apex Field",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakespire_consensus_passed"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "systems",
+                            "discipline",
+                            "defense"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakeapex_field_stable",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You reroute the grav-anchors and the Apex locks in place like a held breath."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakeapex_field_stable",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The platform steadies beneath your boots."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "A plate wobbles and you hire gremlin riggers to bolt it down."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 6
+                                }
+                            ],
+                            "narration": "Gravity whips sideways, slamming you into the rail before the mesh hauls you back."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Stability patch deployed.",
+                        "trader": "Insurance rates drop instantly.",
+                        "whale": "Tide braces the deck.",
+                        "hacker": "Grav daemons sandboxed.",
+                        "shiller": "Floor so steady it passes vibe check.",
+                        "validator": "Anchor lock notarized.",
+                        "miner": "We fused the bolts with comet fire.",
+                        "meme": "APEX FLOOR: NOW 70% LESS YEET."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.3",
+                        "action:wakeapex_field_stabilize"
+                    ]
+                },
+                {
+                    "id": "wakeapex_vector_map",
+                    "label": "Map the Fate Vectors",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakespire_consensus_passed"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "analysis",
+                            "strategy",
+                            "perception"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakeapex_vectors_logged",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You pin every surge, lull, and trap in the four lanes until the Wake itself nods approv",
+                            "al."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakeapex_vectors_logged",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Telemetry pours into your slate in crisp lines of possibility."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 21
+                                }
+                            ],
+                            "narration": "Glare off the Victory Gate forces you to rent anti-flare visors."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 4
+                                }
+                            ],
+                            "narration": "You stare too hard into the Wake and stagger back dizzy with futures."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Vector map uploaded to every HUD.",
+                        "trader": "Odds recalibrated live.",
+                        "whale": "Currents echo the plotlines.",
+                        "hacker": "Telemetry scrubbed for leaks.",
+                        "shiller": "Forecast thread trending.",
+                        "validator": "Survey notarized.",
+                        "miner": "Looks like veins of molten ore.",
+                        "meme": "Weather report: 100% chance of climax."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.3",
+                        "action:wakeapex_vector_map"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "5.3-R2",
+            "description": "Fate Loom — braid the four lanes and load their first-wave caches.",
+            "actions": [
+                {
+                    "id": "wakeapex_quartet_braid",
+                    "label": "Braid the Quartet",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakeapex_field_stable",
+                            "wakeapex_vectors_logged"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "ritual",
+                            "teamwork",
+                            "strategy"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakeapex_quartet_braided",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Loss, concealment, survival, and triumph plait into a radiant rope that refuses to tear."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakeapex_quartet_braided",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The four threads lock together and hum in harmony."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "A knot slips. Traders hand you extra cord when you pay for the upgrade."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 5
+                                }
+                            ],
+                            "narration": "The rope snaps across your palms. You keep weaving through the sting."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Quartet handshake logged.",
+                        "trader": "Diversified fate portfolio aligned.",
+                        "whale": "Currents twine with the braid.",
+                        "hacker": "Thread encrypted at the fiber.",
+                        "shiller": "Friendship bracelet but for apocalypse.",
+                        "validator": "Braid notarized.",
+                        "miner": "We dusted it with ore spark.",
+                        "meme": "Power friendship levels: endgame."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.3",
+                        "action:wakeapex_quartet_braid"
+                    ]
+                },
+                {
+                    "id": "wakeapex_quartet_stock",
+                    "label": "Stock the Quartet Caches",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakeapex_quartet_braided"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "logistics",
+                            "teamwork",
+                            "empathy"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakeapex_caches_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Reliquaries, veils, rations, and laurels slot into position beside each lane, ready fo",
+                            "r whoever needs them first."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakeapex_caches_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Inventory lists light up green across the Apex."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 21
+                                }
+                            ],
+                            "narration": "A crate bursts into celebratory glitter. Worth it, but messy."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 4
+                                }
+                            ],
+                            "narration": "You wrench your shoulder hefting a battery into place."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Cache manifests synced.",
+                        "trader": "Supply chains insured.",
+                        "whale": "Currents deliver pallets.",
+                        "hacker": "Locks tuned to ally bios.",
+                        "shiller": "Loot drop of feelings and fireworks.",
+                        "validator": "Inventory notarized.",
+                        "miner": "Ore batteries humming.",
+                        "meme": "Care packages for every plot twist."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.3",
+                        "action:wakeapex_quartet_stock"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "5.3-R3",
+            "description": "Hidden Infrastructure — sanctify memorial bells and concealment grids while the hearths warm up.",
+            "actions": [
+                {
+                    "id": "wakeapex_memorial_consecrate",
+                    "label": "Consecrate the Memorial Bells",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakeapex_caches_ready"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "ritual",
+                            "empathy",
+                            "harmony"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakeapex_memorials_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Each bell learns a name and a promise. Loss will never be anonymous here."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakeapex_memorials_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The bells settle into a steady cadence of courage."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "One bell cracks. You commission a replacement on the spot."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 5
+                                }
+                            ],
+                            "narration": "The resonance cuts through your chest. Teammates steady you until it fades."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Memorial playlist curated.",
+                        "trader": "Offering pool oversubscribed.",
+                        "whale": "Currents cradle the names.",
+                        "hacker": "No grief-scrapers allowed.",
+                        "shiller": "Tribute stream trending.",
+                        "validator": "Blessing notarized.",
+                        "miner": "We cast the new bell from aurora ore.",
+                        "meme": "Crying but iconic."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.3",
+                        "action:wakeapex_memorial_consecrate"
+                    ]
+                },
+                {
+                    "id": "wakeapex_cloak_grid",
+                    "label": "Prime the Cloak Grid",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakeapex_quartet_braided"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "stealth",
+                            "systems",
+                            "teamwork"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakeapex_cloak_grid_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Veils shimmer over the Hidden Vault. Anyone under your protection slips off hostile le",
+                            "dgers."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakeapex_cloak_grid_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The grid hums like a content ghost."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 21
+                                }
+                            ],
+                            "narration": "A cloak flickers neon. Hackers demand hazard pay to fix it."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 4
+                                }
+                            ],
+                            "narration": "You vanish from your own HUD and panic before the mesh yanks you back."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Stealth grid uptime perfect.",
+                        "trader": "Hide lane premiums skyrocketing.",
+                        "whale": "Currents hush around you.",
+                        "hacker": "Camouflage keyed to friend signatures.",
+                        "shiller": "Influencers begging for cloak selfies.",
+                        "validator": "Grid notarized anonymously.",
+                        "miner": "We laced the veils with star ash.",
+                        "meme": "Stealth but make it glitter."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.3",
+                        "action:wakeapex_cloak_grid"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "5.3-R4",
+            "description": "Signal Lattice — assign the four squads and lace their comms into a single heartbeat.",
+            "actions": [
+                {
+                    "id": "wakeapex_team_assign",
+                    "label": "Assign the Quartet Squads",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakeapex_caches_ready",
+                            "wakeapex_memorials_ready",
+                            "wakeapex_cloak_grid_ready"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "leadership",
+                            "strategy",
+                            "teamwork"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakeapex_squads_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Mourners, ghosts, guardians, and champions take their posts with grins sharp as comets."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakeapex_squads_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The roster locks in and squad channels explode with reaction emojis."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "You double-book a captain and bribe the bench with premium snacks."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 6
+                                }
+                            ],
+                            "narration": "You shout over the cheers until your voice cracks; medics hand you honey tea."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Roster synced to mission planner.",
+                        "trader": "Talent swaps cleared.",
+                        "whale": "Currents drum for each squad.",
+                        "hacker": "Private channels triple sealed.",
+                        "shiller": "Announcement holo trending.",
+                        "validator": "Assignments notarized.",
+                        "miner": "We minted lane badges in the forge.",
+                        "meme": "Squad comp? Chef's kiss."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.3",
+                        "action:wakeapex_team_assign"
+                    ]
+                },
+                {
+                    "id": "wakeapex_lattice_weave",
+                    "label": "Weave the Signal Lattice",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakeapex_squads_ready",
+                            "wakeapex_afk_mesh_ready"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "systems",
+                            "support",
+                            "discipline"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakeapex_lattice_online",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Every ping ricochets through a lattice of light. Loss can warn Win, Hide can shield Liv",
+                            "e, Live can heal Loss, Win can boost them all."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakeapex_lattice_online",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The lattice hums like a choir warming up."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 21
+                                }
+                            ],
+                            "narration": "Feedback squeals across the Apex until you sponsor new filters."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 4
+                                }
+                            ],
+                            "narration": "A spark leaps from the lattice and singes your hair."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Signal quality at six nines.",
+                        "trader": "Latency hedged to zero.",
+                        "whale": "Currents carry every whisper.",
+                        "hacker": "Mesh within the mesh.",
+                        "shiller": "We just invented choir comms.",
+                        "validator": "Lattice notarized.",
+                        "miner": "We strung relays through ore veins.",
+                        "meme": "It's giving telecom deity."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.3",
+                        "action:wakeapex_lattice_weave"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "5.3-R5",
+            "description": "Stress Test — make the squads swap roles and declare the synthesis mission.",
+            "actions": [
+                {
+                    "id": "wakeapex_swap_drill",
+                    "label": "Run the Quad Swap Drill",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakeapex_lattice_online"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "teamwork",
+                            "strategy",
+                            "discipline"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakeapex_swap_mastered",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Squads trade lanes mid-maneuver without dropping a beat. Even the Wake pauses to clap."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakeapex_swap_mastered",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The drill completes with cheers and relieved laughter."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "A timing slip causes a spectacular dogpile. You pay for extra padding."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 5
+                                }
+                            ],
+                            "narration": "You take a friendly tackle to the ribs and laugh through the bruise."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Swap macros compiled.",
+                        "trader": "Risk redistribution flawless.",
+                        "whale": "Currents reroute like lightning.",
+                        "hacker": "Failsafes confirmed.",
+                        "shiller": "Musical chairs but mythic.",
+                        "validator": "Drill notarized mid-spin.",
+                        "miner": "We shifted scenery on the fly.",
+                        "meme": "Squads go brrrr."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.3",
+                        "action:wakeapex_swap_drill"
+                    ]
+                },
+                {
+                    "id": "wakeapex_synthesis_proclaim",
+                    "label": "Proclaim the Synthesis",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakeapex_swap_mastered"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "inspiration",
+                            "ritual",
+                            "leadership"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakeapex_synthesis_declared",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You promise to carry every ending at once. The Wake vibrates as if it just learned a ne",
+                            "w word."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakeapex_synthesis_declared",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The squads shout the vow back at you in four-part harmony."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "You ramble. You make up for it with commemorative patches."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 6
+                                }
+                            ],
+                            "narration": "Emotion closes your throat. The crowd finishes the promise for you."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Speech archived in crystal.",
+                        "trader": "We priced the plan at priceless.",
+                        "whale": "Currents roar assent.",
+                        "hacker": "Echo recorded without leaks.",
+                        "shiller": "Motivation level: transcendence.",
+                        "validator": "Vow notarized.",
+                        "miner": "We etched it into the guard rail.",
+                        "meme": "Mission statement? More like prophecy."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.3",
+                        "action:wakeapex_synthesis_proclaim"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "5.3-R6",
+            "description": "Apex Verdict — gather the council, cast the vote, and archive the plan for the next community.",
+            "actions": [
+                {
+                    "id": "wakeapex_council_convene",
+                    "label": "Convene the Apex Council",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakeapex_synthesis_declared"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "ritual",
+                            "leadership",
+                            "harmony"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakeapex_council_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Delegates from every lane circle the sigil. Bells hush, cloaks shimmer, hearths glow, la",
+                            "urels blaze."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakeapex_council_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Councilors lock hands and nod for the vote."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "Two representatives argue about snacks; you upgrade catering to settle it."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 6
+                                }
+                            ],
+                            "narration": "Your voice cracks during roll call, but the room cheers you through it."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Council attendance logged.",
+                        "trader": "Governance tokens minted.",
+                        "whale": "Currents swirl into quorum.",
+                        "hacker": "Meeting warded against leaks.",
+                        "shiller": "Town hall of legends.",
+                        "validator": "Agenda notarized.",
+                        "miner": "We set the chairs in a ring of ore.",
+                        "meme": "Council? More like hype caucus."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.3",
+                        "action:wakeapex_council_convene"
+                    ]
+                },
+                {
+                    "id": "wakeapex_vote_call",
+                    "label": "Call the Apex Vote",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakeapex_council_ready"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "consensus",
+                            "ritual",
+                            "leadership"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakeapex_consensus_passed",
+                                    "value": true
+                                },
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                }
+                            ],
+                            "narration": "Every hand rises. The bells ring four chords and then a fifth none of you have heard bef",
+                            "ore."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakeapex_consensus_passed",
+                                    "value": true
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                }
+                            ],
+                            "narration": "Consensus holds. The Wake opens a seam toward possibility."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 55
+                                }
+                            ],
+                            "narration": "A tie stalls the room. You sweeten the incentives and call the vote again."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 6
+                                }
+                            ],
+                            "narration": "Voices clash. You absorb the backlash and promise a reconvene."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Vote recorded on-chain and on-heart.",
+                        "trader": "Consensus premium achieved.",
+                        "whale": "Currents crash in applause.",
+                        "hacker": "No bots, all bravery.",
+                        "shiller": "Headline: 'Apex chooses everything.'",
+                        "validator": "Ballots notarized.",
+                        "miner": "We rang the bells with ore mallets.",
+                        "meme": "Motion passes. Motion dances."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.3",
+                        "action:wakeapex_vote_call"
+                    ]
+                },
+                {
+                    "id": "wakeapex_archive",
+                    "label": "Archive the Apex Playbook",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakeapex_consensus_passed"
+                        ]
+                    },
+                    "outcomes": {
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "deck",
+                                    "id": "deck_wakeapex_quartet"
+                                }
+                            ],
+                            "narration": "You compress the rehearsals, drills, and vows into a glowing deck for whoever faces the",
+                            " Wake after you."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Playbook mirrored across shards.",
+                        "trader": "Priceless and freely shared.",
+                        "whale": "Currents carry the archive.",
+                        "hacker": "Checksum verified.",
+                        "shiller": "Collectors already screaming.",
+                        "validator": "Archive notarized.",
+                        "miner": "We etched a backup into the Apex bedrock.",
+                        "meme": "Lore drop!"
+                    },
+                    "telemetry_tags": [
+                        "scene:5.3",
+                        "action:wakeapex_archive"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "5.3-R7",
+            "description": "Aperture Gate — open the blank way toward the Crucible beyond.",
+            "actions": [
+                {
+                    "id": "advance_5_4",
+                    "label": "Open the Blank Aperture",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakeapex_consensus_passed"
+                        ]
+                    },
+                    "outcomes": {
+                        "success": {
+                            "effects": [],
+                            "narration": "The sealed gate unfurls into a path of white fire. Every lane surges forward beside you.",
+                            "next_hint": "5.4"
+                        }
+                    },
+                    "banter": {
+                        "dev": "Transition compiled.",
+                        "trader": "All positions rolling into the Crucible.",
+                        "whale": "Currents beckon you onward.",
+                        "hacker": "No turning back, only turning better.",
+                        "shiller": "Next stop: legend."
+                        ,
+                        "validator": "Gate opening notarized.",
+                        "miner": "We pry the path open with star picks.",
+                        "meme": "Time to full-send destiny."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.3",
+                        "action:advance_5_4"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        }
+    ],
+    "threshold_rewards": [
+        {
+            "focus_gte": 21,
+            "rewards": [
+                {
+                    "type": "coins",
+                    "value": 233
+                }
+            ]
+        },
+        {
+            "xp_gte": 1666,
+            "rewards": [
+                {
+                    "type": "item",
+                    "id": "relic_wakeapex_azimuth"
+                }
+            ]
+        },
+        {
+            "flags_all": [
+                "wakeapex_consensus_passed"
+            ],
+            "rewards": [
+                {
+                    "type": "deck",
+                    "id": "deck_wakeapex_quartet"
+                }
+            ]
+        }
+    ],
+    "arrivals": [
+        {
+            "when": "flags.afk_tracked",
+            "goto": "5.3A"
+        },
+        {
+            "when": "flags.wakeapex_consensus_passed",
+            "goto": "5.4"
+        },
+        {
+            "when": "else",
+            "goto": "5.3"
+        }
+    ]
+}

--- a/content/genesis/scenes/scene_5.4.json
+++ b/content/genesis/scenes/scene_5.4.json
@@ -1,0 +1,1282 @@
+{
+    "schema_version": "1.0",
+    "content_id": "genesis",
+    "book_id": "book_1",
+    "scene_id": "5.4",
+    "title": "The Wake Crucible — Colliding All Threads",
+    "narration": "The blank aperture spits you into the Wake Crucible, a spherical chamber cut from conden",
+    "sed starlight. Hexagonal plates orbit a molten core, each etched with the four lane sigils you carried from the Apex. Above",
+    " and below, ghost-cities of possible endings grind against each other like tectonic plates. Every clash throws sparks that co",
+    "uld become victory, retreat, survival, or sacrifice depending on who catches them first. Gremlins string sensor rigs between",
+    " the plates, traders run arbitrage booths where you can exchange despair for cunning, whales push tides of molten light to fo",
+    "rge temporary bridges, hackers unravel the adversary’s counter-protocols, validators hang verdict prisms ready to refract jus",
+    "tice, miners tap magma vents for raw energy, and the meme division projects graffiti like \"WE DO NOT CHOOSE BETWEEN ENDINGS; W",
+    "E CHOOSE ALL OF THEM\" across the burning walls.\n\nSeven phases keep the Crucible from imploding. The first locks the plates and",
+    " charts the adversary orbit. The second chains your quartet plan into the Crucible forge. The third loads catalysts and shelte",
+    "rs in case the chamber shatters. The fourth assigns strike, veil, rescue, and rally crews with mirrored comms. The fifth runs",
+    " live-fire drills that weaponize endings against each other. The sixth convenes the Crucible Verdict. The seventh cracks the c",
+    "ore, opening the path to the Reckoning ahead.",
+    "rounds": [
+        {
+            "round_id": "5.4-R1",
+            "description": "Crucible Lock — anchor the plates and identify hostile vectors.",
+            "actions": [
+                {
+                    "id": "wakecrucible_core_calibrate",
+                    "label": "Calibrate the Crucible Core",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakeapex_consensus_passed"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "systems",
+                            "discipline",
+                            "defense"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakecrucible_core_stable",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You counter-spin the plates until the chamber hums in balance. The molten heart settle",
+                            "s like a loyal sun."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakecrucible_core_stable",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The plates lock into an orderly orbit around you."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "One plate lurches. You rent whale-guided tow cables to haul it back in line."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 6
+                                }
+                            ],
+                            "narration": "A molten spray scorches your armor. The meme crew tags the scorch mark with a heart."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Orbital lock patched.",
+                        "trader": "Volatility premiums plummet.",
+                        "whale": "Tide cools the core.",
+                        "hacker": "No sabotage vectors detected.",
+                        "shiller": "We stabilized a sun. Casual.",
+                        "validator": "Plate positions notarized.",
+                        "miner": "We hammered the couplings with magma hammers.",
+                        "meme": "Core set to do-not-spin mode."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.4",
+                        "action:wakecrucible_core_calibrate"
+                    ]
+                },
+                {
+                    "id": "wakecrucible_enemy_chart",
+                    "label": "Chart the Enemy Orbit",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakeapex_consensus_passed"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "analysis",
+                            "strategy",
+                            "perception"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakecrucible_vectors_logged",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You map hostile swarms, fail-safes, and counterfates in crisp arcs. The Crucible reveal",
+                            "s every threat it can muster."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakecrucible_vectors_logged",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Vectors highlight across your visor. Weaknesses glow like fault lines."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 21
+                                }
+                            ],
+                            "narration": "Heat haze fogs your scans. You buy cooling pylons to steady the signal."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 4
+                                }
+                            ],
+                            "narration": "A counter-hex pulses back through the sensor and numbs your arm."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Threat matrix streaming.",
+                        "trader": "Shorting their chances already.",
+                        "whale": "Currents outline every predator.",
+                        "hacker": "Scrubbed their mask subroutines.",
+                        "shiller": "Enemy reveal trailer dropping now.",
+                        "validator": "Orbit notarized.",
+                        "miner": "We etched the weaknesses into the rail.",
+                        "meme": "Know thy enemy, roast thy enemy."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.4",
+                        "action:wakecrucible_enemy_chart"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "5.4-R2",
+            "description": "Forge Loop — bind the quartet lanes into the Crucible’s pressure locks.",
+            "actions": [
+                {
+                    "id": "wakecrucible_lane_lock",
+                    "label": "Lock the Fate Loop",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakecrucible_core_stable",
+                            "wakecrucible_vectors_logged"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "ritual",
+                            "teamwork",
+                            "discipline"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakecrucible_loop_locked",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You weld loss, concealment, survival, and triumph into a feedback loop that feeds on ho",
+                            "pe instead of despair."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakecrucible_loop_locked",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The loop seals, glowing white-hot and obedient."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "A weld pops. Traders front extra flux after you pay hazard fees."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 6
+                                }
+                            ],
+                            "narration": "The feedback lashes your chest. You grit through it and finish the lock."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Loop handshake green.",
+                        "trader": "Endings arbitraged in your favor.",
+                        "whale": "Currents flow without backwash.",
+                        "hacker": "No sabotage vector survives.",
+                        "shiller": "We braided fate into adamant.",
+                        "validator": "Loop notarized.",
+                        "miner": "Welded with magma rods.",
+                        "meme": "Feedback loop? More like feedforward legend."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.4",
+                        "action:wakecrucible_lane_lock"
+                    ]
+                },
+                {
+                    "id": "wakecrucible_pressure_reserves",
+                    "label": "Load the Pressure Reserves",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakecrucible_loop_locked"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "logistics",
+                            "support",
+                            "strategy"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakecrucible_reserves_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You seed reliquaries, veil kits, med bays, and celebration cannons into shielded alcove",
+                            "s before the chamber floods with heat."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakecrucible_reserves_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Stockpiles click into place; status lights flash emerald."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 21
+                                }
+                            ],
+                            "narration": "A cache melts. You buy insulated housings and restock."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 4
+                                }
+                            ],
+                            "narration": "You singe your hands shoving supplies into the alcoves."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Reserve manifests synced.",
+                        "trader": "Budget lines survived the lava.",
+                        "whale": "Currents deliver the crates.",
+                        "hacker": "All hatches keyed to ally prints.",
+                        "shiller": "Loot drop but make it lava-proof.",
+                        "validator": "Reserves notarized.",
+                        "miner": "We carved shelves into basalt.",
+                        "meme": "Emergency s'mores kit included."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.4",
+                        "action:wakecrucible_pressure_reserves"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "5.4-R3",
+            "description": "Catalyst Stage — charge the heart and carve bunkers in case the chamber ruptures.",
+            "actions": [
+                {
+                    "id": "wakecrucible_catalyst_charge",
+                    "label": "Charge the Catalyst Heart",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakecrucible_reserves_ready"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "ritual",
+                            "offense",
+                            "inspiration"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakecrucible_catalyst_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You thread lane energy into the molten heart until it spins like a contained nova, wait",
+                            "ing to be unleashed."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakecrucible_catalyst_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The core glows brighter, pulsing to the rhythm of your squads."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "The heart flares wild. You buy dampeners and try again."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 6
+                                }
+                            ],
+                            "narration": "Heat sears through your gauntlets. The meme crew captions the smoke trail."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Catalyst charge within tolerance.",
+                        "trader": "Yield curve now volcanic.",
+                        "whale": "Currents spin the fire gently.",
+                        "hacker": "Containment protocols green.",
+                        "shiller": "Heart of a star, playlist of a hero.",
+                        "validator": "Charge notarized.",
+                        "miner": "We drilled vents to keep it honest.",
+                        "meme": "Core flexing harder than we are."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.4",
+                        "action:wakecrucible_catalyst_charge"
+                    ]
+                },
+                {
+                    "id": "wakecrucible_shadow_bunkers",
+                    "label": "Hollow the Shadow Bunkers",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakecrucible_loop_locked"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "stealth",
+                            "logistics",
+                            "teamwork"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakecrucible_bunkers_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You carve mirrored bunkers inside the plates, cloaking them from hostile sensors and li",
+                            "nking them to the AFK mesh."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakecrucible_bunkers_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Hidden chambers shimmer to life along the walls."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 21
+                                }
+                            ],
+                            "narration": "A bunker vents steam like a beacon. You fund insulation and patch the leak."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 4
+                                }
+                            ],
+                            "narration": "You tumble into molten slag and crawl out smoking but alive."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Bunker network mapped.",
+                        "trader": "Hide assets secured.",
+                        "whale": "Currents chill the crawlspaces.",
+                        "hacker": "Invisible and invitation-only.",
+                        "shiller": "VIP panic rooms, now with mood lighting.",
+                        "validator": "Bunkers notarized anonymously.",
+                        "miner": "We carved them with subsonic drills.",
+                        "meme": "Stealth level: magma-proof."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.4",
+                        "action:wakecrucible_shadow_bunkers"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "5.4-R4",
+            "description": "Strike Grid — assign the four crews and mirror their comm lattice.",
+            "actions": [
+                {
+                    "id": "wakecrucible_strike_assign",
+                    "label": "Assign the Crucible Crews",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakecrucible_reserves_ready",
+                            "wakecrucible_bunkers_ready"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "leadership",
+                            "strategy",
+                            "teamwork"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakecrucible_crews_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Strike, veil, rescue, and rally leaders clasp wrists above the core. Their squads echo",
+                            " the motion in perfect sync."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakecrucible_crews_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Assignments lock; lane icons flare over every helmet."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "Two squads fight over anthem rights. You sponsor a mashup and move on."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 6
+                                }
+                            ],
+                            "narration": "You get hoisted during a celebratory toss and dropped into a foam pit."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Crew rosters synced.",
+                        "trader": "Strike options hedged.",
+                        "whale": "Currents drum for each call sign.",
+                        "hacker": "Private comms sealed.",
+                        "shiller": "Promo posters done before the ink dries.",
+                        "validator": "Assignments notarized.",
+                        "miner": "We forged insignias from cooling slag.",
+                        "meme": "Crews assemble!"
+                    },
+                    "telemetry_tags": [
+                        "scene:5.4",
+                        "action:wakecrucible_strike_assign"
+                    ]
+                },
+                {
+                    "id": "wakecrucible_signal_matrix",
+                    "label": "Mirror the Signal Matrix",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakecrucible_crews_ready",
+                            "wakecrucible_catalyst_ready"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "systems",
+                            "support",
+                            "discipline"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakecrucible_matrix_online",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Twin lattices spin — one inside the Crucible, one ghosted at the Wake Apex — ensuring any",
+                            " message echoes across both arenas."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakecrucible_matrix_online",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Signals shimmer like mirrored constellations across your HUD."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 21
+                                }
+                            ],
+                            "narration": "Echoes feedback until you underwrite more dampeners."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 4
+                                }
+                            ],
+                            "narration": "The twin matrix clips your shoulder with raw static."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Matrix mirrored without drift.",
+                        "trader": "Latency trades at zero.",
+                        "whale": "Currents carry your echoes.",
+                        "hacker": "Cross-sync locked.",
+                        "shiller": "Two arenas, one shout.",
+                        "validator": "Matrix notarized.",
+                        "miner": "We strung relay crystals through molten veins.",
+                        "meme": "It's stereo destiny."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.4",
+                        "action:wakecrucible_signal_matrix"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "5.4-R5",
+            "description": "Trial Fires — weaponize lane energy and rehearse emergency recoveries.",
+            "actions": [
+                {
+                    "id": "wakecrucible_overload_test",
+                    "label": "Test the Overload Spiral",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakecrucible_matrix_online"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "offense",
+                            "strategy",
+                            "teamwork"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakecrucible_overload_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You unleash the catalyst heart in a controlled burst that ricochets between lanes and r",
+                            "eturns as pure momentum."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakecrucible_overload_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The spiral holds. Your squads cheer over the comms."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "Energy leaks sideways. You pay miners to brace the conduits."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 6
+                                }
+                            ],
+                            "narration": "The spiral whips you off your feet. The AFK mesh slams you safely into a bunker."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Overload script tuned.",
+                        "trader": "Momentum futures skyrocketing.",
+                        "whale": "Currents ride the spiral.",
+                        "hacker": "Failsafes triple redundant.",
+                        "shiller": "That blast had merch potential.",
+                        "validator": "Test notarized mid-flare.",
+                        "miner": "We reinforced the conduits.",
+                        "meme": "Explosions but tasteful."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.4",
+                        "action:wakecrucible_overload_test"
+                    ]
+                },
+                {
+                    "id": "wakecrucible_recovery_wave",
+                    "label": "Launch the Recovery Wave",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakecrucible_overload_ready",
+                            "wakecrucible_crews_ready"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "support",
+                            "teamwork",
+                            "medicine"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakecrucible_recovery_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Healers, smugglers, shieldbearers, and hype squads flood the chamber in choreographed w",
+                            "aves, undoing damage faster than the Crucible can inflict it."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakecrucible_recovery_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The wave leaves every squad grinning and recharged."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "Timing slips; you pay overtime to rehearse again."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 5
+                                }
+                            ],
+                            "narration": "A stray surge knocks you into a med bay. You wake up already healed."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Recovery macros synced.",
+                        "trader": "Resilience premium locked.",
+                        "whale": "Currents cushion every fall.",
+                        "hacker": "Med feeds encrypted.",
+                        "shiller": "Wellness wave trending.",
+                        "validator": "Wave notarized.",
+                        "miner": "We piped coolant where it counts.",
+                        "meme": "Group hug but tactical."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.4",
+                        "action:wakecrucible_recovery_wave"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "5.4-R6",
+            "description": "Crucible Verdict — call the council, ratify the plan, and archive the forge notes.",
+            "actions": [
+                {
+                    "id": "wakecrucible_council_convene",
+                    "label": "Convene the Crucible Council",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakecrucible_recovery_ready"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "ritual",
+                            "leadership",
+                            "harmony"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakecrucible_council_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Delegates meet on a floating plate while molten light frames them like stained glass."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakecrucible_council_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The council stands ready; the chamber hushes."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "Heat makes tempers flare. You sponsor cooling wards until everyone smiles again."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 6
+                                }
+                            ],
+                            "narration": "Your throat scorches mid-address. A healer mists your voice back into service."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Council quorum logged.",
+                        "trader": "Governance bonds trading hot.",
+                        "whale": "Currents curl into a halo.",
+                        "hacker": "Minutes encrypted.",
+                        "shiller": "Forge floor doubles as council chamber.",
+                        "validator": "Agenda notarized.",
+                        "miner": "We bolted the chairs to keep them from drifting.",
+                        "meme": "Molten parliament assemble."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.4",
+                        "action:wakecrucible_council_convene"
+                    ]
+                },
+                {
+                    "id": "wakecrucible_vote_call",
+                    "label": "Call the Crucible Vote",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakecrucible_council_ready"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "consensus",
+                            "ritual",
+                            "leadership"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakecrucible_consensus_passed",
+                                    "value": true
+                                },
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                }
+                            ],
+                            "narration": "The verdict prisms ring in ascending chords. The chamber acknowledges your fourfold stra",
+                            "tegy."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakecrucible_consensus_passed",
+                                    "value": true
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                }
+                            ],
+                            "narration": "Consensus flashes across every visor."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 55
+                                }
+                            ],
+                            "narration": "A stalemate forms. You buy extra coolant and emotional support snacks to break it."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 6
+                                }
+                            ],
+                            "narration": "Arguments spike like lava. You absorb the backlash and promise a calmer re-vote."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Vote recorded in molten ink.",
+                        "trader": "Consensus premium secured.",
+                        "whale": "Currents applaud.",
+                        "hacker": "No tampering on my watch.",
+                        "shiller": "Headline: 'Crucible picks all outcomes.'",
+                        "validator": "Ballots notarized.",
+                        "miner": "We rang the prisms with ore mallets.",
+                        "meme": "Motion passes with molten swagger."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.4",
+                        "action:wakecrucible_vote_call"
+                    ]
+                },
+                {
+                    "id": "wakecrucible_archive",
+                    "label": "Archive the Forge Notes",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakecrucible_consensus_passed"
+                        ]
+                    },
+                    "outcomes": {
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "item",
+                                    "id": "relic_crucible_codex"
+                                }
+                            ],
+                            "narration": "You emboss the drills, failsafes, and bravado into a heat-proof codex for the next coho",
+                            "rt."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Codex etched and cooled.",
+                        "trader": "Priced at 'share freely'.",
+                        "whale": "Currents carry copies outward.",
+                        "hacker": "Checksum sealed.",
+                        "shiller": "Collector's edition forged today.",
+                        "validator": "Archive notarized.",
+                        "miner": "We quenched it in comet water.",
+                        "meme": "New lore drop smells like lava."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.4",
+                        "action:wakecrucible_archive"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "5.4-R7",
+            "description": "Core Shatter — crack the molten heart and reveal the Reckoning path.",
+            "actions": [
+                {
+                    "id": "advance_5_5",
+                    "label": "Shatter the Crucible Core",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakecrucible_consensus_passed"
+                        ]
+                    },
+                    "outcomes": {
+                        "success": {
+                            "effects": [],
+                            "narration": "You strike the molten heart with the quartet loop. The chamber blooms into a corridor of",
+                            " red-white light leading deeper.",
+                            "next_hint": "5.5"
+                        }
+                    },
+                    "banter": {
+                        "dev": "Reckoning gateway stable.",
+                        "trader": "All stakes roll forward.",
+                        "whale": "Currents surge toward the breach.",
+                        "hacker": "No failsafes left behind.",
+                        "shiller": "Stage five hype unlocked.",
+                        "validator": "Shatter notarized.",
+                        "miner": "We cracked a star and called it progress.",
+                        "meme": "Next zone speedrun when?"
+                    },
+                    "telemetry_tags": [
+                        "scene:5.4",
+                        "action:advance_5_5"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        }
+    ],
+    "threshold_rewards": [
+        {
+            "focus_gte": 22,
+            "rewards": [
+                {
+                    "type": "coins",
+                    "value": 255
+                }
+            ]
+        },
+        {
+            "xp_gte": 1777,
+            "rewards": [
+                {
+                    "type": "item",
+                    "id": "relic_crucible_core"
+                }
+            ]
+        },
+        {
+            "flags_all": [
+                "wakecrucible_consensus_passed"
+            ],
+            "rewards": [
+                {
+                    "type": "item",
+                    "id": "relic_crucible_codex"
+                }
+            ]
+        }
+    ],
+    "arrivals": [
+        {
+            "when": "flags.afk_tracked",
+            "goto": "5.4A"
+        },
+        {
+            "when": "flags.wakecrucible_consensus_passed",
+            "goto": "5.5"
+        },
+        {
+            "when": "else",
+            "goto": "5.4"
+        }
+    ]
+}

--- a/content/genesis/scenes/scene_5.5.json
+++ b/content/genesis/scenes/scene_5.5.json
@@ -1,0 +1,1284 @@
+{
+    "schema_version": "1.0",
+    "content_id": "genesis",
+    "book_id": "book_1",
+    "scene_id": "5.5",
+    "title": "The Wake Reckoning — Drawing the Lines",
+    "narration": "Beyond the shattered Crucible lies the Wake Reckoning: a colossal amphitheater of grav staircases spiral",
+    "ing around a void of mirrored water. Every reflection shows a different resolution of Act Five. Some gleam with victory parad",
+    "es, some whisper with hidden caravans, some hold cities that survived with scars, and some shimmer with memorial gardens. A ma",
+    "ssive ledger-constellation hovers overhead, ticking down the moments before the final confrontation. Gremlins wire the stairs",
+    " with phase gates, traders float credit orbs you can cash in for last-minute miracles, whales fold the void so any squad can ",
+    "surface instantly, hackers weave counter-scripts against the Reckoning intelligence, validators align oath pylons around the",
+    " rim, miners anchor resonance pylons, and the meme division throws up sigils reading \"WE GO ALL-IN, WE GO ALL-TOGETHER\" in an",
+    "y language you ever loved.\n\nSeven beats prepare the Reckoning. The first anchors the amphitheater and decodes the adversary",
+    " clock. The second phases your quartet plan across reflected timelines. The third consecrates memory vaults and cloak flux cha",
+    "nnels. The fourth assigns phalanx, shadow, lifeline, and herald crews to the staircases. The fifth rehearses simultaneous tria",
+    "ls and resolves. The sixth convenes the Reckoning Verdict. The seventh opens the mirrored descent toward Act Five’s deciding mo",
+    "ment.",
+    "rounds": [
+        {
+            "round_id": "5.5-R1",
+            "description": "Reckoning Anchor — steady the amphitheater and decipher the enemy countdown.",
+            "actions": [
+                {
+                    "id": "wakereckoning_stage_anchor",
+                    "label": "Anchor the Reckoning Stage",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakecrucible_consensus_passed"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "systems",
+                            "discipline",
+                            "defense"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakereckoning_stage_stable",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You lock the grav staircases in synchronized orbit. The void settles like a waiting dr",
+                            "um."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakereckoning_stage_stable",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The amphitheater steadies and the reflections align."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "A staircase wobbles. You fund whale-guided braces to lock it down."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 6
+                                }
+                            ],
+                            "narration": "You tumble three tiers before the AFK mesh yanks you upright."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Stage anchor patch applied.",
+                        "trader": "Volatility curve calms.",
+                        "whale": "Currents hold the stairs firm.",
+                        "hacker": "Gravity gremlins declawed.",
+                        "shiller": "Arena locked, hype unlocked.",
+                        "validator": "Anchor notarized.",
+                        "miner": "We bolted every tread with star rivets.",
+                        "meme": "Zero wobble, all drama."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.5",
+                        "action:wakereckoning_stage_anchor"
+                    ]
+                },
+                {
+                    "id": "wakereckoning_enemy_decode",
+                    "label": "Decode the Reckoning Clock",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakecrucible_consensus_passed"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "analysis",
+                            "strategy",
+                            "perception"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakereckoning_clock_decoded",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You read the ledger-constellation like sheet music. You now know exactly when the reck",
+                            "oning intelligence plans to strike."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakereckoning_clock_decoded",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The countdown resolves into a clear rhythm on your HUD."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 21
+                                }
+                            ],
+                            "narration": "Glare off the mirrored void throws your readings; you buy polarized visors."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 4
+                                }
+                            ],
+                            "narration": "A counter-pulse spikes your vision. Teammates steady you while the clock snaps into foc",
+                            "us."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Countdown feed mirrored to everyone.",
+                        "trader": "Risk horizon plotted.",
+                        "whale": "Currents echo the tempo.",
+                        "hacker": "Clock firmware exploited.",
+                        "shiller": "Time to destiny: trending.",
+                        "validator": "Decode notarized.",
+                        "miner": "We carved the timing into the steps.",
+                        "meme": "Final boss schedule obtained."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.5",
+                        "action:wakereckoning_enemy_decode"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "5.5-R2",
+            "description": "Phase Weave — align the quartet plan across mirrored timelines and reinforce supply wards.",
+            "actions": [
+                {
+                    "id": "wakereckoning_lane_phase",
+                    "label": "Phase the Quartet Across Mirrors",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakereckoning_stage_stable",
+                            "wakereckoning_clock_decoded"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "ritual",
+                            "teamwork",
+                            "strategy"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakereckoning_phase_aligned",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Loss, hide, live, and win shimmer through every reflection. The Reckoning recognizes y",
+                            "ou in all futures at once."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakereckoning_phase_aligned",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The mirrored lanes echo your plan with crisp precision."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "One reflection desyncs; you bribe the Reckoning with a vow and resync it."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 6
+                                }
+                            ],
+                            "narration": "The mirrors shatter and reassemble around you. You keep weaving through the vertigo."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Phase handshake verified.",
+                        "trader": "Timeline arbitrage locked.",
+                        "whale": "Currents ripple in quadruple.",
+                        "hacker": "Reflections patched against spoofs.",
+                        "shiller": "We are everywhere at once, babe.",
+                        "validator": "Phase notarized.",
+                        "miner": "We studded the mirrors with ore anchors.",
+                        "meme": "Multiverse? More like multivictory."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.5",
+                        "action:wakereckoning_lane_phase"
+                    ]
+                },
+                {
+                    "id": "wakereckoning_ward_reserves",
+                    "label": "Ward the Supply Rings",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakereckoning_phase_aligned"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "logistics",
+                            "support",
+                            "discipline"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakereckoning_reserves_warded",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You ring the amphitheater with shielded caches. Whoever falls back will find reliquarie",
+                            "s, cloaks, rations, and banners waiting."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakereckoning_reserves_warded",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Status icons flash green around the arena."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 21
+                                }
+                            ],
+                            "narration": "A cache falls into the void; traders bill you for retrieval."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 4
+                                }
+                            ],
+                            "narration": "A ward detonates in your hands. You shake off the sparks and rebuild it."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Supply wards monitored.",
+                        "trader": "Backup budgets balanced.",
+                        "whale": "Currents guard every stash.",
+                        "hacker": "Locks biometric and vibe-metric.",
+                        "shiller": "Snack rings plus banner vaults? Luxury.",
+                        "validator": "Wards notarized.",
+                        "miner": "We riveted each cache into bedrock.",
+                        "meme": "Ring of power, but it's snacks and hope."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.5",
+                        "action:wakereckoning_ward_reserves"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "5.5-R3",
+            "description": "Memory Flux — bless the vaults and tune cloak pathways across the void.",
+            "actions": [
+                {
+                    "id": "wakereckoning_memory_vault",
+                    "label": "Sanctify the Memory Vault",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakereckoning_reserves_warded"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "ritual",
+                            "empathy",
+                            "harmony"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakereckoning_memory_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You seal vows, names, and unfinished toasts into the vault. The Reckoning promises none",
+                            " of them will be erased."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakereckoning_memory_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The vault doors glow with every story you honor."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "A ledger squeals. You buy a new stylus and keep writing."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 5
+                                }
+                            ],
+                            "narration": "Memories flood you until you sob; friends steady you and add their own stories."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Vault UI now tear-proof.",
+                        "trader": "Sentiment index off the charts.",
+                        "whale": "Currents hum remembrance hymns.",
+                        "hacker": "No edits without consent.",
+                        "shiller": "Tribute wall trending.",
+                        "validator": "Blessing notarized.",
+                        "miner": "We lined the vault with luminous ore.",
+                        "meme": "Cry harder, fight harder."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.5",
+                        "action:wakereckoning_memory_vault"
+                    ]
+                },
+                {
+                    "id": "wakereckoning_cloak_flux",
+                    "label": "Stabilize the Cloak Flux",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakereckoning_phase_aligned"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "stealth",
+                            "systems",
+                            "teamwork"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakereckoning_cloak_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Veil currents flow across the void like aurora. Anyone under your guard can vanish betw",
+                            "een reflections at will."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakereckoning_cloak_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The cloak pathways glow faint and obedient."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 21
+                                }
+                            ],
+                            "narration": "A veil flickers. You pay hackers to retune the flux channels."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 4
+                                }
+                            ],
+                            "narration": "You vanish mid-sentence and reappear upside down. The squad applauds your acrobatics."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Flux map stable.",
+                        "trader": "Shadow liquidity abundant.",
+                        "whale": "Currents obey your whispers.",
+                        "hacker": "No leak leaves these veils.",
+                        "shiller": "Stealth, but glitter core.",
+                        "validator": "Flux notarized.",
+                        "miner": "We threaded the flux through crystal veins.",
+                        "meme": "Teleport but make it dramatic."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.5",
+                        "action:wakereckoning_cloak_flux"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "5.5-R4",
+            "description": "Phalanx Designation — assign crews to stairwells and link them with mirrored comm bridges.",
+            "actions": [
+                {
+                    "id": "wakereckoning_phalanx_assign",
+                    "label": "Assign the Reckoning Crews",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakereckoning_memory_ready",
+                            "wakereckoning_cloak_ready"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "leadership",
+                            "strategy",
+                            "teamwork"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakereckoning_crews_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Phalanx, shadowline, lifeline, and herald squads claim stairwells with chants that shak",
+                            "e the amphitheater."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakereckoning_crews_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Assignments lock; mirrored insignias bloom over every squad."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "Two crews fight over theme music. You sponsor a mashup remix to settle it."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 6
+                                }
+                            ],
+                            "narration": "You get hoisted in celebration and accidentally dropped into a fountain."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Rosters synced to mirrored HUDs.",
+                        "trader": "Stairwell equities balanced.",
+                        "whale": "Currents applaud the lineup.",
+                        "hacker": "Private comms sealed.",
+                        "shiller": "Squad reveal trending.",
+                        "validator": "Assignments notarized.",
+                        "miner": "We carved insignias into the steps.",
+                        "meme": "Roll call? More like rock concert."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.5",
+                        "action:wakereckoning_phalanx_assign"
+                    ]
+                },
+                {
+                    "id": "wakereckoning_signal_bridge",
+                    "label": "Bridge the Mirror Comms",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakereckoning_crews_ready",
+                            "wakereckoning_phase_aligned"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "systems",
+                            "support",
+                            "discipline"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 2
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 89
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakereckoning_bridge_online",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Your comm grid folds through every reflection, letting squads call across realities with",
+                            "out delay."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakereckoning_bridge_online",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Mirrored signals lock into crisp harmony."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 21
+                                }
+                            ],
+                            "narration": "Echoes screech; you underwrite extra dampeners."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 4
+                                }
+                            ],
+                            "narration": "The bridge zaps you through twelve reflections before it stabilizes."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Signal bridge latency zero.",
+                        "trader": "Communication futures bullish.",
+                        "whale": "Currents carry whispers perfectly.",
+                        "hacker": "Crossworld handshake locked.",
+                        "shiller": "We built a hotline to every possible us.",
+                        "validator": "Bridge notarized.",
+                        "miner": "We strung the relays through mirrored ore.",
+                        "meme": "Group chat includes alternate timelines now."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.5",
+                        "action:wakereckoning_signal_bridge"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "5.5-R5",
+            "description": "Trial Rehearsal — simulate multi-ending clashes and prime the resolve chant.",
+            "actions": [
+                {
+                    "id": "wakereckoning_trial_sim",
+                    "label": "Simulate the Reckoning Trial",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakereckoning_bridge_online"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "strategy",
+                            "teamwork",
+                            "offense"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakereckoning_trial_mastered",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "You stage simultaneous duels, rescues, stealth strikes, and celebrations until every sq",
+                            "uad moves like a choir."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakereckoning_trial_mastered",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The simulations run hot and end with applause."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "A mis-timed swap collapses half the staging. You rebuild with upgraded props."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 6
+                                }
+                            ],
+                            "narration": "The simulation hits you with a surprise sacrifice scenario. You stagger but stay standi",
+                            "ng."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Trial sim flagged as heroic canon.",
+                        "trader": "Outcome spreads trending in your favor.",
+                        "whale": "Currents clap along.",
+                        "hacker": "Recording sealed for posterity.",
+                        "shiller": "Behind-the-scenes doc incoming.",
+                        "validator": "Trial notarized.",
+                        "miner": "We reset sets between runs.",
+                        "meme": "Dress rehearsal? Stress rehearsal."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.5",
+                        "action:wakereckoning_trial_sim"
+                    ]
+                },
+                {
+                    "id": "wakereckoning_resolve_chant",
+                    "label": "Prime the Resolve Chant",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakereckoning_trial_mastered"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "inspiration",
+                            "ritual",
+                            "harmony"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakereckoning_resolve_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Your chant threads through every mirrored future. Even timelines you never visited ans",
+                            "wer with echoes."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakereckoning_resolve_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The amphitheater vibrates with collective resolve."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "Your voice cracks; you hand out throat lozenges and start over."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 6
+                                }
+                            ],
+                            "narration": "Emotion floors you mid-verse. The crowd finishes it with tears and laughter."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Chant audio normalized.",
+                        "trader": "Sentiment graph ascends.",
+                        "whale": "Currents hum the melody.",
+                        "hacker": "No spoiler leaks.",
+                        "shiller": "National anthem of Act Five.",
+                        "validator": "Chant notarized.",
+                        "miner": "We carved lyrics into the rail.",
+                        "meme": "Earworm of destiny."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.5",
+                        "action:wakereckoning_resolve_chant"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "5.5-R6",
+            "description": "Reckoning Verdict — call the council, commit the plan, and archive the chant for posterity.",
+            "actions": [
+                {
+                    "id": "wakereckoning_council_convene",
+                    "label": "Convene the Reckoning Council",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakereckoning_resolve_ready"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "ritual",
+                            "leadership",
+                            "harmony"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakereckoning_council_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "Delegates from every mirror stand on the central dais. The void mirrors them into infin",
+                            "ity."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                },
+                                {
+                                    "type": "flag",
+                                    "id": "wakereckoning_council_ready",
+                                    "value": true
+                                }
+                            ],
+                            "narration": "The council assembles, voices steady."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 34
+                                }
+                            ],
+                            "narration": "Logistics hiccup. You underwrite extra teleport gates to bring everyone in."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 6
+                                }
+                            ],
+                            "narration": "Your heart stutters from adrenaline; medics steady you while the council waits."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Council quorum logged across mirrors.",
+                        "trader": "Governance spread tight.",
+                        "whale": "Currents circle the dais.",
+                        "hacker": "Minutes encrypted.",
+                        "shiller": "Town hall of every world.",
+                        "validator": "Agenda notarized.",
+                        "miner": "We carved seats from mirrored stone.",
+                        "meme": "Council? More like multiversal hype squad."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.5",
+                        "action:wakereckoning_council_convene"
+                    ]
+                },
+                {
+                    "id": "wakereckoning_vote_call",
+                    "label": "Call the Reckoning Vote",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakereckoning_council_ready"
+                        ]
+                    },
+                    "roll": {
+                        "kind": "phi_d20",
+                        "tags": [
+                            "consensus",
+                            "ritual",
+                            "leadership"
+                        ]
+                    },
+                    "outcomes": {
+                        "crit_success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakereckoning_consensus_passed",
+                                    "value": true
+                                },
+                                {
+                                    "type": "focus",
+                                    "op": "+",
+                                    "value": 3
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 144
+                                }
+                            ],
+                            "narration": "Hands rise across the amphitheater and within every reflection. The Reckoning accepts yo",
+                            "ur plan."
+                        },
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "flag",
+                                    "id": "wakereckoning_consensus_passed",
+                                    "value": true
+                                },
+                                {
+                                    "type": "xp",
+                                    "value": 55
+                                }
+                            ],
+                            "narration": "Consensus ripples through the void in concentric light."
+                        },
+                        "fail": {
+                            "effects": [
+                                {
+                                    "type": "coins",
+                                    "op": "-",
+                                    "value": 55
+                                }
+                            ],
+                            "narration": "A stalemate forms. You bribe destiny with another round of miracle credits."
+                        },
+                        "crit_fail": {
+                            "effects": [
+                                {
+                                    "type": "hp",
+                                    "op": "-",
+                                    "value": 6
+                                }
+                            ],
+                            "narration": "Debate spikes; you take the backlash and promise a calmer re-call."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Vote recorded in mirrored ink.",
+                        "trader": "Consensus premium secured.",
+                        "whale": "Currents thunder their approval.",
+                        "hacker": "No tampering, just heart.",
+                        "shiller": "Headline: 'Reckoning chooses everyone.'",
+                        "validator": "Ballots notarized.",
+                        "miner": "We rang the stair bells in chorus.",
+                        "meme": "Motion passes across realities."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.5",
+                        "action:wakereckoning_vote_call"
+                    ]
+                },
+                {
+                    "id": "wakereckoning_archive",
+                    "label": "Archive the Resolve Hymnal",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakereckoning_consensus_passed"
+                        ]
+                    },
+                    "outcomes": {
+                        "success": {
+                            "effects": [
+                                {
+                                    "type": "deck",
+                                    "id": "deck_wakereckoning_resolve"
+                                }
+                            ],
+                            "narration": "You bind the chant, drills, and promises into a mirrored hymnal that future crews can u",
+                            "nfurl."
+                        }
+                    },
+                    "banter": {
+                        "dev": "Hymnal archived across reflections.",
+                        "trader": "Priced at infinite goodwill.",
+                        "whale": "Currents carry the melody onward.",
+                        "hacker": "Checksum locked.",
+                        "shiller": "Collector's edition includes glow scripts.",
+                        "validator": "Archive notarized.",
+                        "miner": "We etched staves into mirrored stone.",
+                        "meme": "Drop the mixtape already!"
+                    },
+                    "telemetry_tags": [
+                        "scene:5.5",
+                        "action:wakereckoning_archive"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        },
+        {
+            "round_id": "5.5-R7",
+            "description": "Mirrored Descent — open the way toward Act Five’s decisive confrontation.",
+            "actions": [
+                {
+                    "id": "advance_5_6",
+                    "label": "Descend into the Wake Reckoning",
+                    "requirements": {
+                        "items_any": [],
+                        "flags_all": [
+                            "wakereckoning_consensus_passed"
+                        ]
+                    },
+                    "outcomes": {
+                        "success": {
+                            "effects": [],
+                            "narration": "Mirrors fold into a single stair of light. Every squad marches beside its reflection to",
+                            "ward whatever waits.",
+                            "next_hint": "5.6"
+                        }
+                    },
+                    "banter": {
+                        "dev": "Final descent compiled.",
+                        "trader": "All stakes consolidated.",
+                        "whale": "Currents usher you downward.",
+                        "hacker": "No exit but triumph.",
+                        "shiller": "Act Five endgame unlocked.",
+                        "validator": "Descent notarized.",
+                        "miner": "We polished the stair with comet dust.",
+                        "meme": "Time to meet destiny face to face."
+                    },
+                    "telemetry_tags": [
+                        "scene:5.5",
+                        "action:advance_5_6"
+                    ]
+                }
+            ],
+            "rewards": [
+                {
+                    "type": "xp",
+                    "value": 55
+                }
+            ]
+        }
+    ],
+    "threshold_rewards": [
+        {
+            "focus_gte": 23,
+            "rewards": [
+                {
+                    "type": "coins",
+                    "value": 288
+                }
+            ]
+        },
+        {
+            "xp_gte": 1888,
+            "rewards": [
+                {
+                    "type": "item",
+                    "id": "relic_wakereckoning_lens"
+                }
+            ]
+        },
+        {
+            "flags_all": [
+                "wakereckoning_consensus_passed"
+            ],
+            "rewards": [
+                {
+                    "type": "deck",
+                    "id": "deck_wakereckoning_resolve"
+                }
+            ]
+        }
+    ],
+    "arrivals": [
+        {
+            "when": "flags.afk_tracked",
+            "goto": "5.5A"
+        },
+        {
+            "when": "flags.wakereckoning_consensus_passed",
+            "goto": "5.6"
+        },
+        {
+            "when": "else",
+            "goto": "5.5"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- script the Wake Apex scene (5.3) to stabilize the platform, braid the four fate lanes, run synthesis drills, and secure the council vote that opens the Act Five Crucible
- forge the Wake Crucible scene (5.4) with molten-phase logistics, crew assignments, live-fire rehearsals, and a verdict that cracks the core toward 5.5
- stage the Wake Reckoning scene (5.5) around mirrored timelines, memory vaults, cross-reality squads, and the resolve council that descends toward the finale

## Testing
- not run (content update only)

------
https://chatgpt.com/codex/tasks/task_e_68d30c3abbbc8330869392a84157ba73