### PR TITLE
Add raid content, systems, and tournament fixes

### DIFF
--- a/content/genesis/manifest.json
+++ b/content/genesis/manifest.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0",
   "content_id": "genesis",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "book_name": "Wallet Wake-Up",
   "scenes": [
     "1.1",
@@ -10,6 +10,7 @@
     "1.4",
     "1.5",
     "1.6",
-    "1.7"
+    "1.7",
+    "boss.custodian"
   ]
 }

--- a/content/genesis/scenes/scene_boss.custodian.json
+++ b/content/genesis/scenes/scene_boss.custodian.json
@@ -1,0 +1,251 @@
+{
+  "schema_version": "1.0",
+  "content_id": "genesis",
+  "book_id": "bosses",
+  "scene_id": "boss.custodian",
+  "title": "The Stone Custodian Awakens",
+  "narration": "Deep beneath the ledger vault, a ring of obsidian pillars guards a dormant construct known as the Stone Custodian. When the audit beacon flares, the chamber seals shut and the golem unfurls, shaking dust and forgotten decrees from its plating. Obelisks around the arena pulse with contract glyphs that power the guardian. Each phase of the fight shifts the battlefield, forcing raiders to adapt their positioning and tactics.",
+  "phases": [
+    {
+      "phase": 1,
+      "hp_threshold": 100,
+      "mechanics": ["stone_gaze", "ledger_audit"],
+      "description": "The Custodian activates defensive scripts and tests the party's ledgers with wide arc attacks."
+    },
+    {
+      "phase": 2,
+      "hp_threshold": 50,
+      "mechanics": ["consensus_break", "gremlin_swarm"],
+      "description": "The vault destabilizes and gremlin underlings erupt from the walls while the Custodian fractures the floor into ledgers of molten stone."
+    },
+    {
+      "phase": 3,
+      "hp_threshold": 15,
+      "mechanics": ["stone_gaze", "enrage", "cataclysm_pulse"],
+      "description": "In its final rage the Custodian drains the obelisks to unleash cataclysmic pulses that must be intercepted by empowered raiders."
+    }
+  ],
+  "rounds": [
+    {
+      "round_id": "boss.custodian-R1",
+      "description": "Phase One — Stabilize ledgers and disrupt the Custodian's opening audits.",
+      "actions": [
+        {
+          "id": "interrupt_audit",
+          "label": "Disrupt Ledger Audit",
+          "roll": { "kind": "phi_d20", "tags": ["focus", "tech"] },
+          "requirements": { "items_any": ["ledger_spike"], "flags_all": [] },
+          "outcomes": {
+            "crit_success": {
+              "effects": [
+                { "type": "focus", "op": "+", "value": 2 },
+                { "type": "xp", "value": 85 },
+                { "type": "flag", "id": "custodian_audit_staggered", "value": true }
+              ],
+              "narration": "You spike the ledger stream and the Custodian stutters, exposing a core sigil."
+            },
+            "success": {
+              "effects": [
+                { "type": "xp", "value": 55 },
+                { "type": "flag", "id": "custodian_audit_staggered", "value": true }
+              ],
+              "narration": "A feedback loop ripples across the obelisks, buying precious seconds."
+            },
+            "fail": {
+              "effects": [
+                { "type": "hp", "op": "-", "value": 6 }
+              ],
+              "narration": "The audit completes and sears you with compliance glyphs."
+            },
+            "crit_fail": {
+              "effects": [
+                { "type": "hp", "op": "-", "value": 12 }
+              ],
+              "narration": "You trip the failsafe; the Custodian's gaze petrifies your armor."
+            }
+          }
+        },
+        {
+          "id": "kite_gaze",
+          "label": "Kite the Stone Gaze",
+          "roll": { "kind": "phi_d20", "tags": ["agility", "tactics"] },
+          "outcomes": {
+            "crit_success": {
+              "effects": [
+                { "type": "xp", "value": 70 },
+                { "type": "flag", "id": "stone_gaze_redirected", "value": true }
+              ],
+              "narration": "You guide the petrifying beam into an obelisk, cracking its power siphon."
+            },
+            "success": {
+              "effects": [
+                { "type": "xp", "value": 40 }
+              ],
+              "narration": "The gaze sweeps past, leaving glassed runes where you once stood."
+            },
+            "fail": {
+              "effects": [
+                { "type": "hp", "op": "-", "value": 5 }
+              ],
+              "narration": "Stone creeps across your limbs before the healers break the glaze."
+            },
+            "crit_fail": {
+              "effects": [
+                { "type": "hp", "op": "-", "value": 10 }
+              ],
+              "narration": "The beam locks onto you and the vault floor shatters beneath your feet."
+            }
+          }
+        }
+      ]
+    },
+    {
+      "round_id": "boss.custodian-R2",
+      "description": "Phase Two — Hold the line against swarm adds and stabilize consensus fractures.",
+      "actions": [
+        {
+          "id": "seal_fracture",
+          "label": "Seal Consensus Fracture",
+          "roll": { "kind": "phi_d20", "tags": ["ritual", "support"] },
+          "outcomes": {
+            "crit_success": {
+              "effects": [
+                { "type": "xp", "value": 95 },
+                { "type": "flag", "id": "fracture_sealed", "value": true }
+              ],
+              "narration": "The tear mends with radiant ledger threads that empower your raid."
+            },
+            "success": {
+              "effects": [
+                { "type": "xp", "value": 60 }
+              ],
+              "narration": "You stabilize the crack, preventing a wipe cascade."
+            },
+            "fail": {
+              "effects": [
+                { "type": "hp", "op": "-", "value": 7 }
+              ],
+              "narration": "An implosion ripples across the arena, staggering the team."
+            },
+            "crit_fail": {
+              "effects": [
+                { "type": "hp", "op": "-", "value": 12 }
+              ],
+              "narration": "The fracture erupts, unleashing volatile ledger shards."
+            }
+          }
+        },
+        {
+          "id": "rally_line",
+          "label": "Rally the Gremlin Line",
+          "roll": { "kind": "phi_d20", "tags": ["leadership", "support"] },
+          "outcomes": {
+            "crit_success": {
+              "effects": [
+                { "type": "xp", "value": 80 },
+                { "type": "focus", "op": "+", "value": 3 }
+              ],
+              "narration": "You coordinate the gremlin defenders into a disciplined bulwark."
+            },
+            "success": {
+              "effects": [
+                { "type": "xp", "value": 45 }
+              ],
+              "narration": "The gremlin allies regroup and hold the breach."
+            },
+            "fail": {
+              "effects": [
+                { "type": "focus", "op": "-", "value": 1 }
+              ],
+              "narration": "Chaos spreads and swarm damage increases."
+            },
+            "crit_fail": {
+              "effects": [
+                { "type": "hp", "op": "-", "value": 8 }
+              ],
+              "narration": "A miscommunication sends half the squad tumbling into the ledger pit."
+            }
+          }
+        }
+      ]
+    },
+    {
+      "round_id": "boss.custodian-R3",
+      "description": "Final Phase — Redirect the cataclysm pulses and end the Custodian before enrage.",
+      "actions": [
+        {
+          "id": "channel_obelisk",
+          "label": "Channel Obelisk Power",
+          "requirements": { "items_any": ["custodian_seal"], "flags_all": ["fracture_sealed"] },
+          "roll": { "kind": "phi_d20", "tags": ["ritual", "focus"] },
+          "outcomes": {
+            "crit_success": {
+              "effects": [
+                { "type": "xp", "value": 120 },
+                { "type": "flag", "id": "custodian_core_exposed", "value": true }
+              ],
+              "narration": "You weave obelisk energy into a spear that pierces the Custodian's heartstone."
+            },
+            "success": {
+              "effects": [
+                { "type": "xp", "value": 85 }
+              ],
+              "narration": "Power funnels into the raid, mitigating the enrage pulse."
+            },
+            "fail": {
+              "effects": [
+                { "type": "hp", "op": "-", "value": 10 }
+              ],
+              "narration": "The obelisk overloads and disorients you."
+            },
+            "crit_fail": {
+              "effects": [
+                { "type": "hp", "op": "-", "value": 18 }
+              ],
+              "narration": "The channel destabilizes and wipes half the raid."
+            }
+          }
+        },
+        {
+          "id": "deliver_final_blow",
+          "label": "Deliver the Final Blow",
+          "requirements": { "flags_all": ["custodian_core_exposed"] },
+          "roll": { "kind": "phi_d20", "tags": ["martial", "burst"] },
+          "outcomes": {
+            "crit_success": {
+              "effects": [
+                { "type": "item", "id": "custodian_seal" },
+                { "type": "xp", "value": 150 }
+              ],
+              "narration": "Your strike shatters the Custodian core, ending the raid with flawless form."
+            },
+            "success": {
+              "effects": [
+                { "type": "xp", "value": 110 }
+              ],
+              "narration": "The Custodian collapses into inert ledgers, defeated."
+            },
+            "fail": {
+              "effects": [
+                { "type": "hp", "op": "-", "value": 12 }
+              ],
+              "narration": "You misjudge the timing and the enrage pulse knocks you aside."
+            },
+            "crit_fail": {
+              "effects": [
+                { "type": "hp", "op": "-", "value": 20 }
+              ],
+              "narration": "The Custodian retaliates with a cataclysm pulse that nearly wipes the raid."
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "loot_table": {
+    "guaranteed": ["custodian_seal"],
+    "rare_drops": ["eternal_ledger_page", "stone_heart"],
+    "mythic_drops": ["primordial_core_shard"],
+    "currency": { "coins": 500, "gems": 10 }
+  }
+}

--- a/content/quests/main_story.json
+++ b/content/quests/main_story.json
@@ -1,0 +1,48 @@
+{
+  "the_ledger_prophecy": {
+    "title": "The Ledger Prophecy",
+    "chapters": [
+      {
+        "id": "awakening",
+        "name": "Awakening",
+        "scenes": ["1.1", "1.7"],
+        "summary": "Discover the first whispers of the ledger prophecy and rally a team of gremlins to investigate.",
+        "rewards": {
+          "items": ["prophecy_fragment"],
+          "xp": 200
+        }
+      },
+      {
+        "id": "the_fork",
+        "name": "The Fork",
+        "scenes": ["2.1", "2.2", "2.3", "2.4"],
+        "choices_matter": true,
+        "summary": "Navigate diverging paths and decide whether to ally with the consensus keepers or the rogue archivists.",
+        "rewards": {
+          "items": ["forked_token"],
+          "coins": 300
+        }
+      },
+      {
+        "id": "convergence",
+        "name": "Convergence",
+        "scenes": ["3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7"],
+        "multiple_endings": true,
+        "summary": "Return to the vault to confront the converging futures and prepare for the Stone Custodian.",
+        "rewards": {
+          "items": ["convergence_cache"],
+          "xp": 500,
+          "flags": ["legendary_crafted"]
+        }
+      }
+    ],
+    "epilogue": {
+      "scenes": ["boss.custodian"],
+      "summary": "Face the Stone Custodian in a raid-scale confrontation to secure the ledger prophecy.",
+      "rewards": {
+        "items": ["custodian_seal"],
+        "xp": 800
+      }
+    }
+  }
+}

--- a/content/recipes/legendary.json
+++ b/content/recipes/legendary.json
@@ -1,0 +1,49 @@
+{
+  "reality_weaver_staff": {
+    "materials": {
+      "ancient_ore": 10,
+      "gremlin_essence": 50,
+      "custodian_stone": 1,
+      "consensus_fragment": 100
+    },
+    "requirements": {
+      "crafting_level": 10,
+      "discovered_recipe": true
+    },
+    "outcomes": {
+      "item": "reality_weaver_staff",
+      "bonus_flags": ["legendary_crafted"]
+    }
+  },
+  "custodian_plate": {
+    "materials": {
+      "custodian_stone": 4,
+      "stone_heart": 1,
+      "reinforced_alloy": 25
+    },
+    "requirements": {
+      "crafting_level": 9,
+      "raid_clear": "boss.custodian"
+    },
+    "outcomes": {
+      "item": "custodian_plate",
+      "bonus_flags": ["raid_defender"]
+    }
+  },
+  "ledger_phylactery": {
+    "materials": {
+      "eternal_ledger_page": 3,
+      "astral_ink": 20,
+      "void_glass": 12
+    },
+    "requirements": {
+      "crafting_level": 11,
+      "discovered_recipe": true,
+      "quest_completed": "the_ledger_prophecy"
+    },
+    "outcomes": {
+      "item": "ledger_phylactery",
+      "bonus_flags": ["legendary_crafted", "knowledge_keeper"]
+    }
+  }
+}

--- a/content/registry/cards.json
+++ b/content/registry/cards.json
@@ -5,16 +5,5312 @@
       "name": "Infinite Recursion",
       "rarity": "epic",
       "type": "instant",
-      "cost": { "focus": 3 },
+      "cost": {
+        "focus": 3
+      },
       "effects": [
-        { "type": "buff", "id": "reroll_next", "value": 1 },
-        { "type": "flag", "id": "recursion_active", "value": true }
+        {
+          "type": "buff",
+          "id": "reroll_next",
+          "value": 1
+        },
+        {
+          "type": "flag",
+          "id": "recursion_active",
+          "value": true
+        }
       ],
-      "tags": ["dev", "logic", "instant"],
+      "tags": [
+        "dev",
+        "logic",
+        "instant"
+      ],
       "description": "Reroll your next failed action. If successful, draw another card.",
       "flavorText": "Stack overflow is just another kind of infinity.",
       "set": "genesis",
-      "requiresClass": ["dev"]
+      "requiresClass": [
+        "dev"
+      ]
+    },
+    "ledger_card_001": {
+      "id": "ledger_card_001",
+      "name": "Ledger Technique 001",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_001",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 001 to sway encounters.",
+      "flavorText": "Debug iteration 001 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_002": {
+      "id": "ledger_card_002",
+      "name": "Ledger Technique 002",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_002",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 002 to sway encounters.",
+      "flavorText": "Debug iteration 002 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_003": {
+      "id": "ledger_card_003",
+      "name": "Ledger Technique 003",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_003",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 003 to sway encounters.",
+      "flavorText": "Debug iteration 003 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_004": {
+      "id": "ledger_card_004",
+      "name": "Ledger Technique 004",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_004",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 004 to sway encounters.",
+      "flavorText": "Debug iteration 004 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_005": {
+      "id": "ledger_card_005",
+      "name": "Ledger Technique 005",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_005",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 005 to sway encounters.",
+      "flavorText": "Debug iteration 005 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_006": {
+      "id": "ledger_card_006",
+      "name": "Ledger Technique 006",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_006",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 006 to sway encounters.",
+      "flavorText": "Debug iteration 006 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_007": {
+      "id": "ledger_card_007",
+      "name": "Ledger Technique 007",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_007",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 007 to sway encounters.",
+      "flavorText": "Debug iteration 007 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_008": {
+      "id": "ledger_card_008",
+      "name": "Ledger Technique 008",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_008",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 008 to sway encounters.",
+      "flavorText": "Debug iteration 008 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_009": {
+      "id": "ledger_card_009",
+      "name": "Ledger Technique 009",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_009",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 009 to sway encounters.",
+      "flavorText": "Debug iteration 009 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_010": {
+      "id": "ledger_card_010",
+      "name": "Ledger Technique 010",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_010",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 010 to sway encounters.",
+      "flavorText": "Debug iteration 010 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_011": {
+      "id": "ledger_card_011",
+      "name": "Ledger Technique 011",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_011",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 011 to sway encounters.",
+      "flavorText": "Debug iteration 011 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_012": {
+      "id": "ledger_card_012",
+      "name": "Ledger Technique 012",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_012",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 012 to sway encounters.",
+      "flavorText": "Debug iteration 012 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_013": {
+      "id": "ledger_card_013",
+      "name": "Ledger Technique 013",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_013",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 013 to sway encounters.",
+      "flavorText": "Debug iteration 013 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_014": {
+      "id": "ledger_card_014",
+      "name": "Ledger Technique 014",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_014",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 014 to sway encounters.",
+      "flavorText": "Debug iteration 014 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_015": {
+      "id": "ledger_card_015",
+      "name": "Ledger Technique 015",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_015",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 015 to sway encounters.",
+      "flavorText": "Debug iteration 015 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_016": {
+      "id": "ledger_card_016",
+      "name": "Ledger Technique 016",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_016",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 016 to sway encounters.",
+      "flavorText": "Debug iteration 016 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_017": {
+      "id": "ledger_card_017",
+      "name": "Ledger Technique 017",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_017",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 017 to sway encounters.",
+      "flavorText": "Debug iteration 017 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_018": {
+      "id": "ledger_card_018",
+      "name": "Ledger Technique 018",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_018",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 018 to sway encounters.",
+      "flavorText": "Debug iteration 018 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_019": {
+      "id": "ledger_card_019",
+      "name": "Ledger Technique 019",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_019",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 019 to sway encounters.",
+      "flavorText": "Debug iteration 019 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_020": {
+      "id": "ledger_card_020",
+      "name": "Ledger Technique 020",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_020",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 020 to sway encounters.",
+      "flavorText": "Debug iteration 020 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_021": {
+      "id": "ledger_card_021",
+      "name": "Ledger Technique 021",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_021",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 021 to sway encounters.",
+      "flavorText": "Debug iteration 021 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_022": {
+      "id": "ledger_card_022",
+      "name": "Ledger Technique 022",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_022",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 022 to sway encounters.",
+      "flavorText": "Debug iteration 022 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_023": {
+      "id": "ledger_card_023",
+      "name": "Ledger Technique 023",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_023",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 023 to sway encounters.",
+      "flavorText": "Debug iteration 023 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_024": {
+      "id": "ledger_card_024",
+      "name": "Ledger Technique 024",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_024",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 024 to sway encounters.",
+      "flavorText": "Debug iteration 024 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_025": {
+      "id": "ledger_card_025",
+      "name": "Ledger Technique 025",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_025",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 025 to sway encounters.",
+      "flavorText": "Debug iteration 025 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_026": {
+      "id": "ledger_card_026",
+      "name": "Ledger Technique 026",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_026",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 026 to sway encounters.",
+      "flavorText": "Debug iteration 026 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_027": {
+      "id": "ledger_card_027",
+      "name": "Ledger Technique 027",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_027",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 027 to sway encounters.",
+      "flavorText": "Debug iteration 027 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_028": {
+      "id": "ledger_card_028",
+      "name": "Ledger Technique 028",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_028",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 028 to sway encounters.",
+      "flavorText": "Debug iteration 028 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_029": {
+      "id": "ledger_card_029",
+      "name": "Ledger Technique 029",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_029",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 029 to sway encounters.",
+      "flavorText": "Debug iteration 029 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_030": {
+      "id": "ledger_card_030",
+      "name": "Ledger Technique 030",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_030",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 030 to sway encounters.",
+      "flavorText": "Debug iteration 030 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_031": {
+      "id": "ledger_card_031",
+      "name": "Ledger Technique 031",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_031",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 031 to sway encounters.",
+      "flavorText": "Debug iteration 031 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_032": {
+      "id": "ledger_card_032",
+      "name": "Ledger Technique 032",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_032",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 032 to sway encounters.",
+      "flavorText": "Debug iteration 032 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_033": {
+      "id": "ledger_card_033",
+      "name": "Ledger Technique 033",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_033",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 033 to sway encounters.",
+      "flavorText": "Debug iteration 033 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_034": {
+      "id": "ledger_card_034",
+      "name": "Ledger Technique 034",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_034",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 034 to sway encounters.",
+      "flavorText": "Debug iteration 034 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_035": {
+      "id": "ledger_card_035",
+      "name": "Ledger Technique 035",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_035",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 035 to sway encounters.",
+      "flavorText": "Debug iteration 035 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_036": {
+      "id": "ledger_card_036",
+      "name": "Ledger Technique 036",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_036",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 036 to sway encounters.",
+      "flavorText": "Debug iteration 036 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_037": {
+      "id": "ledger_card_037",
+      "name": "Ledger Technique 037",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_037",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 037 to sway encounters.",
+      "flavorText": "Debug iteration 037 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_038": {
+      "id": "ledger_card_038",
+      "name": "Ledger Technique 038",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_038",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 038 to sway encounters.",
+      "flavorText": "Debug iteration 038 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_039": {
+      "id": "ledger_card_039",
+      "name": "Ledger Technique 039",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_039",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 039 to sway encounters.",
+      "flavorText": "Debug iteration 039 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_040": {
+      "id": "ledger_card_040",
+      "name": "Ledger Technique 040",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_040",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 040 to sway encounters.",
+      "flavorText": "Debug iteration 040 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_041": {
+      "id": "ledger_card_041",
+      "name": "Ledger Technique 041",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_041",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 041 to sway encounters.",
+      "flavorText": "Debug iteration 041 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_042": {
+      "id": "ledger_card_042",
+      "name": "Ledger Technique 042",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_042",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 042 to sway encounters.",
+      "flavorText": "Debug iteration 042 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_043": {
+      "id": "ledger_card_043",
+      "name": "Ledger Technique 043",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_043",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 043 to sway encounters.",
+      "flavorText": "Debug iteration 043 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_044": {
+      "id": "ledger_card_044",
+      "name": "Ledger Technique 044",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_044",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 044 to sway encounters.",
+      "flavorText": "Debug iteration 044 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_045": {
+      "id": "ledger_card_045",
+      "name": "Ledger Technique 045",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_045",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 045 to sway encounters.",
+      "flavorText": "Debug iteration 045 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_046": {
+      "id": "ledger_card_046",
+      "name": "Ledger Technique 046",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_046",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 046 to sway encounters.",
+      "flavorText": "Debug iteration 046 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_047": {
+      "id": "ledger_card_047",
+      "name": "Ledger Technique 047",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_047",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 047 to sway encounters.",
+      "flavorText": "Debug iteration 047 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_048": {
+      "id": "ledger_card_048",
+      "name": "Ledger Technique 048",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_048",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 048 to sway encounters.",
+      "flavorText": "Debug iteration 048 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_049": {
+      "id": "ledger_card_049",
+      "name": "Ledger Technique 049",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_049",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 049 to sway encounters.",
+      "flavorText": "Debug iteration 049 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_050": {
+      "id": "ledger_card_050",
+      "name": "Ledger Technique 050",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_050",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 050 to sway encounters.",
+      "flavorText": "Debug iteration 050 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_051": {
+      "id": "ledger_card_051",
+      "name": "Ledger Technique 051",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_051",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 051 to sway encounters.",
+      "flavorText": "Debug iteration 051 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_052": {
+      "id": "ledger_card_052",
+      "name": "Ledger Technique 052",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_052",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 052 to sway encounters.",
+      "flavorText": "Debug iteration 052 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_053": {
+      "id": "ledger_card_053",
+      "name": "Ledger Technique 053",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_053",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 053 to sway encounters.",
+      "flavorText": "Debug iteration 053 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_054": {
+      "id": "ledger_card_054",
+      "name": "Ledger Technique 054",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_054",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 054 to sway encounters.",
+      "flavorText": "Debug iteration 054 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_055": {
+      "id": "ledger_card_055",
+      "name": "Ledger Technique 055",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_055",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 055 to sway encounters.",
+      "flavorText": "Debug iteration 055 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_056": {
+      "id": "ledger_card_056",
+      "name": "Ledger Technique 056",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_056",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 056 to sway encounters.",
+      "flavorText": "Debug iteration 056 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_057": {
+      "id": "ledger_card_057",
+      "name": "Ledger Technique 057",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_057",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 057 to sway encounters.",
+      "flavorText": "Debug iteration 057 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_058": {
+      "id": "ledger_card_058",
+      "name": "Ledger Technique 058",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_058",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 058 to sway encounters.",
+      "flavorText": "Debug iteration 058 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_059": {
+      "id": "ledger_card_059",
+      "name": "Ledger Technique 059",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_059",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 059 to sway encounters.",
+      "flavorText": "Debug iteration 059 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_060": {
+      "id": "ledger_card_060",
+      "name": "Ledger Technique 060",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_060",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 060 to sway encounters.",
+      "flavorText": "Debug iteration 060 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_061": {
+      "id": "ledger_card_061",
+      "name": "Ledger Technique 061",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_061",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 061 to sway encounters.",
+      "flavorText": "Debug iteration 061 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_062": {
+      "id": "ledger_card_062",
+      "name": "Ledger Technique 062",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_062",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 062 to sway encounters.",
+      "flavorText": "Debug iteration 062 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_063": {
+      "id": "ledger_card_063",
+      "name": "Ledger Technique 063",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_063",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 063 to sway encounters.",
+      "flavorText": "Debug iteration 063 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_064": {
+      "id": "ledger_card_064",
+      "name": "Ledger Technique 064",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_064",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 064 to sway encounters.",
+      "flavorText": "Debug iteration 064 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_065": {
+      "id": "ledger_card_065",
+      "name": "Ledger Technique 065",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_065",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 065 to sway encounters.",
+      "flavorText": "Debug iteration 065 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_066": {
+      "id": "ledger_card_066",
+      "name": "Ledger Technique 066",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_066",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 066 to sway encounters.",
+      "flavorText": "Debug iteration 066 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_067": {
+      "id": "ledger_card_067",
+      "name": "Ledger Technique 067",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_067",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 067 to sway encounters.",
+      "flavorText": "Debug iteration 067 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_068": {
+      "id": "ledger_card_068",
+      "name": "Ledger Technique 068",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_068",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 068 to sway encounters.",
+      "flavorText": "Debug iteration 068 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_069": {
+      "id": "ledger_card_069",
+      "name": "Ledger Technique 069",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_069",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 069 to sway encounters.",
+      "flavorText": "Debug iteration 069 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_070": {
+      "id": "ledger_card_070",
+      "name": "Ledger Technique 070",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_070",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 070 to sway encounters.",
+      "flavorText": "Debug iteration 070 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_071": {
+      "id": "ledger_card_071",
+      "name": "Ledger Technique 071",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_071",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 071 to sway encounters.",
+      "flavorText": "Debug iteration 071 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_072": {
+      "id": "ledger_card_072",
+      "name": "Ledger Technique 072",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_072",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 072 to sway encounters.",
+      "flavorText": "Debug iteration 072 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_073": {
+      "id": "ledger_card_073",
+      "name": "Ledger Technique 073",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_073",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 073 to sway encounters.",
+      "flavorText": "Debug iteration 073 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_074": {
+      "id": "ledger_card_074",
+      "name": "Ledger Technique 074",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_074",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 074 to sway encounters.",
+      "flavorText": "Debug iteration 074 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_075": {
+      "id": "ledger_card_075",
+      "name": "Ledger Technique 075",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_075",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 075 to sway encounters.",
+      "flavorText": "Debug iteration 075 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_076": {
+      "id": "ledger_card_076",
+      "name": "Ledger Technique 076",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_076",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 076 to sway encounters.",
+      "flavorText": "Debug iteration 076 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_077": {
+      "id": "ledger_card_077",
+      "name": "Ledger Technique 077",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_077",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 077 to sway encounters.",
+      "flavorText": "Debug iteration 077 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_078": {
+      "id": "ledger_card_078",
+      "name": "Ledger Technique 078",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_078",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 078 to sway encounters.",
+      "flavorText": "Debug iteration 078 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_079": {
+      "id": "ledger_card_079",
+      "name": "Ledger Technique 079",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_079",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 079 to sway encounters.",
+      "flavorText": "Debug iteration 079 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_080": {
+      "id": "ledger_card_080",
+      "name": "Ledger Technique 080",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_080",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 080 to sway encounters.",
+      "flavorText": "Debug iteration 080 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_081": {
+      "id": "ledger_card_081",
+      "name": "Ledger Technique 081",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_081",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 081 to sway encounters.",
+      "flavorText": "Debug iteration 081 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_082": {
+      "id": "ledger_card_082",
+      "name": "Ledger Technique 082",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_082",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 082 to sway encounters.",
+      "flavorText": "Debug iteration 082 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_083": {
+      "id": "ledger_card_083",
+      "name": "Ledger Technique 083",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_083",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 083 to sway encounters.",
+      "flavorText": "Debug iteration 083 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_084": {
+      "id": "ledger_card_084",
+      "name": "Ledger Technique 084",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_084",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 084 to sway encounters.",
+      "flavorText": "Debug iteration 084 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_085": {
+      "id": "ledger_card_085",
+      "name": "Ledger Technique 085",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_085",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 085 to sway encounters.",
+      "flavorText": "Debug iteration 085 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_086": {
+      "id": "ledger_card_086",
+      "name": "Ledger Technique 086",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_086",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 086 to sway encounters.",
+      "flavorText": "Debug iteration 086 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_087": {
+      "id": "ledger_card_087",
+      "name": "Ledger Technique 087",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_087",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 087 to sway encounters.",
+      "flavorText": "Debug iteration 087 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_088": {
+      "id": "ledger_card_088",
+      "name": "Ledger Technique 088",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_088",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 088 to sway encounters.",
+      "flavorText": "Debug iteration 088 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_089": {
+      "id": "ledger_card_089",
+      "name": "Ledger Technique 089",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_089",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 089 to sway encounters.",
+      "flavorText": "Debug iteration 089 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_090": {
+      "id": "ledger_card_090",
+      "name": "Ledger Technique 090",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_090",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 090 to sway encounters.",
+      "flavorText": "Debug iteration 090 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_091": {
+      "id": "ledger_card_091",
+      "name": "Ledger Technique 091",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_091",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 091 to sway encounters.",
+      "flavorText": "Debug iteration 091 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_092": {
+      "id": "ledger_card_092",
+      "name": "Ledger Technique 092",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_092",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 092 to sway encounters.",
+      "flavorText": "Debug iteration 092 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_093": {
+      "id": "ledger_card_093",
+      "name": "Ledger Technique 093",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_093",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 093 to sway encounters.",
+      "flavorText": "Debug iteration 093 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_094": {
+      "id": "ledger_card_094",
+      "name": "Ledger Technique 094",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_094",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 094 to sway encounters.",
+      "flavorText": "Debug iteration 094 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_095": {
+      "id": "ledger_card_095",
+      "name": "Ledger Technique 095",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_095",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 095 to sway encounters.",
+      "flavorText": "Debug iteration 095 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_096": {
+      "id": "ledger_card_096",
+      "name": "Ledger Technique 096",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_096",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 096 to sway encounters.",
+      "flavorText": "Debug iteration 096 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_097": {
+      "id": "ledger_card_097",
+      "name": "Ledger Technique 097",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_097",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 097 to sway encounters.",
+      "flavorText": "Debug iteration 097 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_098": {
+      "id": "ledger_card_098",
+      "name": "Ledger Technique 098",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_098",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 098 to sway encounters.",
+      "flavorText": "Debug iteration 098 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_099": {
+      "id": "ledger_card_099",
+      "name": "Ledger Technique 099",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_099",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 099 to sway encounters.",
+      "flavorText": "Debug iteration 099 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_100": {
+      "id": "ledger_card_100",
+      "name": "Ledger Technique 100",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_100",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 100 to sway encounters.",
+      "flavorText": "Debug iteration 100 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_101": {
+      "id": "ledger_card_101",
+      "name": "Ledger Technique 101",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_101",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 101 to sway encounters.",
+      "flavorText": "Debug iteration 101 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_102": {
+      "id": "ledger_card_102",
+      "name": "Ledger Technique 102",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_102",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 102 to sway encounters.",
+      "flavorText": "Debug iteration 102 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_103": {
+      "id": "ledger_card_103",
+      "name": "Ledger Technique 103",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_103",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 103 to sway encounters.",
+      "flavorText": "Debug iteration 103 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_104": {
+      "id": "ledger_card_104",
+      "name": "Ledger Technique 104",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_104",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 104 to sway encounters.",
+      "flavorText": "Debug iteration 104 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_105": {
+      "id": "ledger_card_105",
+      "name": "Ledger Technique 105",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_105",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 105 to sway encounters.",
+      "flavorText": "Debug iteration 105 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_106": {
+      "id": "ledger_card_106",
+      "name": "Ledger Technique 106",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_106",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 106 to sway encounters.",
+      "flavorText": "Debug iteration 106 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_107": {
+      "id": "ledger_card_107",
+      "name": "Ledger Technique 107",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_107",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 107 to sway encounters.",
+      "flavorText": "Debug iteration 107 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_108": {
+      "id": "ledger_card_108",
+      "name": "Ledger Technique 108",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_108",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 108 to sway encounters.",
+      "flavorText": "Debug iteration 108 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_109": {
+      "id": "ledger_card_109",
+      "name": "Ledger Technique 109",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_109",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 109 to sway encounters.",
+      "flavorText": "Debug iteration 109 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_110": {
+      "id": "ledger_card_110",
+      "name": "Ledger Technique 110",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_110",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 110 to sway encounters.",
+      "flavorText": "Debug iteration 110 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_111": {
+      "id": "ledger_card_111",
+      "name": "Ledger Technique 111",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_111",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 111 to sway encounters.",
+      "flavorText": "Debug iteration 111 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_112": {
+      "id": "ledger_card_112",
+      "name": "Ledger Technique 112",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_112",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 112 to sway encounters.",
+      "flavorText": "Debug iteration 112 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_113": {
+      "id": "ledger_card_113",
+      "name": "Ledger Technique 113",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_113",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 113 to sway encounters.",
+      "flavorText": "Debug iteration 113 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_114": {
+      "id": "ledger_card_114",
+      "name": "Ledger Technique 114",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_114",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 114 to sway encounters.",
+      "flavorText": "Debug iteration 114 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_115": {
+      "id": "ledger_card_115",
+      "name": "Ledger Technique 115",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_115",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 115 to sway encounters.",
+      "flavorText": "Debug iteration 115 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_116": {
+      "id": "ledger_card_116",
+      "name": "Ledger Technique 116",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_116",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 116 to sway encounters.",
+      "flavorText": "Debug iteration 116 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_117": {
+      "id": "ledger_card_117",
+      "name": "Ledger Technique 117",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_117",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 117 to sway encounters.",
+      "flavorText": "Debug iteration 117 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_118": {
+      "id": "ledger_card_118",
+      "name": "Ledger Technique 118",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_118",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 118 to sway encounters.",
+      "flavorText": "Debug iteration 118 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_119": {
+      "id": "ledger_card_119",
+      "name": "Ledger Technique 119",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_119",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 119 to sway encounters.",
+      "flavorText": "Debug iteration 119 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_120": {
+      "id": "ledger_card_120",
+      "name": "Ledger Technique 120",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_120",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 120 to sway encounters.",
+      "flavorText": "Debug iteration 120 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_121": {
+      "id": "ledger_card_121",
+      "name": "Ledger Technique 121",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_121",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 121 to sway encounters.",
+      "flavorText": "Debug iteration 121 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_122": {
+      "id": "ledger_card_122",
+      "name": "Ledger Technique 122",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_122",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 122 to sway encounters.",
+      "flavorText": "Debug iteration 122 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_123": {
+      "id": "ledger_card_123",
+      "name": "Ledger Technique 123",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_123",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 123 to sway encounters.",
+      "flavorText": "Debug iteration 123 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_124": {
+      "id": "ledger_card_124",
+      "name": "Ledger Technique 124",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_124",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 124 to sway encounters.",
+      "flavorText": "Debug iteration 124 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_125": {
+      "id": "ledger_card_125",
+      "name": "Ledger Technique 125",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_125",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 125 to sway encounters.",
+      "flavorText": "Debug iteration 125 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_126": {
+      "id": "ledger_card_126",
+      "name": "Ledger Technique 126",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_126",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 126 to sway encounters.",
+      "flavorText": "Debug iteration 126 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_127": {
+      "id": "ledger_card_127",
+      "name": "Ledger Technique 127",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_127",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 127 to sway encounters.",
+      "flavorText": "Debug iteration 127 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_128": {
+      "id": "ledger_card_128",
+      "name": "Ledger Technique 128",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_128",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 128 to sway encounters.",
+      "flavorText": "Debug iteration 128 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_129": {
+      "id": "ledger_card_129",
+      "name": "Ledger Technique 129",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_129",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 129 to sway encounters.",
+      "flavorText": "Debug iteration 129 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_130": {
+      "id": "ledger_card_130",
+      "name": "Ledger Technique 130",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_130",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 130 to sway encounters.",
+      "flavorText": "Debug iteration 130 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_131": {
+      "id": "ledger_card_131",
+      "name": "Ledger Technique 131",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_131",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 131 to sway encounters.",
+      "flavorText": "Debug iteration 131 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_132": {
+      "id": "ledger_card_132",
+      "name": "Ledger Technique 132",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_132",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 132 to sway encounters.",
+      "flavorText": "Debug iteration 132 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_133": {
+      "id": "ledger_card_133",
+      "name": "Ledger Technique 133",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_133",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 133 to sway encounters.",
+      "flavorText": "Debug iteration 133 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_134": {
+      "id": "ledger_card_134",
+      "name": "Ledger Technique 134",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_134",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 134 to sway encounters.",
+      "flavorText": "Debug iteration 134 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_135": {
+      "id": "ledger_card_135",
+      "name": "Ledger Technique 135",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_135",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 135 to sway encounters.",
+      "flavorText": "Debug iteration 135 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_136": {
+      "id": "ledger_card_136",
+      "name": "Ledger Technique 136",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_136",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 136 to sway encounters.",
+      "flavorText": "Debug iteration 136 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_137": {
+      "id": "ledger_card_137",
+      "name": "Ledger Technique 137",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_137",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 137 to sway encounters.",
+      "flavorText": "Debug iteration 137 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_138": {
+      "id": "ledger_card_138",
+      "name": "Ledger Technique 138",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_138",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 138 to sway encounters.",
+      "flavorText": "Debug iteration 138 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_139": {
+      "id": "ledger_card_139",
+      "name": "Ledger Technique 139",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_139",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 139 to sway encounters.",
+      "flavorText": "Debug iteration 139 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_140": {
+      "id": "ledger_card_140",
+      "name": "Ledger Technique 140",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_140",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 140 to sway encounters.",
+      "flavorText": "Debug iteration 140 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_141": {
+      "id": "ledger_card_141",
+      "name": "Ledger Technique 141",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_141",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 141 to sway encounters.",
+      "flavorText": "Debug iteration 141 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_142": {
+      "id": "ledger_card_142",
+      "name": "Ledger Technique 142",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_142",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 142 to sway encounters.",
+      "flavorText": "Debug iteration 142 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_143": {
+      "id": "ledger_card_143",
+      "name": "Ledger Technique 143",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_143",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 143 to sway encounters.",
+      "flavorText": "Debug iteration 143 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_144": {
+      "id": "ledger_card_144",
+      "name": "Ledger Technique 144",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_144",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 144 to sway encounters.",
+      "flavorText": "Debug iteration 144 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_145": {
+      "id": "ledger_card_145",
+      "name": "Ledger Technique 145",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_145",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 145 to sway encounters.",
+      "flavorText": "Debug iteration 145 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_146": {
+      "id": "ledger_card_146",
+      "name": "Ledger Technique 146",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_146",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 146 to sway encounters.",
+      "flavorText": "Debug iteration 146 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_147": {
+      "id": "ledger_card_147",
+      "name": "Ledger Technique 147",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_147",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 147 to sway encounters.",
+      "flavorText": "Debug iteration 147 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_148": {
+      "id": "ledger_card_148",
+      "name": "Ledger Technique 148",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_148",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 148 to sway encounters.",
+      "flavorText": "Debug iteration 148 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_149": {
+      "id": "ledger_card_149",
+      "name": "Ledger Technique 149",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_149",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 149 to sway encounters.",
+      "flavorText": "Debug iteration 149 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_150": {
+      "id": "ledger_card_150",
+      "name": "Ledger Technique 150",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_150",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 150 to sway encounters.",
+      "flavorText": "Debug iteration 150 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_151": {
+      "id": "ledger_card_151",
+      "name": "Ledger Technique 151",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_151",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 151 to sway encounters.",
+      "flavorText": "Debug iteration 151 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_152": {
+      "id": "ledger_card_152",
+      "name": "Ledger Technique 152",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_152",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 152 to sway encounters.",
+      "flavorText": "Debug iteration 152 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_153": {
+      "id": "ledger_card_153",
+      "name": "Ledger Technique 153",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_153",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 153 to sway encounters.",
+      "flavorText": "Debug iteration 153 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_154": {
+      "id": "ledger_card_154",
+      "name": "Ledger Technique 154",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_154",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 154 to sway encounters.",
+      "flavorText": "Debug iteration 154 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_155": {
+      "id": "ledger_card_155",
+      "name": "Ledger Technique 155",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_155",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 155 to sway encounters.",
+      "flavorText": "Debug iteration 155 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_156": {
+      "id": "ledger_card_156",
+      "name": "Ledger Technique 156",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_156",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 156 to sway encounters.",
+      "flavorText": "Debug iteration 156 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_157": {
+      "id": "ledger_card_157",
+      "name": "Ledger Technique 157",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_157",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 157 to sway encounters.",
+      "flavorText": "Debug iteration 157 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_158": {
+      "id": "ledger_card_158",
+      "name": "Ledger Technique 158",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_158",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 158 to sway encounters.",
+      "flavorText": "Debug iteration 158 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_159": {
+      "id": "ledger_card_159",
+      "name": "Ledger Technique 159",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_159",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 159 to sway encounters.",
+      "flavorText": "Debug iteration 159 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_160": {
+      "id": "ledger_card_160",
+      "name": "Ledger Technique 160",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_160",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 160 to sway encounters.",
+      "flavorText": "Debug iteration 160 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_161": {
+      "id": "ledger_card_161",
+      "name": "Ledger Technique 161",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_161",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 161 to sway encounters.",
+      "flavorText": "Debug iteration 161 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_162": {
+      "id": "ledger_card_162",
+      "name": "Ledger Technique 162",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_162",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 162 to sway encounters.",
+      "flavorText": "Debug iteration 162 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_163": {
+      "id": "ledger_card_163",
+      "name": "Ledger Technique 163",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_163",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 163 to sway encounters.",
+      "flavorText": "Debug iteration 163 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_164": {
+      "id": "ledger_card_164",
+      "name": "Ledger Technique 164",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_164",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 164 to sway encounters.",
+      "flavorText": "Debug iteration 164 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_165": {
+      "id": "ledger_card_165",
+      "name": "Ledger Technique 165",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_165",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 165 to sway encounters.",
+      "flavorText": "Debug iteration 165 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_166": {
+      "id": "ledger_card_166",
+      "name": "Ledger Technique 166",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_166",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 166 to sway encounters.",
+      "flavorText": "Debug iteration 166 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_167": {
+      "id": "ledger_card_167",
+      "name": "Ledger Technique 167",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_167",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 167 to sway encounters.",
+      "flavorText": "Debug iteration 167 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_168": {
+      "id": "ledger_card_168",
+      "name": "Ledger Technique 168",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_168",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 168 to sway encounters.",
+      "flavorText": "Debug iteration 168 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_169": {
+      "id": "ledger_card_169",
+      "name": "Ledger Technique 169",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_169",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 169 to sway encounters.",
+      "flavorText": "Debug iteration 169 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_170": {
+      "id": "ledger_card_170",
+      "name": "Ledger Technique 170",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_170",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 170 to sway encounters.",
+      "flavorText": "Debug iteration 170 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_171": {
+      "id": "ledger_card_171",
+      "name": "Ledger Technique 171",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_171",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 171 to sway encounters.",
+      "flavorText": "Debug iteration 171 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_172": {
+      "id": "ledger_card_172",
+      "name": "Ledger Technique 172",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_172",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 172 to sway encounters.",
+      "flavorText": "Debug iteration 172 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_173": {
+      "id": "ledger_card_173",
+      "name": "Ledger Technique 173",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_173",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 173 to sway encounters.",
+      "flavorText": "Debug iteration 173 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_174": {
+      "id": "ledger_card_174",
+      "name": "Ledger Technique 174",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_174",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 174 to sway encounters.",
+      "flavorText": "Debug iteration 174 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_175": {
+      "id": "ledger_card_175",
+      "name": "Ledger Technique 175",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_175",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 175 to sway encounters.",
+      "flavorText": "Debug iteration 175 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_176": {
+      "id": "ledger_card_176",
+      "name": "Ledger Technique 176",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_176",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 176 to sway encounters.",
+      "flavorText": "Debug iteration 176 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_177": {
+      "id": "ledger_card_177",
+      "name": "Ledger Technique 177",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_177",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 177 to sway encounters.",
+      "flavorText": "Debug iteration 177 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_178": {
+      "id": "ledger_card_178",
+      "name": "Ledger Technique 178",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_178",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 178 to sway encounters.",
+      "flavorText": "Debug iteration 178 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_179": {
+      "id": "ledger_card_179",
+      "name": "Ledger Technique 179",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_179",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 179 to sway encounters.",
+      "flavorText": "Debug iteration 179 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_180": {
+      "id": "ledger_card_180",
+      "name": "Ledger Technique 180",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_180",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 180 to sway encounters.",
+      "flavorText": "Debug iteration 180 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_181": {
+      "id": "ledger_card_181",
+      "name": "Ledger Technique 181",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_181",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 181 to sway encounters.",
+      "flavorText": "Debug iteration 181 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_182": {
+      "id": "ledger_card_182",
+      "name": "Ledger Technique 182",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_182",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 182 to sway encounters.",
+      "flavorText": "Debug iteration 182 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_183": {
+      "id": "ledger_card_183",
+      "name": "Ledger Technique 183",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_183",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 183 to sway encounters.",
+      "flavorText": "Debug iteration 183 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_184": {
+      "id": "ledger_card_184",
+      "name": "Ledger Technique 184",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_184",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 184 to sway encounters.",
+      "flavorText": "Debug iteration 184 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_185": {
+      "id": "ledger_card_185",
+      "name": "Ledger Technique 185",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_185",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 185 to sway encounters.",
+      "flavorText": "Debug iteration 185 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_186": {
+      "id": "ledger_card_186",
+      "name": "Ledger Technique 186",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_186",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 186 to sway encounters.",
+      "flavorText": "Debug iteration 186 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_187": {
+      "id": "ledger_card_187",
+      "name": "Ledger Technique 187",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_187",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 187 to sway encounters.",
+      "flavorText": "Debug iteration 187 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_188": {
+      "id": "ledger_card_188",
+      "name": "Ledger Technique 188",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_188",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 188 to sway encounters.",
+      "flavorText": "Debug iteration 188 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_189": {
+      "id": "ledger_card_189",
+      "name": "Ledger Technique 189",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_189",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 189 to sway encounters.",
+      "flavorText": "Debug iteration 189 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_190": {
+      "id": "ledger_card_190",
+      "name": "Ledger Technique 190",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_190",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 190 to sway encounters.",
+      "flavorText": "Debug iteration 190 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_191": {
+      "id": "ledger_card_191",
+      "name": "Ledger Technique 191",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_191",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 191 to sway encounters.",
+      "flavorText": "Debug iteration 191 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_192": {
+      "id": "ledger_card_192",
+      "name": "Ledger Technique 192",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_192",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 192 to sway encounters.",
+      "flavorText": "Debug iteration 192 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_193": {
+      "id": "ledger_card_193",
+      "name": "Ledger Technique 193",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_193",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 193 to sway encounters.",
+      "flavorText": "Debug iteration 193 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_194": {
+      "id": "ledger_card_194",
+      "name": "Ledger Technique 194",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_194",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 194 to sway encounters.",
+      "flavorText": "Debug iteration 194 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_195": {
+      "id": "ledger_card_195",
+      "name": "Ledger Technique 195",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_195",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 195 to sway encounters.",
+      "flavorText": "Debug iteration 195 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_196": {
+      "id": "ledger_card_196",
+      "name": "Ledger Technique 196",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_196",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 196 to sway encounters.",
+      "flavorText": "Debug iteration 196 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_197": {
+      "id": "ledger_card_197",
+      "name": "Ledger Technique 197",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_197",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 197 to sway encounters.",
+      "flavorText": "Debug iteration 197 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_198": {
+      "id": "ledger_card_198",
+      "name": "Ledger Technique 198",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_198",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 198 to sway encounters.",
+      "flavorText": "Debug iteration 198 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_199": {
+      "id": "ledger_card_199",
+      "name": "Ledger Technique 199",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_199",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 199 to sway encounters.",
+      "flavorText": "Debug iteration 199 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_200": {
+      "id": "ledger_card_200",
+      "name": "Ledger Technique 200",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_200",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 200 to sway encounters.",
+      "flavorText": "Debug iteration 200 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_201": {
+      "id": "ledger_card_201",
+      "name": "Ledger Technique 201",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_201",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 201 to sway encounters.",
+      "flavorText": "Debug iteration 201 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_202": {
+      "id": "ledger_card_202",
+      "name": "Ledger Technique 202",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_202",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 202 to sway encounters.",
+      "flavorText": "Debug iteration 202 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_203": {
+      "id": "ledger_card_203",
+      "name": "Ledger Technique 203",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_203",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 203 to sway encounters.",
+      "flavorText": "Debug iteration 203 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_204": {
+      "id": "ledger_card_204",
+      "name": "Ledger Technique 204",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_204",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 204 to sway encounters.",
+      "flavorText": "Debug iteration 204 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_205": {
+      "id": "ledger_card_205",
+      "name": "Ledger Technique 205",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_205",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 205 to sway encounters.",
+      "flavorText": "Debug iteration 205 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_206": {
+      "id": "ledger_card_206",
+      "name": "Ledger Technique 206",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_206",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 206 to sway encounters.",
+      "flavorText": "Debug iteration 206 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_207": {
+      "id": "ledger_card_207",
+      "name": "Ledger Technique 207",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_207",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 207 to sway encounters.",
+      "flavorText": "Debug iteration 207 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_208": {
+      "id": "ledger_card_208",
+      "name": "Ledger Technique 208",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_208",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 208 to sway encounters.",
+      "flavorText": "Debug iteration 208 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_209": {
+      "id": "ledger_card_209",
+      "name": "Ledger Technique 209",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_209",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 209 to sway encounters.",
+      "flavorText": "Debug iteration 209 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_210": {
+      "id": "ledger_card_210",
+      "name": "Ledger Technique 210",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_210",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 210 to sway encounters.",
+      "flavorText": "Debug iteration 210 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_211": {
+      "id": "ledger_card_211",
+      "name": "Ledger Technique 211",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_211",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 211 to sway encounters.",
+      "flavorText": "Debug iteration 211 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_212": {
+      "id": "ledger_card_212",
+      "name": "Ledger Technique 212",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_212",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 212 to sway encounters.",
+      "flavorText": "Debug iteration 212 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_213": {
+      "id": "ledger_card_213",
+      "name": "Ledger Technique 213",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_213",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 213 to sway encounters.",
+      "flavorText": "Debug iteration 213 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_214": {
+      "id": "ledger_card_214",
+      "name": "Ledger Technique 214",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_214",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 214 to sway encounters.",
+      "flavorText": "Debug iteration 214 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_215": {
+      "id": "ledger_card_215",
+      "name": "Ledger Technique 215",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_215",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 215 to sway encounters.",
+      "flavorText": "Debug iteration 215 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_216": {
+      "id": "ledger_card_216",
+      "name": "Ledger Technique 216",
+      "rarity": "uncommon",
+      "type": "instant",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_216",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "instant",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 216 to sway encounters.",
+      "flavorText": "Debug iteration 216 of the seasonal toolkit.",
+      "set": "genesis"
+    },
+    "ledger_card_217": {
+      "id": "ledger_card_217",
+      "name": "Ledger Technique 217",
+      "rarity": "rare",
+      "type": "ritual",
+      "cost": {
+        "focus": 2
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_217",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "ritual",
+        "ledger",
+        "raid"
+      ],
+      "description": "Deploys ledger algorithm 217 to sway encounters.",
+      "flavorText": "Debug iteration 217 of the seasonal toolkit.",
+      "set": "raid"
+    },
+    "ledger_card_218": {
+      "id": "ledger_card_218",
+      "name": "Ledger Technique 218",
+      "rarity": "epic",
+      "type": "tech",
+      "cost": {
+        "focus": 3
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_218",
+          "value": 3
+        }
+      ],
+      "tags": [
+        "tech",
+        "ledger",
+        "seasonal"
+      ],
+      "description": "Deploys ledger algorithm 218 to sway encounters.",
+      "flavorText": "Debug iteration 218 of the seasonal toolkit.",
+      "set": "seasonal"
+    },
+    "ledger_card_219": {
+      "id": "ledger_card_219",
+      "name": "Ledger Technique 219",
+      "rarity": "legendary",
+      "type": "support",
+      "cost": {
+        "focus": 4
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_219",
+          "value": 1
+        }
+      ],
+      "tags": [
+        "support",
+        "ledger",
+        "pvp"
+      ],
+      "description": "Deploys ledger algorithm 219 to sway encounters.",
+      "flavorText": "Debug iteration 219 of the seasonal toolkit.",
+      "set": "pvp"
+    },
+    "ledger_card_220": {
+      "id": "ledger_card_220",
+      "name": "Ledger Technique 220",
+      "rarity": "common",
+      "type": "skill",
+      "cost": {
+        "focus": 1
+      },
+      "effects": [
+        {
+          "type": "buff",
+          "id": "technique_220",
+          "value": 2
+        }
+      ],
+      "tags": [
+        "skill",
+        "ledger",
+        "genesis"
+      ],
+      "description": "Deploys ledger algorithm 220 to sway encounters.",
+      "flavorText": "Debug iteration 220 of the seasonal toolkit.",
+      "set": "genesis"
     }
   }
 }

--- a/content/registry/items.json
+++ b/content/registry/items.json
@@ -6,15 +6,2192 @@
       "type": "weapon",
       "slot": "weapon",
       "rarity": "epic",
-      "emoji": "⚔️",
+      "emoji": "\u2694\ufe0f",
       "description": "A spear that flows through gaps in consensus.",
       "bonuses": {
         "dcOffset": -1,
-        "advantageTags": ["rush", "momentum", "gremlin"],
+        "advantageTags": [
+          "rush",
+          "momentum",
+          "gremlin"
+        ],
         "sleightBonus": 1
       },
       "setKey": "liquidity",
       "durability": 100
+    },
+    "reality_anchor": {
+      "id": "reality_anchor",
+      "name": "Reality Anchor",
+      "rarity": "mythic",
+      "slot": "trinket",
+      "type": "trinket",
+      "bonuses": {
+        "preventReality": true,
+        "dcOffset": -3
+      },
+      "set": "primordial",
+      "lore": "Forged before the first block to keep chaos tethered to ledgers."
+    },
+    "ledger_item_001": {
+      "id": "ledger_item_001",
+      "name": "Ledger Artifact 001",
+      "type": "armor",
+      "slot": "armor",
+      "rarity": "uncommon",
+      "description": "Prototype artifact #001 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 1,
+        "advantageTags": [
+          "seasonal",
+          "armor"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 51
+    },
+    "ledger_item_002": {
+      "id": "ledger_item_002",
+      "name": "Ledger Artifact 002",
+      "type": "trinket",
+      "slot": "trinket",
+      "rarity": "rare",
+      "description": "Prototype artifact #002 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 2,
+        "advantageTags": [
+          "seasonal",
+          "trinket"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 52
+    },
+    "ledger_item_003": {
+      "id": "ledger_item_003",
+      "name": "Ledger Artifact 003",
+      "type": "consumable",
+      "slot": "consumable",
+      "rarity": "epic",
+      "description": "Prototype artifact #003 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 3,
+        "advantageTags": [
+          "seasonal",
+          "consumable"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 53
+    },
+    "ledger_item_004": {
+      "id": "ledger_item_004",
+      "name": "Ledger Artifact 004",
+      "type": "offhand",
+      "slot": "offhand",
+      "rarity": "legendary",
+      "description": "Prototype artifact #004 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 4,
+        "advantageTags": [
+          "seasonal",
+          "offhand"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 54
+    },
+    "ledger_item_005": {
+      "id": "ledger_item_005",
+      "name": "Ledger Artifact 005",
+      "type": "weapon",
+      "slot": "weapon",
+      "rarity": "common",
+      "description": "Prototype artifact #005 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 0,
+        "advantageTags": [
+          "seasonal",
+          "weapon"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 55
+    },
+    "ledger_item_006": {
+      "id": "ledger_item_006",
+      "name": "Ledger Artifact 006",
+      "type": "armor",
+      "slot": "armor",
+      "rarity": "uncommon",
+      "description": "Prototype artifact #006 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 1,
+        "advantageTags": [
+          "seasonal",
+          "armor"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 56
+    },
+    "ledger_item_007": {
+      "id": "ledger_item_007",
+      "name": "Ledger Artifact 007",
+      "type": "trinket",
+      "slot": "trinket",
+      "rarity": "rare",
+      "description": "Prototype artifact #007 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 2,
+        "advantageTags": [
+          "seasonal",
+          "trinket"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 57
+    },
+    "ledger_item_008": {
+      "id": "ledger_item_008",
+      "name": "Ledger Artifact 008",
+      "type": "consumable",
+      "slot": "consumable",
+      "rarity": "epic",
+      "description": "Prototype artifact #008 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 3,
+        "advantageTags": [
+          "seasonal",
+          "consumable"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 58
+    },
+    "ledger_item_009": {
+      "id": "ledger_item_009",
+      "name": "Ledger Artifact 009",
+      "type": "offhand",
+      "slot": "offhand",
+      "rarity": "legendary",
+      "description": "Prototype artifact #009 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 4,
+        "advantageTags": [
+          "seasonal",
+          "offhand"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 59
+    },
+    "ledger_item_010": {
+      "id": "ledger_item_010",
+      "name": "Ledger Artifact 010",
+      "type": "weapon",
+      "slot": "weapon",
+      "rarity": "common",
+      "description": "Prototype artifact #010 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 0,
+        "advantageTags": [
+          "seasonal",
+          "weapon"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 60
+    },
+    "ledger_item_011": {
+      "id": "ledger_item_011",
+      "name": "Ledger Artifact 011",
+      "type": "armor",
+      "slot": "armor",
+      "rarity": "uncommon",
+      "description": "Prototype artifact #011 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 1,
+        "advantageTags": [
+          "seasonal",
+          "armor"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 61
+    },
+    "ledger_item_012": {
+      "id": "ledger_item_012",
+      "name": "Ledger Artifact 012",
+      "type": "trinket",
+      "slot": "trinket",
+      "rarity": "rare",
+      "description": "Prototype artifact #012 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 2,
+        "advantageTags": [
+          "seasonal",
+          "trinket"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 62
+    },
+    "ledger_item_013": {
+      "id": "ledger_item_013",
+      "name": "Ledger Artifact 013",
+      "type": "consumable",
+      "slot": "consumable",
+      "rarity": "epic",
+      "description": "Prototype artifact #013 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 3,
+        "advantageTags": [
+          "seasonal",
+          "consumable"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 63
+    },
+    "ledger_item_014": {
+      "id": "ledger_item_014",
+      "name": "Ledger Artifact 014",
+      "type": "offhand",
+      "slot": "offhand",
+      "rarity": "legendary",
+      "description": "Prototype artifact #014 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 4,
+        "advantageTags": [
+          "seasonal",
+          "offhand"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 64
+    },
+    "ledger_item_015": {
+      "id": "ledger_item_015",
+      "name": "Ledger Artifact 015",
+      "type": "weapon",
+      "slot": "weapon",
+      "rarity": "common",
+      "description": "Prototype artifact #015 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 0,
+        "advantageTags": [
+          "seasonal",
+          "weapon"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 65
+    },
+    "ledger_item_016": {
+      "id": "ledger_item_016",
+      "name": "Ledger Artifact 016",
+      "type": "armor",
+      "slot": "armor",
+      "rarity": "uncommon",
+      "description": "Prototype artifact #016 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 1,
+        "advantageTags": [
+          "seasonal",
+          "armor"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 66
+    },
+    "ledger_item_017": {
+      "id": "ledger_item_017",
+      "name": "Ledger Artifact 017",
+      "type": "trinket",
+      "slot": "trinket",
+      "rarity": "rare",
+      "description": "Prototype artifact #017 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 2,
+        "advantageTags": [
+          "seasonal",
+          "trinket"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 67
+    },
+    "ledger_item_018": {
+      "id": "ledger_item_018",
+      "name": "Ledger Artifact 018",
+      "type": "consumable",
+      "slot": "consumable",
+      "rarity": "epic",
+      "description": "Prototype artifact #018 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 3,
+        "advantageTags": [
+          "seasonal",
+          "consumable"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 68
+    },
+    "ledger_item_019": {
+      "id": "ledger_item_019",
+      "name": "Ledger Artifact 019",
+      "type": "offhand",
+      "slot": "offhand",
+      "rarity": "legendary",
+      "description": "Prototype artifact #019 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 4,
+        "advantageTags": [
+          "seasonal",
+          "offhand"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 69
+    },
+    "ledger_item_020": {
+      "id": "ledger_item_020",
+      "name": "Ledger Artifact 020",
+      "type": "weapon",
+      "slot": "weapon",
+      "rarity": "common",
+      "description": "Prototype artifact #020 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 0,
+        "advantageTags": [
+          "seasonal",
+          "weapon"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 70
+    },
+    "ledger_item_021": {
+      "id": "ledger_item_021",
+      "name": "Ledger Artifact 021",
+      "type": "armor",
+      "slot": "armor",
+      "rarity": "uncommon",
+      "description": "Prototype artifact #021 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 1,
+        "advantageTags": [
+          "seasonal",
+          "armor"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 71
+    },
+    "ledger_item_022": {
+      "id": "ledger_item_022",
+      "name": "Ledger Artifact 022",
+      "type": "trinket",
+      "slot": "trinket",
+      "rarity": "rare",
+      "description": "Prototype artifact #022 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 2,
+        "advantageTags": [
+          "seasonal",
+          "trinket"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 72
+    },
+    "ledger_item_023": {
+      "id": "ledger_item_023",
+      "name": "Ledger Artifact 023",
+      "type": "consumable",
+      "slot": "consumable",
+      "rarity": "epic",
+      "description": "Prototype artifact #023 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 3,
+        "advantageTags": [
+          "seasonal",
+          "consumable"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 73
+    },
+    "ledger_item_024": {
+      "id": "ledger_item_024",
+      "name": "Ledger Artifact 024",
+      "type": "offhand",
+      "slot": "offhand",
+      "rarity": "legendary",
+      "description": "Prototype artifact #024 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 4,
+        "advantageTags": [
+          "seasonal",
+          "offhand"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 74
+    },
+    "ledger_item_025": {
+      "id": "ledger_item_025",
+      "name": "Ledger Artifact 025",
+      "type": "weapon",
+      "slot": "weapon",
+      "rarity": "common",
+      "description": "Prototype artifact #025 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 0,
+        "advantageTags": [
+          "seasonal",
+          "weapon"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 75
+    },
+    "ledger_item_026": {
+      "id": "ledger_item_026",
+      "name": "Ledger Artifact 026",
+      "type": "armor",
+      "slot": "armor",
+      "rarity": "uncommon",
+      "description": "Prototype artifact #026 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 1,
+        "advantageTags": [
+          "seasonal",
+          "armor"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 76
+    },
+    "ledger_item_027": {
+      "id": "ledger_item_027",
+      "name": "Ledger Artifact 027",
+      "type": "trinket",
+      "slot": "trinket",
+      "rarity": "rare",
+      "description": "Prototype artifact #027 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 2,
+        "advantageTags": [
+          "seasonal",
+          "trinket"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 77
+    },
+    "ledger_item_028": {
+      "id": "ledger_item_028",
+      "name": "Ledger Artifact 028",
+      "type": "consumable",
+      "slot": "consumable",
+      "rarity": "epic",
+      "description": "Prototype artifact #028 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 3,
+        "advantageTags": [
+          "seasonal",
+          "consumable"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 78
+    },
+    "ledger_item_029": {
+      "id": "ledger_item_029",
+      "name": "Ledger Artifact 029",
+      "type": "offhand",
+      "slot": "offhand",
+      "rarity": "legendary",
+      "description": "Prototype artifact #029 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 4,
+        "advantageTags": [
+          "seasonal",
+          "offhand"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 79
+    },
+    "ledger_item_030": {
+      "id": "ledger_item_030",
+      "name": "Ledger Artifact 030",
+      "type": "weapon",
+      "slot": "weapon",
+      "rarity": "common",
+      "description": "Prototype artifact #030 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 0,
+        "advantageTags": [
+          "seasonal",
+          "weapon"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 80
+    },
+    "ledger_item_031": {
+      "id": "ledger_item_031",
+      "name": "Ledger Artifact 031",
+      "type": "armor",
+      "slot": "armor",
+      "rarity": "uncommon",
+      "description": "Prototype artifact #031 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 1,
+        "advantageTags": [
+          "seasonal",
+          "armor"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 81
+    },
+    "ledger_item_032": {
+      "id": "ledger_item_032",
+      "name": "Ledger Artifact 032",
+      "type": "trinket",
+      "slot": "trinket",
+      "rarity": "rare",
+      "description": "Prototype artifact #032 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 2,
+        "advantageTags": [
+          "seasonal",
+          "trinket"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 82
+    },
+    "ledger_item_033": {
+      "id": "ledger_item_033",
+      "name": "Ledger Artifact 033",
+      "type": "consumable",
+      "slot": "consumable",
+      "rarity": "epic",
+      "description": "Prototype artifact #033 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 3,
+        "advantageTags": [
+          "seasonal",
+          "consumable"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 83
+    },
+    "ledger_item_034": {
+      "id": "ledger_item_034",
+      "name": "Ledger Artifact 034",
+      "type": "offhand",
+      "slot": "offhand",
+      "rarity": "legendary",
+      "description": "Prototype artifact #034 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 4,
+        "advantageTags": [
+          "seasonal",
+          "offhand"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 84
+    },
+    "ledger_item_035": {
+      "id": "ledger_item_035",
+      "name": "Ledger Artifact 035",
+      "type": "weapon",
+      "slot": "weapon",
+      "rarity": "common",
+      "description": "Prototype artifact #035 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 0,
+        "advantageTags": [
+          "seasonal",
+          "weapon"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 85
+    },
+    "ledger_item_036": {
+      "id": "ledger_item_036",
+      "name": "Ledger Artifact 036",
+      "type": "armor",
+      "slot": "armor",
+      "rarity": "uncommon",
+      "description": "Prototype artifact #036 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 1,
+        "advantageTags": [
+          "seasonal",
+          "armor"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 86
+    },
+    "ledger_item_037": {
+      "id": "ledger_item_037",
+      "name": "Ledger Artifact 037",
+      "type": "trinket",
+      "slot": "trinket",
+      "rarity": "rare",
+      "description": "Prototype artifact #037 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 2,
+        "advantageTags": [
+          "seasonal",
+          "trinket"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 87
+    },
+    "ledger_item_038": {
+      "id": "ledger_item_038",
+      "name": "Ledger Artifact 038",
+      "type": "consumable",
+      "slot": "consumable",
+      "rarity": "epic",
+      "description": "Prototype artifact #038 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 3,
+        "advantageTags": [
+          "seasonal",
+          "consumable"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 88
+    },
+    "ledger_item_039": {
+      "id": "ledger_item_039",
+      "name": "Ledger Artifact 039",
+      "type": "offhand",
+      "slot": "offhand",
+      "rarity": "legendary",
+      "description": "Prototype artifact #039 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 4,
+        "advantageTags": [
+          "seasonal",
+          "offhand"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 89
+    },
+    "ledger_item_040": {
+      "id": "ledger_item_040",
+      "name": "Ledger Artifact 040",
+      "type": "weapon",
+      "slot": "weapon",
+      "rarity": "common",
+      "description": "Prototype artifact #040 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 0,
+        "advantageTags": [
+          "seasonal",
+          "weapon"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 90
+    },
+    "ledger_item_041": {
+      "id": "ledger_item_041",
+      "name": "Ledger Artifact 041",
+      "type": "armor",
+      "slot": "armor",
+      "rarity": "uncommon",
+      "description": "Prototype artifact #041 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 1,
+        "advantageTags": [
+          "seasonal",
+          "armor"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 91
+    },
+    "ledger_item_042": {
+      "id": "ledger_item_042",
+      "name": "Ledger Artifact 042",
+      "type": "trinket",
+      "slot": "trinket",
+      "rarity": "rare",
+      "description": "Prototype artifact #042 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 2,
+        "advantageTags": [
+          "seasonal",
+          "trinket"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 92
+    },
+    "ledger_item_043": {
+      "id": "ledger_item_043",
+      "name": "Ledger Artifact 043",
+      "type": "consumable",
+      "slot": "consumable",
+      "rarity": "epic",
+      "description": "Prototype artifact #043 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 3,
+        "advantageTags": [
+          "seasonal",
+          "consumable"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 93
+    },
+    "ledger_item_044": {
+      "id": "ledger_item_044",
+      "name": "Ledger Artifact 044",
+      "type": "offhand",
+      "slot": "offhand",
+      "rarity": "legendary",
+      "description": "Prototype artifact #044 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 4,
+        "advantageTags": [
+          "seasonal",
+          "offhand"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 94
+    },
+    "ledger_item_045": {
+      "id": "ledger_item_045",
+      "name": "Ledger Artifact 045",
+      "type": "weapon",
+      "slot": "weapon",
+      "rarity": "common",
+      "description": "Prototype artifact #045 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 0,
+        "advantageTags": [
+          "seasonal",
+          "weapon"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 95
+    },
+    "ledger_item_046": {
+      "id": "ledger_item_046",
+      "name": "Ledger Artifact 046",
+      "type": "armor",
+      "slot": "armor",
+      "rarity": "uncommon",
+      "description": "Prototype artifact #046 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 1,
+        "advantageTags": [
+          "seasonal",
+          "armor"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 96
+    },
+    "ledger_item_047": {
+      "id": "ledger_item_047",
+      "name": "Ledger Artifact 047",
+      "type": "trinket",
+      "slot": "trinket",
+      "rarity": "rare",
+      "description": "Prototype artifact #047 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 2,
+        "advantageTags": [
+          "seasonal",
+          "trinket"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 97
+    },
+    "ledger_item_048": {
+      "id": "ledger_item_048",
+      "name": "Ledger Artifact 048",
+      "type": "consumable",
+      "slot": "consumable",
+      "rarity": "epic",
+      "description": "Prototype artifact #048 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 3,
+        "advantageTags": [
+          "seasonal",
+          "consumable"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 98
+    },
+    "ledger_item_049": {
+      "id": "ledger_item_049",
+      "name": "Ledger Artifact 049",
+      "type": "offhand",
+      "slot": "offhand",
+      "rarity": "legendary",
+      "description": "Prototype artifact #049 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 4,
+        "advantageTags": [
+          "seasonal",
+          "offhand"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 99
+    },
+    "ledger_item_050": {
+      "id": "ledger_item_050",
+      "name": "Ledger Artifact 050",
+      "type": "weapon",
+      "slot": "weapon",
+      "rarity": "common",
+      "description": "Prototype artifact #050 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 0,
+        "advantageTags": [
+          "seasonal",
+          "weapon"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 100
+    },
+    "ledger_item_051": {
+      "id": "ledger_item_051",
+      "name": "Ledger Artifact 051",
+      "type": "armor",
+      "slot": "armor",
+      "rarity": "uncommon",
+      "description": "Prototype artifact #051 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 1,
+        "advantageTags": [
+          "seasonal",
+          "armor"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 101
+    },
+    "ledger_item_052": {
+      "id": "ledger_item_052",
+      "name": "Ledger Artifact 052",
+      "type": "trinket",
+      "slot": "trinket",
+      "rarity": "rare",
+      "description": "Prototype artifact #052 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 2,
+        "advantageTags": [
+          "seasonal",
+          "trinket"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 102
+    },
+    "ledger_item_053": {
+      "id": "ledger_item_053",
+      "name": "Ledger Artifact 053",
+      "type": "consumable",
+      "slot": "consumable",
+      "rarity": "epic",
+      "description": "Prototype artifact #053 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 3,
+        "advantageTags": [
+          "seasonal",
+          "consumable"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 103
+    },
+    "ledger_item_054": {
+      "id": "ledger_item_054",
+      "name": "Ledger Artifact 054",
+      "type": "offhand",
+      "slot": "offhand",
+      "rarity": "legendary",
+      "description": "Prototype artifact #054 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 4,
+        "advantageTags": [
+          "seasonal",
+          "offhand"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 104
+    },
+    "ledger_item_055": {
+      "id": "ledger_item_055",
+      "name": "Ledger Artifact 055",
+      "type": "weapon",
+      "slot": "weapon",
+      "rarity": "common",
+      "description": "Prototype artifact #055 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 0,
+        "advantageTags": [
+          "seasonal",
+          "weapon"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 105
+    },
+    "ledger_item_056": {
+      "id": "ledger_item_056",
+      "name": "Ledger Artifact 056",
+      "type": "armor",
+      "slot": "armor",
+      "rarity": "uncommon",
+      "description": "Prototype artifact #056 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 1,
+        "advantageTags": [
+          "seasonal",
+          "armor"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 106
+    },
+    "ledger_item_057": {
+      "id": "ledger_item_057",
+      "name": "Ledger Artifact 057",
+      "type": "trinket",
+      "slot": "trinket",
+      "rarity": "rare",
+      "description": "Prototype artifact #057 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 2,
+        "advantageTags": [
+          "seasonal",
+          "trinket"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 107
+    },
+    "ledger_item_058": {
+      "id": "ledger_item_058",
+      "name": "Ledger Artifact 058",
+      "type": "consumable",
+      "slot": "consumable",
+      "rarity": "epic",
+      "description": "Prototype artifact #058 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 3,
+        "advantageTags": [
+          "seasonal",
+          "consumable"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 108
+    },
+    "ledger_item_059": {
+      "id": "ledger_item_059",
+      "name": "Ledger Artifact 059",
+      "type": "offhand",
+      "slot": "offhand",
+      "rarity": "legendary",
+      "description": "Prototype artifact #059 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 4,
+        "advantageTags": [
+          "seasonal",
+          "offhand"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 109
+    },
+    "ledger_item_060": {
+      "id": "ledger_item_060",
+      "name": "Ledger Artifact 060",
+      "type": "weapon",
+      "slot": "weapon",
+      "rarity": "common",
+      "description": "Prototype artifact #060 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 0,
+        "advantageTags": [
+          "seasonal",
+          "weapon"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 110
+    },
+    "ledger_item_061": {
+      "id": "ledger_item_061",
+      "name": "Ledger Artifact 061",
+      "type": "armor",
+      "slot": "armor",
+      "rarity": "uncommon",
+      "description": "Prototype artifact #061 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 1,
+        "advantageTags": [
+          "seasonal",
+          "armor"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 111
+    },
+    "ledger_item_062": {
+      "id": "ledger_item_062",
+      "name": "Ledger Artifact 062",
+      "type": "trinket",
+      "slot": "trinket",
+      "rarity": "rare",
+      "description": "Prototype artifact #062 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 2,
+        "advantageTags": [
+          "seasonal",
+          "trinket"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 112
+    },
+    "ledger_item_063": {
+      "id": "ledger_item_063",
+      "name": "Ledger Artifact 063",
+      "type": "consumable",
+      "slot": "consumable",
+      "rarity": "epic",
+      "description": "Prototype artifact #063 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 3,
+        "advantageTags": [
+          "seasonal",
+          "consumable"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 113
+    },
+    "ledger_item_064": {
+      "id": "ledger_item_064",
+      "name": "Ledger Artifact 064",
+      "type": "offhand",
+      "slot": "offhand",
+      "rarity": "legendary",
+      "description": "Prototype artifact #064 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 4,
+        "advantageTags": [
+          "seasonal",
+          "offhand"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 114
+    },
+    "ledger_item_065": {
+      "id": "ledger_item_065",
+      "name": "Ledger Artifact 065",
+      "type": "weapon",
+      "slot": "weapon",
+      "rarity": "common",
+      "description": "Prototype artifact #065 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 0,
+        "advantageTags": [
+          "seasonal",
+          "weapon"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 115
+    },
+    "ledger_item_066": {
+      "id": "ledger_item_066",
+      "name": "Ledger Artifact 066",
+      "type": "armor",
+      "slot": "armor",
+      "rarity": "uncommon",
+      "description": "Prototype artifact #066 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 1,
+        "advantageTags": [
+          "seasonal",
+          "armor"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 116
+    },
+    "ledger_item_067": {
+      "id": "ledger_item_067",
+      "name": "Ledger Artifact 067",
+      "type": "trinket",
+      "slot": "trinket",
+      "rarity": "rare",
+      "description": "Prototype artifact #067 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 2,
+        "advantageTags": [
+          "seasonal",
+          "trinket"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 117
+    },
+    "ledger_item_068": {
+      "id": "ledger_item_068",
+      "name": "Ledger Artifact 068",
+      "type": "consumable",
+      "slot": "consumable",
+      "rarity": "epic",
+      "description": "Prototype artifact #068 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 3,
+        "advantageTags": [
+          "seasonal",
+          "consumable"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 118
+    },
+    "ledger_item_069": {
+      "id": "ledger_item_069",
+      "name": "Ledger Artifact 069",
+      "type": "offhand",
+      "slot": "offhand",
+      "rarity": "legendary",
+      "description": "Prototype artifact #069 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 4,
+        "advantageTags": [
+          "seasonal",
+          "offhand"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 119
+    },
+    "ledger_item_070": {
+      "id": "ledger_item_070",
+      "name": "Ledger Artifact 070",
+      "type": "weapon",
+      "slot": "weapon",
+      "rarity": "common",
+      "description": "Prototype artifact #070 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 0,
+        "advantageTags": [
+          "seasonal",
+          "weapon"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 120
+    },
+    "ledger_item_071": {
+      "id": "ledger_item_071",
+      "name": "Ledger Artifact 071",
+      "type": "armor",
+      "slot": "armor",
+      "rarity": "uncommon",
+      "description": "Prototype artifact #071 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 1,
+        "advantageTags": [
+          "seasonal",
+          "armor"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 121
+    },
+    "ledger_item_072": {
+      "id": "ledger_item_072",
+      "name": "Ledger Artifact 072",
+      "type": "trinket",
+      "slot": "trinket",
+      "rarity": "rare",
+      "description": "Prototype artifact #072 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 2,
+        "advantageTags": [
+          "seasonal",
+          "trinket"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 122
+    },
+    "ledger_item_073": {
+      "id": "ledger_item_073",
+      "name": "Ledger Artifact 073",
+      "type": "consumable",
+      "slot": "consumable",
+      "rarity": "epic",
+      "description": "Prototype artifact #073 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 3,
+        "advantageTags": [
+          "seasonal",
+          "consumable"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 123
+    },
+    "ledger_item_074": {
+      "id": "ledger_item_074",
+      "name": "Ledger Artifact 074",
+      "type": "offhand",
+      "slot": "offhand",
+      "rarity": "legendary",
+      "description": "Prototype artifact #074 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 4,
+        "advantageTags": [
+          "seasonal",
+          "offhand"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 124
+    },
+    "ledger_item_075": {
+      "id": "ledger_item_075",
+      "name": "Ledger Artifact 075",
+      "type": "weapon",
+      "slot": "weapon",
+      "rarity": "common",
+      "description": "Prototype artifact #075 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 0,
+        "advantageTags": [
+          "seasonal",
+          "weapon"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 125
+    },
+    "ledger_item_076": {
+      "id": "ledger_item_076",
+      "name": "Ledger Artifact 076",
+      "type": "armor",
+      "slot": "armor",
+      "rarity": "uncommon",
+      "description": "Prototype artifact #076 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 1,
+        "advantageTags": [
+          "seasonal",
+          "armor"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 126
+    },
+    "ledger_item_077": {
+      "id": "ledger_item_077",
+      "name": "Ledger Artifact 077",
+      "type": "trinket",
+      "slot": "trinket",
+      "rarity": "rare",
+      "description": "Prototype artifact #077 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 2,
+        "advantageTags": [
+          "seasonal",
+          "trinket"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 127
+    },
+    "ledger_item_078": {
+      "id": "ledger_item_078",
+      "name": "Ledger Artifact 078",
+      "type": "consumable",
+      "slot": "consumable",
+      "rarity": "epic",
+      "description": "Prototype artifact #078 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 3,
+        "advantageTags": [
+          "seasonal",
+          "consumable"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 128
+    },
+    "ledger_item_079": {
+      "id": "ledger_item_079",
+      "name": "Ledger Artifact 079",
+      "type": "offhand",
+      "slot": "offhand",
+      "rarity": "legendary",
+      "description": "Prototype artifact #079 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 4,
+        "advantageTags": [
+          "seasonal",
+          "offhand"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 129
+    },
+    "ledger_item_080": {
+      "id": "ledger_item_080",
+      "name": "Ledger Artifact 080",
+      "type": "weapon",
+      "slot": "weapon",
+      "rarity": "common",
+      "description": "Prototype artifact #080 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 0,
+        "advantageTags": [
+          "seasonal",
+          "weapon"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 130
+    },
+    "ledger_item_081": {
+      "id": "ledger_item_081",
+      "name": "Ledger Artifact 081",
+      "type": "armor",
+      "slot": "armor",
+      "rarity": "uncommon",
+      "description": "Prototype artifact #081 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 1,
+        "advantageTags": [
+          "seasonal",
+          "armor"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 131
+    },
+    "ledger_item_082": {
+      "id": "ledger_item_082",
+      "name": "Ledger Artifact 082",
+      "type": "trinket",
+      "slot": "trinket",
+      "rarity": "rare",
+      "description": "Prototype artifact #082 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 2,
+        "advantageTags": [
+          "seasonal",
+          "trinket"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 132
+    },
+    "ledger_item_083": {
+      "id": "ledger_item_083",
+      "name": "Ledger Artifact 083",
+      "type": "consumable",
+      "slot": "consumable",
+      "rarity": "epic",
+      "description": "Prototype artifact #083 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 3,
+        "advantageTags": [
+          "seasonal",
+          "consumable"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 133
+    },
+    "ledger_item_084": {
+      "id": "ledger_item_084",
+      "name": "Ledger Artifact 084",
+      "type": "offhand",
+      "slot": "offhand",
+      "rarity": "legendary",
+      "description": "Prototype artifact #084 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 4,
+        "advantageTags": [
+          "seasonal",
+          "offhand"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 134
+    },
+    "ledger_item_085": {
+      "id": "ledger_item_085",
+      "name": "Ledger Artifact 085",
+      "type": "weapon",
+      "slot": "weapon",
+      "rarity": "common",
+      "description": "Prototype artifact #085 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 0,
+        "advantageTags": [
+          "seasonal",
+          "weapon"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 135
+    },
+    "ledger_item_086": {
+      "id": "ledger_item_086",
+      "name": "Ledger Artifact 086",
+      "type": "armor",
+      "slot": "armor",
+      "rarity": "uncommon",
+      "description": "Prototype artifact #086 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 1,
+        "advantageTags": [
+          "seasonal",
+          "armor"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 136
+    },
+    "ledger_item_087": {
+      "id": "ledger_item_087",
+      "name": "Ledger Artifact 087",
+      "type": "trinket",
+      "slot": "trinket",
+      "rarity": "rare",
+      "description": "Prototype artifact #087 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 2,
+        "advantageTags": [
+          "seasonal",
+          "trinket"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 137
+    },
+    "ledger_item_088": {
+      "id": "ledger_item_088",
+      "name": "Ledger Artifact 088",
+      "type": "consumable",
+      "slot": "consumable",
+      "rarity": "epic",
+      "description": "Prototype artifact #088 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 3,
+        "advantageTags": [
+          "seasonal",
+          "consumable"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 138
+    },
+    "ledger_item_089": {
+      "id": "ledger_item_089",
+      "name": "Ledger Artifact 089",
+      "type": "offhand",
+      "slot": "offhand",
+      "rarity": "legendary",
+      "description": "Prototype artifact #089 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 4,
+        "advantageTags": [
+          "seasonal",
+          "offhand"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 139
+    },
+    "ledger_item_090": {
+      "id": "ledger_item_090",
+      "name": "Ledger Artifact 090",
+      "type": "weapon",
+      "slot": "weapon",
+      "rarity": "common",
+      "description": "Prototype artifact #090 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 0,
+        "advantageTags": [
+          "seasonal",
+          "weapon"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 140
+    },
+    "ledger_item_091": {
+      "id": "ledger_item_091",
+      "name": "Ledger Artifact 091",
+      "type": "armor",
+      "slot": "armor",
+      "rarity": "uncommon",
+      "description": "Prototype artifact #091 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 1,
+        "advantageTags": [
+          "seasonal",
+          "armor"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 141
+    },
+    "ledger_item_092": {
+      "id": "ledger_item_092",
+      "name": "Ledger Artifact 092",
+      "type": "trinket",
+      "slot": "trinket",
+      "rarity": "rare",
+      "description": "Prototype artifact #092 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 2,
+        "advantageTags": [
+          "seasonal",
+          "trinket"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 142
+    },
+    "ledger_item_093": {
+      "id": "ledger_item_093",
+      "name": "Ledger Artifact 093",
+      "type": "consumable",
+      "slot": "consumable",
+      "rarity": "epic",
+      "description": "Prototype artifact #093 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 3,
+        "advantageTags": [
+          "seasonal",
+          "consumable"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 143
+    },
+    "ledger_item_094": {
+      "id": "ledger_item_094",
+      "name": "Ledger Artifact 094",
+      "type": "offhand",
+      "slot": "offhand",
+      "rarity": "legendary",
+      "description": "Prototype artifact #094 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 4,
+        "advantageTags": [
+          "seasonal",
+          "offhand"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 144
+    },
+    "ledger_item_095": {
+      "id": "ledger_item_095",
+      "name": "Ledger Artifact 095",
+      "type": "weapon",
+      "slot": "weapon",
+      "rarity": "common",
+      "description": "Prototype artifact #095 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 0,
+        "advantageTags": [
+          "seasonal",
+          "weapon"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 145
+    },
+    "ledger_item_096": {
+      "id": "ledger_item_096",
+      "name": "Ledger Artifact 096",
+      "type": "armor",
+      "slot": "armor",
+      "rarity": "uncommon",
+      "description": "Prototype artifact #096 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 1,
+        "advantageTags": [
+          "seasonal",
+          "armor"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 146
+    },
+    "ledger_item_097": {
+      "id": "ledger_item_097",
+      "name": "Ledger Artifact 097",
+      "type": "trinket",
+      "slot": "trinket",
+      "rarity": "rare",
+      "description": "Prototype artifact #097 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 2,
+        "advantageTags": [
+          "seasonal",
+          "trinket"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 147
+    },
+    "ledger_item_098": {
+      "id": "ledger_item_098",
+      "name": "Ledger Artifact 098",
+      "type": "consumable",
+      "slot": "consumable",
+      "rarity": "epic",
+      "description": "Prototype artifact #098 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 3,
+        "advantageTags": [
+          "seasonal",
+          "consumable"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 148
+    },
+    "ledger_item_099": {
+      "id": "ledger_item_099",
+      "name": "Ledger Artifact 099",
+      "type": "offhand",
+      "slot": "offhand",
+      "rarity": "legendary",
+      "description": "Prototype artifact #099 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 4,
+        "advantageTags": [
+          "seasonal",
+          "offhand"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 149
+    },
+    "ledger_item_100": {
+      "id": "ledger_item_100",
+      "name": "Ledger Artifact 100",
+      "type": "weapon",
+      "slot": "weapon",
+      "rarity": "common",
+      "description": "Prototype artifact #100 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 0,
+        "advantageTags": [
+          "seasonal",
+          "weapon"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 150
+    },
+    "ledger_item_101": {
+      "id": "ledger_item_101",
+      "name": "Ledger Artifact 101",
+      "type": "armor",
+      "slot": "armor",
+      "rarity": "uncommon",
+      "description": "Prototype artifact #101 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 1,
+        "advantageTags": [
+          "seasonal",
+          "armor"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 151
+    },
+    "ledger_item_102": {
+      "id": "ledger_item_102",
+      "name": "Ledger Artifact 102",
+      "type": "trinket",
+      "slot": "trinket",
+      "rarity": "rare",
+      "description": "Prototype artifact #102 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 2,
+        "advantageTags": [
+          "seasonal",
+          "trinket"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 152
+    },
+    "ledger_item_103": {
+      "id": "ledger_item_103",
+      "name": "Ledger Artifact 103",
+      "type": "consumable",
+      "slot": "consumable",
+      "rarity": "epic",
+      "description": "Prototype artifact #103 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 3,
+        "advantageTags": [
+          "seasonal",
+          "consumable"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 153
+    },
+    "ledger_item_104": {
+      "id": "ledger_item_104",
+      "name": "Ledger Artifact 104",
+      "type": "offhand",
+      "slot": "offhand",
+      "rarity": "legendary",
+      "description": "Prototype artifact #104 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 4,
+        "advantageTags": [
+          "seasonal",
+          "offhand"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 154
+    },
+    "ledger_item_105": {
+      "id": "ledger_item_105",
+      "name": "Ledger Artifact 105",
+      "type": "weapon",
+      "slot": "weapon",
+      "rarity": "common",
+      "description": "Prototype artifact #105 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 0,
+        "advantageTags": [
+          "seasonal",
+          "weapon"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 155
+    },
+    "ledger_item_106": {
+      "id": "ledger_item_106",
+      "name": "Ledger Artifact 106",
+      "type": "armor",
+      "slot": "armor",
+      "rarity": "uncommon",
+      "description": "Prototype artifact #106 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 1,
+        "advantageTags": [
+          "seasonal",
+          "armor"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 156
+    },
+    "ledger_item_107": {
+      "id": "ledger_item_107",
+      "name": "Ledger Artifact 107",
+      "type": "trinket",
+      "slot": "trinket",
+      "rarity": "rare",
+      "description": "Prototype artifact #107 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 2,
+        "advantageTags": [
+          "seasonal",
+          "trinket"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 157
+    },
+    "ledger_item_108": {
+      "id": "ledger_item_108",
+      "name": "Ledger Artifact 108",
+      "type": "consumable",
+      "slot": "consumable",
+      "rarity": "epic",
+      "description": "Prototype artifact #108 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 3,
+        "advantageTags": [
+          "seasonal",
+          "consumable"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 158
+    },
+    "ledger_item_109": {
+      "id": "ledger_item_109",
+      "name": "Ledger Artifact 109",
+      "type": "offhand",
+      "slot": "offhand",
+      "rarity": "legendary",
+      "description": "Prototype artifact #109 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 4,
+        "advantageTags": [
+          "seasonal",
+          "offhand"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 159
+    },
+    "ledger_item_110": {
+      "id": "ledger_item_110",
+      "name": "Ledger Artifact 110",
+      "type": "weapon",
+      "slot": "weapon",
+      "rarity": "common",
+      "description": "Prototype artifact #110 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 0,
+        "advantageTags": [
+          "seasonal",
+          "weapon"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 160
+    },
+    "ledger_item_111": {
+      "id": "ledger_item_111",
+      "name": "Ledger Artifact 111",
+      "type": "armor",
+      "slot": "armor",
+      "rarity": "uncommon",
+      "description": "Prototype artifact #111 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 1,
+        "advantageTags": [
+          "seasonal",
+          "armor"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 161
+    },
+    "ledger_item_112": {
+      "id": "ledger_item_112",
+      "name": "Ledger Artifact 112",
+      "type": "trinket",
+      "slot": "trinket",
+      "rarity": "rare",
+      "description": "Prototype artifact #112 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 2,
+        "advantageTags": [
+          "seasonal",
+          "trinket"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 162
+    },
+    "ledger_item_113": {
+      "id": "ledger_item_113",
+      "name": "Ledger Artifact 113",
+      "type": "consumable",
+      "slot": "consumable",
+      "rarity": "epic",
+      "description": "Prototype artifact #113 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 3,
+        "advantageTags": [
+          "seasonal",
+          "consumable"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 163
+    },
+    "ledger_item_114": {
+      "id": "ledger_item_114",
+      "name": "Ledger Artifact 114",
+      "type": "offhand",
+      "slot": "offhand",
+      "rarity": "legendary",
+      "description": "Prototype artifact #114 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 4,
+        "advantageTags": [
+          "seasonal",
+          "offhand"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 164
+    },
+    "ledger_item_115": {
+      "id": "ledger_item_115",
+      "name": "Ledger Artifact 115",
+      "type": "weapon",
+      "slot": "weapon",
+      "rarity": "common",
+      "description": "Prototype artifact #115 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 0,
+        "advantageTags": [
+          "seasonal",
+          "weapon"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 165
+    },
+    "ledger_item_116": {
+      "id": "ledger_item_116",
+      "name": "Ledger Artifact 116",
+      "type": "armor",
+      "slot": "armor",
+      "rarity": "uncommon",
+      "description": "Prototype artifact #116 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 1,
+        "advantageTags": [
+          "seasonal",
+          "armor"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 166
+    },
+    "ledger_item_117": {
+      "id": "ledger_item_117",
+      "name": "Ledger Artifact 117",
+      "type": "trinket",
+      "slot": "trinket",
+      "rarity": "rare",
+      "description": "Prototype artifact #117 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 2,
+        "advantageTags": [
+          "seasonal",
+          "trinket"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 167
+    },
+    "ledger_item_118": {
+      "id": "ledger_item_118",
+      "name": "Ledger Artifact 118",
+      "type": "consumable",
+      "slot": "consumable",
+      "rarity": "epic",
+      "description": "Prototype artifact #118 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -1,
+        "focusBonus": 3,
+        "advantageTags": [
+          "seasonal",
+          "consumable"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 168
+    },
+    "ledger_item_119": {
+      "id": "ledger_item_119",
+      "name": "Ledger Artifact 119",
+      "type": "offhand",
+      "slot": "offhand",
+      "rarity": "legendary",
+      "description": "Prototype artifact #119 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": -2,
+        "focusBonus": 4,
+        "advantageTags": [
+          "seasonal",
+          "offhand"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 169
+    },
+    "ledger_item_120": {
+      "id": "ledger_item_120",
+      "name": "Ledger Artifact 120",
+      "type": "weapon",
+      "slot": "weapon",
+      "rarity": "common",
+      "description": "Prototype artifact #120 tuned for seasonal expeditions.",
+      "bonuses": {
+        "dcOffset": 0,
+        "focusBonus": 0,
+        "advantageTags": [
+          "seasonal",
+          "weapon"
+        ]
+      },
+      "setKey": "expansion_alpha",
+      "durability": 170
     }
   }
 }

--- a/content/seasons/halloween2025/manifest.json
+++ b/content/seasons/halloween2025/manifest.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "1.0",
+  "content_id": "seasons/halloween2025",
+  "version": "2025.10",
+  "book_name": "Spooky Ledgers",
+  "scenes": ["H25-1", "H25-2"],
+  "time_window": {
+    "start": "2025-10-15T00:00:00Z",
+    "end": "2025-11-05T23:59:59Z"
+  }
+}

--- a/content/seasons/halloween2025/scenes/scene_H25-1.json
+++ b/content/seasons/halloween2025/scenes/scene_H25-1.json
@@ -1,0 +1,71 @@
+{
+  "schema_version": "1.0",
+  "content_id": "seasons/halloween2025",
+  "book_id": "spooky_ledgers",
+  "scene_id": "H25-1",
+  "title": "Pumpkin Paradox Procession",
+  "narration": "Jack-o-ledgers drift through the plaza as gremlin lantern bearers trace a loop of spectral fire. Each lap increases the paradox charge powering the harvest gate. Players must manipulate the procession to maintain equilibrium and unlock limited rewards.",
+  "rounds": [
+    {
+      "round_id": "H25-1-R1",
+      "description": "Guide the procession and manage paradox drift.",
+      "actions": [
+        {
+          "id": "sync_lanterns",
+          "label": "Sync Lantern Cadence",
+          "roll": { "kind": "phi_d20", "tags": ["ritual", "focus"] },
+          "outcomes": {
+            "crit_success": {
+              "effects": [
+                { "type": "xp", "value": 60 },
+                { "type": "item", "id": "pumpkin_sigil" }
+              ],
+              "narration": "The lanterns hum in resonance, granting you a Pumpkin Sigil."
+            },
+            "success": {
+              "effects": [
+                { "type": "xp", "value": 35 }
+              ],
+              "narration": "The cadence stabilizes and paradox drift slows."
+            },
+            "fail": {
+              "effects": [
+                { "type": "focus", "op": "-", "value": 2 }
+              ],
+              "narration": "The flames flare and singe your notes."
+            }
+          }
+        },
+        {
+          "id": "redirect_specters",
+          "label": "Redirect Mischievous Specters",
+          "roll": { "kind": "phi_d20", "tags": ["tactics", "spirit"] },
+          "outcomes": {
+            "success": {
+              "effects": [
+                { "type": "xp", "value": 40 },
+                { "type": "flag", "id": "specters_redirected", "value": true }
+              ],
+              "narration": "You coax the specters back onto the parade route." 
+            },
+            "fail": {
+              "effects": [
+                { "type": "hp", "op": "-", "value": 4 }
+              ],
+              "narration": "A specter slips through and drains warmth from the plaza."
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "rewards": {
+    "first_clear": [
+      { "type": "item", "id": "lantern_of_twilight" },
+      { "type": "flag", "id": "seasonal_fast_clear", "value": true }
+    ],
+    "repeat_clear": [
+      { "type": "coins", "value": 60 }
+    ]
+  }
+}

--- a/content/seasons/halloween2025/scenes/scene_H25-2.json
+++ b/content/seasons/halloween2025/scenes/scene_H25-2.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": "1.0",
+  "content_id": "seasons/halloween2025",
+  "book_id": "spooky_ledgers",
+  "scene_id": "H25-2",
+  "title": "Ledger of Whispering Masks",
+  "narration": "An obsidian ledger opens to reveal blank mask pages. Spirits bargain to write their stories if you balance the ledger with tales from the living. Choices shift the alignment of the masks, unlocking unique cosmetics and titles before the event expires.",
+  "rounds": [
+    {
+      "round_id": "H25-2-R1",
+      "description": "Negotiate with whispering spirits for limited time boons.",
+      "actions": [
+        {
+          "id": "trade_story",
+          "label": "Trade a Living Story",
+          "roll": { "kind": "phi_d20", "tags": ["social", "ritual"] },
+          "outcomes": {
+            "success": {
+              "effects": [
+                { "type": "xp", "value": 45 },
+                { "type": "item", "id": "whispering_mask" }
+              ],
+              "narration": "A mask inks itself with your tale and gifts you a seasonal cosmetic."
+            },
+            "fail": {
+              "effects": [
+                { "type": "focus", "op": "-", "value": 2 }
+              ],
+              "narration": "The spirit rejects your offering; the ledger remains blank."
+            }
+          }
+        },
+        {
+          "id": "seal_breach",
+          "label": "Seal Mask Breach",
+          "roll": { "kind": "phi_d20", "tags": ["tech", "support"] },
+          "outcomes": {
+            "crit_success": {
+              "effects": [
+                { "type": "xp", "value": 70 },
+                { "type": "flag", "id": "mask_balance", "value": true }
+              ],
+              "narration": "You stabilize the ledger and unlock the Mask Balance title."
+            },
+            "success": {
+              "effects": [
+                { "type": "xp", "value": 40 }
+              ],
+              "narration": "The breach closes before the spirits escape."
+            },
+            "fail": {
+              "effects": [
+                { "type": "hp", "op": "-", "value": 5 }
+              ],
+              "narration": "A gust of wails knocks you back."
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "time_limited_rewards": {
+    "cosmetics": ["mask_balance_title", "spectral_trail"],
+    "items": ["whispering_mask"],
+    "expires": "2025-11-05T23:59:59Z"
+  }
+}

--- a/content/seasons/summer_solstice/manifest.json
+++ b/content/seasons/summer_solstice/manifest.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "1.0",
+  "content_id": "seasons/summer_solstice",
+  "version": "2025.06",
+  "book_name": "Solstice Radiance",
+  "scenes": ["SS-1", "SS-2"],
+  "time_window": {
+    "start": "2025-06-10T00:00:00Z",
+    "end": "2025-06-30T23:59:59Z"
+  }
+}

--- a/content/seasons/summer_solstice/scenes/scene_SS-1.json
+++ b/content/seasons/summer_solstice/scenes/scene_SS-1.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": "1.0",
+  "content_id": "seasons/summer_solstice",
+  "book_id": "solstice_radiance",
+  "scene_id": "SS-1",
+  "title": "Solar Engine Defense",
+  "narration": "The solar engine that powers the ledger city draws solstice light into a spinning array. Sun-gremlins scramble to keep the mirrors aligned as prismatic raiders attempt to siphon the energy. The party must defend the engine and calibrate the mirrors before the timer expires.",
+  "rounds": [
+    {
+      "round_id": "SS-1-R1",
+      "description": "Calibrate the mirrors and repel invaders.",
+      "actions": [
+        {
+          "id": "align_mirror",
+          "label": "Align Solar Mirrors",
+          "roll": { "kind": "phi_d20", "tags": ["tech", "ritual"] },
+          "outcomes": {
+            "crit_success": {
+              "effects": [
+                { "type": "xp", "value": 80 },
+                { "type": "flag", "id": "mirror_overcharge", "value": true }
+              ],
+              "narration": "The mirrors flare brilliantly, overcharging the solar engine."
+            },
+            "success": {
+              "effects": [
+                { "type": "xp", "value": 50 }
+              ],
+              "narration": "You lock the mirrors in place and stabilize the engine."
+            },
+            "fail": {
+              "effects": [
+                { "type": "focus", "op": "-", "value": 2 }
+              ],
+              "narration": "The mirror slips, scattering heat across the plaza."
+            }
+          }
+        },
+        {
+          "id": "repel_raid",
+          "label": "Repel Prismatic Raiders",
+          "roll": { "kind": "phi_d20", "tags": ["martial", "burst"] },
+          "outcomes": {
+            "success": {
+              "effects": [
+                { "type": "xp", "value": 45 },
+                { "type": "coins", "value": 70 }
+              ],
+              "narration": "You fend off the raiders, scattering prism shards you quickly collect."
+            },
+            "fail": {
+              "effects": [
+                { "type": "hp", "op": "-", "value": 6 }
+              ],
+              "narration": "The raiders nick the engine, causing a flare backlash."
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "limited_rewards": {
+    "first_clear": [
+      { "type": "item", "id": "solstice_aegis" },
+      { "type": "flag", "id": "solar_engine_defense", "value": true }
+    ],
+    "weekly": [
+      { "type": "coins", "value": 120 },
+      { "type": "xp", "value": 60 }
+    ]
+  }
+}

--- a/content/seasons/summer_solstice/scenes/scene_SS-2.json
+++ b/content/seasons/summer_solstice/scenes/scene_SS-2.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "1.0",
+  "content_id": "seasons/summer_solstice",
+  "book_id": "solstice_radiance",
+  "scene_id": "SS-2",
+  "title": "Aurora Archive Expedition",
+  "narration": "During the solstice, the aurora archives descend into the lower vault. Teams dive into light tunnels to recover prismatic data caches while avoiding heat surges and temporal loops.",
+  "rounds": [
+    {
+      "round_id": "SS-2-R1",
+      "description": "Navigate the light tunnels and secure aurora caches.",
+      "actions": [
+        {
+          "id": "map_tunnels",
+          "label": "Map the Light Tunnels",
+          "roll": { "kind": "phi_d20", "tags": ["analysis", "ritual"] },
+          "outcomes": {
+            "success": {
+              "effects": [
+                { "type": "xp", "value": 55 },
+                { "type": "flag", "id": "tunnels_mapped", "value": true }
+              ],
+              "narration": "You chart a safe route through the aurora currents."
+            },
+            "fail": {
+              "effects": [
+                { "type": "focus", "op": "-", "value": 2 }
+              ],
+              "narration": "The currents scramble your readings."
+            }
+          }
+        },
+        {
+          "id": "capture_cache",
+          "label": "Capture Prismatic Cache",
+          "requirements": { "flags_all": ["tunnels_mapped"] },
+          "roll": { "kind": "phi_d20", "tags": ["agility", "collection"] },
+          "outcomes": {
+            "crit_success": {
+              "effects": [
+                { "type": "item", "id": "aurora_cache" },
+                { "type": "xp", "value": 85 }
+              ],
+              "narration": "You snag a radiant cache containing solstice-only loot."
+            },
+            "success": {
+              "effects": [
+                { "type": "xp", "value": 55 }
+              ],
+              "narration": "The cache dissolves into your storage crystals."
+            },
+            "fail": {
+              "effects": [
+                { "type": "hp", "op": "-", "value": 4 }
+              ],
+              "narration": "You clip a temporal loop and get scorched."
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "limited_rewards": {
+    "first_clear": [
+      { "type": "item", "id": "aurora_cache" },
+      { "type": "flag", "id": "solstice_explorer", "value": true }
+    ],
+    "daily": [
+      { "type": "xp", "value": 40 },
+      { "type": "coins", "value": 80 }
+    ]
+  }
+}

--- a/src/analytics/metrics.ts
+++ b/src/analytics/metrics.ts
@@ -1,0 +1,71 @@
+export interface SceneCompletionMetric {
+  scene: string;
+  outcome: string;
+  party: string[];
+  timestamp: number;
+}
+
+export interface ItemUsageMetric {
+  item: string;
+  effectiveness: number;
+  timestamp: number;
+}
+
+export interface RetentionMetric {
+  cohort: string;
+  retained: number;
+  sample: number;
+  timestamp: number;
+}
+
+export interface BalanceReport {
+  scenes_played: Record<string, number>;
+  average_effectiveness: Record<string, number>;
+  retention_rates: Record<string, number>;
+}
+
+export class MetricsCollector {
+  private sceneCompletions: SceneCompletionMetric[] = [];
+  private itemUsage: ItemUsageMetric[] = [];
+  private retention: RetentionMetric[] = [];
+
+  trackSceneCompletion(scene: string, outcome: string, party: string[]): void {
+    this.sceneCompletions.push({ scene, outcome, party, timestamp: Date.now() });
+  }
+
+  trackItemUsage(item: string, effectiveness: number): void {
+    this.itemUsage.push({ item, effectiveness, timestamp: Date.now() });
+  }
+
+  trackPlayerRetention(cohort: string, retained = 0, sample = 0): void {
+    this.retention.push({ cohort, retained, sample, timestamp: Date.now() });
+  }
+
+  generateBalanceReport(): BalanceReport {
+    const scenes_played: Record<string, number> = {};
+    const average_effectiveness: Record<string, number> = {};
+    const effectivenessCounts: Record<string, number> = {};
+    const retention_rates: Record<string, number> = {};
+
+    for (const completion of this.sceneCompletions) {
+      scenes_played[completion.scene] = (scenes_played[completion.scene] ?? 0) + 1;
+    }
+
+    for (const usage of this.itemUsage) {
+      average_effectiveness[usage.item] = (average_effectiveness[usage.item] ?? 0) + usage.effectiveness;
+      effectivenessCounts[usage.item] = (effectivenessCounts[usage.item] ?? 0) + 1;
+    }
+
+    for (const item of Object.keys(average_effectiveness)) {
+      average_effectiveness[item] = average_effectiveness[item] / (effectivenessCounts[item] ?? 1);
+    }
+
+    for (const cohortMetric of this.retention) {
+      if (cohortMetric.sample > 0) {
+        retention_rates[cohortMetric.cohort] = cohortMetric.retained / cohortMetric.sample;
+      }
+    }
+
+    return { scenes_played, average_effectiveness, retention_rates };
+  }
+}

--- a/src/engine/orchestrator.ts
+++ b/src/engine/orchestrator.ts
@@ -396,7 +396,6 @@ export function handleAction(
   worldEventManager.recordActionImpact(worldContexts, {
     serverId: run.guild_id,
     userId: user_id,
-    userId,
     tags,
     rollKind: roll.kind,
     coinsDelta: state._coins[user_id] ?? 0,

--- a/src/events/worldEvents.ts
+++ b/src/events/worldEvents.ts
@@ -329,8 +329,8 @@ export const WORLD_EVENTS: WorldEvent[] = [
 
 class WorldEventManager {
   private readonly activeEvents = new Map<string, WorldEventInstance>();
-  private readonly timers = new Map<string, NodeJS.Timeout>();
-  private triggerInterval?: NodeJS.Timeout;
+  private readonly timers = new Map<string, ReturnType<typeof setTimeout>>();
+  private triggerInterval?: ReturnType<typeof setInterval>;
   private initialized = false;
 
   initialize(): void {

--- a/src/pvp/arenas.ts
+++ b/src/pvp/arenas.ts
@@ -1,0 +1,79 @@
+export type ArenaMode = 'capture_the_ledger' | 'control' | 'elimination';
+
+export interface ArenaObjective {
+  id: string;
+  description: string;
+  scoring: 'progressive' | 'tick' | 'capture';
+}
+
+export interface ArenaDefinition {
+  mode: ArenaMode;
+  teams: number;
+  max_players: number;
+  objectives: string[];
+  rotation?: 'ranked' | 'seasonal' | 'skirmish';
+  modifiers?: string[];
+  rewards?: {
+    coins?: number;
+    xp?: number;
+    items?: string[];
+  };
+}
+
+export const ARENAS: Record<string, ArenaDefinition> = {
+  consensus_colosseum: {
+    mode: 'capture_the_ledger',
+    teams: 2,
+    max_players: 10,
+    objectives: ['central_node', 'alpha_terminal', 'beta_terminal'],
+    rotation: 'ranked',
+    modifiers: ['ledger_flux'],
+    rewards: { coins: 200, xp: 80, items: ['colosseum_banner'] }
+  },
+  vault_spires: {
+    mode: 'control',
+    teams: 3,
+    max_players: 12,
+    objectives: ['spire_a', 'spire_b', 'spire_c'],
+    rotation: 'seasonal',
+    modifiers: ['elevated_platforms'],
+    rewards: { coins: 180, xp: 65 }
+  }
+};
+
+export const ARENA_OBJECTIVES: Record<string, ArenaObjective> = {
+  central_node: {
+    id: 'central_node',
+    description: 'Capture and hold the core ledger node to score consensus ticks.',
+    scoring: 'tick'
+  },
+  alpha_terminal: {
+    id: 'alpha_terminal',
+    description: 'A flanking terminal providing speed boosts when secured.',
+    scoring: 'progressive'
+  },
+  beta_terminal: {
+    id: 'beta_terminal',
+    description: 'Defensive terminal that deploys shield drones to the team in control.',
+    scoring: 'progressive'
+  },
+  spire_a: {
+    id: 'spire_a',
+    description: 'Upper spire rewarding aerial dominance.',
+    scoring: 'capture'
+  },
+  spire_b: {
+    id: 'spire_b',
+    description: 'Mid spire generating focus pulses.',
+    scoring: 'tick'
+  },
+  spire_c: {
+    id: 'spire_c',
+    description: 'Lower spire granting defensive wards.',
+    scoring: 'tick'
+  }
+};
+
+export function getArenaByMode(mode: ArenaMode): ArenaDefinition[] {
+  return Object.values(ARENAS).filter((arena) => arena.mode === mode);
+}

--- a/src/systems/achievements.ts
+++ b/src/systems/achievements.ts
@@ -1,0 +1,197 @@
+export interface Achievement {
+  id: string;
+  name: string;
+  description: string;
+  points: number;
+  category: 'story' | 'combat' | 'exploration' | 'social' | 'seasonal' | 'collection';
+  hidden?: boolean;
+  requirements?: {
+    scenes_completed?: string[];
+    items_collected?: string[];
+    stat_thresholds?: Record<string, number>;
+    tags?: string[];
+  };
+  rewards?: {
+    title?: string;
+    cosmetics?: string[];
+    items?: string[];
+  };
+}
+
+export const ACHIEVEMENTS: Record<string, Achievement> = {
+  first_steps: {
+    id: 'first_steps',
+    name: 'First Steps',
+    description: 'Complete Scene 1.1',
+    points: 10,
+    category: 'story',
+    requirements: { scenes_completed: ['1.1'] }
+  },
+  gremlin_whisperer: {
+    id: 'gremlin_whisperer',
+    name: 'Gremlin Whisperer',
+    description: 'Befriend 10 gremlins',
+    points: 25,
+    category: 'social',
+    requirements: { stat_thresholds: { gremlins_befriended: 10 } },
+    rewards: { title: 'Gremlin Whisperer' }
+  },
+  perfect_run: {
+    id: 'perfect_run',
+    name: 'Flawless Victory',
+    description: 'Complete a scene with no damage',
+    points: 50,
+    category: 'combat',
+    requirements: { tags: ['no_damage'] }
+  },
+  consensus_keeper: {
+    id: 'consensus_keeper',
+    name: 'Consensus Keeper',
+    description: 'Stabilize five consensus fractures in raids.',
+    points: 30,
+    category: 'combat',
+    requirements: { stat_thresholds: { fractures_stabilized: 5 } },
+    rewards: { cosmetics: ['fracture_stabilizer_trail'] }
+  },
+  archivist: {
+    id: 'archivist',
+    name: 'Vault Archivist',
+    description: 'Collect 50 lore fragments.',
+    points: 40,
+    category: 'collection',
+    requirements: { stat_thresholds: { lore_fragments: 50 } }
+  },
+  seasonal_spirit: {
+    id: 'seasonal_spirit',
+    name: 'Seasonal Spirit',
+    description: 'Complete all seasonal event scenes during an active festival.',
+    points: 60,
+    category: 'seasonal',
+    requirements: { scenes_completed: ['halloween2025:all', 'summer_solstice:all'] }
+  },
+  raid_vanguard: {
+    id: 'raid_vanguard',
+    name: 'Raid Vanguard',
+    description: 'Defeat the Stone Custodian within 12 rounds.',
+    points: 80,
+    category: 'combat',
+    requirements: { scenes_completed: ['boss.custodian'], stat_thresholds: { rounds_elapsed: 12 } },
+    rewards: { items: ['custodian_seal'] }
+  },
+  legendary_crafter: {
+    id: 'legendary_crafter',
+    name: 'Legendary Crafter',
+    description: 'Craft your first legendary item.',
+    points: 75,
+    category: 'collection',
+    requirements: { tags: ['legendary_crafted'] }
+  },
+  guild_founder: {
+    id: 'guild_founder',
+    name: 'Guild Founder',
+    description: 'Establish a new guild and claim territory.',
+    points: 55,
+    category: 'social',
+    requirements: { tags: ['guild_created'], scenes_completed: ['territory.claim'] }
+  },
+  voice_maestro: {
+    id: 'voice_maestro',
+    name: 'Voice Maestro',
+    description: 'Complete a narrated run using the Voice RPG session tools.',
+    points: 35,
+    category: 'social',
+    requirements: { tags: ['voice_session_clear'] }
+  },
+  telemetry_analyst: {
+    id: 'telemetry_analyst',
+    name: 'Telemetry Analyst',
+    description: 'Generate a balance report from the analytics dashboard.',
+    points: 20,
+    category: 'exploration',
+    requirements: { tags: ['balance_report_generated'] }
+  },
+  seasonal_speedrunner: {
+    id: 'seasonal_speedrunner',
+    name: 'Seasonal Speedrunner',
+    description: 'Finish a seasonal scene in under three rounds.',
+    points: 45,
+    category: 'seasonal',
+    requirements: { tags: ['seasonal_fast_clear'] }
+  },
+  perfect_collection: {
+    id: 'perfect_collection',
+    name: 'Complete Collection',
+    description: 'Collect all cards from the Genesis set.',
+    points: 120,
+    category: 'collection',
+    hidden: true,
+    requirements: { tags: ['genesis_cards_complete'] }
+  },
+  arena_champion: {
+    id: 'arena_champion',
+    name: 'Consensus Colosseum Champion',
+    description: 'Win ten matches in the Consensus Colosseum arena.',
+    points: 65,
+    category: 'combat',
+    requirements: { stat_thresholds: { arena_wins: 10 } }
+  },
+  pet_whisperer: {
+    id: 'pet_whisperer',
+    name: 'Companion Whisperer',
+    description: 'Level a companion to stage three.',
+    points: 30,
+    category: 'exploration',
+    requirements: { stat_thresholds: { companion_stage_three: 1 } }
+  },
+  expeditionary: {
+    id: 'expeditionary',
+    name: 'Expeditionary Ledger',
+    description: 'Complete 25 random encounters.',
+    points: 30,
+    category: 'exploration',
+    requirements: { stat_thresholds: { random_encounters_cleared: 25 } }
+  },
+  revivalist: {
+    id: 'revivalist',
+    name: 'Ledger Revivalist',
+    description: 'Restore a wiped raid using the state recovery system.',
+    points: 55,
+    category: 'story',
+    requirements: { tags: ['state_recovery_success'] }
+  },
+  scholar_of_voices: {
+    id: 'scholar_of_voices',
+    name: 'Scholar of Voices',
+    description: 'Unlock every ambient track in the voice system.',
+    points: 25,
+    category: 'exploration',
+    requirements: { stat_thresholds: { voice_tracks_unlocked: 8 } }
+  },
+  marketplace_maven: {
+    id: 'marketplace_maven',
+    name: 'Marketplace Maven',
+    description: 'Trade with the wandering merchant five times.',
+    points: 30,
+    category: 'social',
+    requirements: { stat_thresholds: { merchant_trades: 5 } }
+  },
+  gremlin_librarian: {
+    id: 'gremlin_librarian',
+    name: 'Gremlin Librarian',
+    description: 'Unlock every lore entry in the Hall of Records.',
+    points: 90,
+    category: 'story',
+    hidden: true,
+    requirements: { tags: ['records_completed'] }
+  },
+  solstice_guardian: {
+    id: 'solstice_guardian',
+    name: 'Solstice Guardian',
+    description: 'Protect the solar engine during the Summer Solstice event.',
+    points: 45,
+    category: 'seasonal',
+    requirements: { scenes_completed: ['summer_solstice:solar_engine_defense'] }
+  }
+};
+
+export const ACHIEVEMENT_LIST = Object.values(ACHIEVEMENTS);

--- a/src/systems/companions.ts
+++ b/src/systems/companions.ts
@@ -1,0 +1,79 @@
+export type CompanionType = 'gremlin' | 'construct' | 'spirit';
+
+export interface CompanionAbility {
+  id: string;
+  name: string;
+  description: string;
+  cooldown_rounds: number;
+  tags: string[];
+}
+
+export interface Companion {
+  id: string;
+  type: CompanionType;
+  level: number;
+  abilities: CompanionAbility[];
+  evolution_stage: number;
+  bonding_level: number;
+}
+
+export const COMPANION_ABILITY_LIBRARY: Record<string, CompanionAbility> = {
+  gremlin_mischief: {
+    id: 'gremlin_mischief',
+    name: 'Gremlin Mischief',
+    description: 'Distracts enemies and lowers their focus for one round.',
+    cooldown_rounds: 3,
+    tags: ['debuff', 'support']
+  },
+  construct_aegis: {
+    id: 'construct_aegis',
+    name: 'Construct Aegis',
+    description: 'Projects a shield that absorbs damage equal to your companion level x 5.',
+    cooldown_rounds: 4,
+    tags: ['defense']
+  },
+  spirit_echo: {
+    id: 'spirit_echo',
+    name: 'Spirit Echo',
+    description: 'Amplifies the next ritual roll granting advantage.',
+    cooldown_rounds: 2,
+    tags: ['buff', 'ritual']
+  }
+};
+
+export const COMPANION_REGISTRY: Record<string, Companion> = {
+  ember_tail: {
+    id: 'ember_tail',
+    type: 'gremlin',
+    level: 1,
+    evolution_stage: 1,
+    bonding_level: 0,
+    abilities: [COMPANION_ABILITY_LIBRARY.gremlin_mischief]
+  },
+  wardforge: {
+    id: 'wardforge',
+    type: 'construct',
+    level: 1,
+    evolution_stage: 1,
+    bonding_level: 0,
+    abilities: [COMPANION_ABILITY_LIBRARY.construct_aegis]
+  },
+  aurora_wisp: {
+    id: 'aurora_wisp',
+    type: 'spirit',
+    level: 1,
+    evolution_stage: 1,
+    bonding_level: 0,
+    abilities: [COMPANION_ABILITY_LIBRARY.spirit_echo]
+  }
+};
+
+export function evolveCompanion(companion: Companion): Companion {
+  const upgraded: Companion = {
+    ...companion,
+    evolution_stage: companion.evolution_stage + 1,
+    level: companion.level + 1,
+    bonding_level: Math.min(100, companion.bonding_level + 10)
+  };
+  return upgraded;
+}

--- a/src/systems/randomEncounters.ts
+++ b/src/systems/randomEncounters.ts
@@ -1,0 +1,104 @@
+export interface EncounterRequirement {
+  min_scene?: string;
+  max_scene?: string;
+  tags_all?: string[];
+  tags_any?: string[];
+}
+
+export interface EncounterReward {
+  shop_discount?: number;
+  rare_items?: boolean;
+  items?: string[];
+  buffs?: string[];
+  xp?: number;
+  coins?: number;
+}
+
+export interface RandomEncounter {
+  id: string;
+  chance: number;
+  requirements?: EncounterRequirement;
+  combat?: boolean;
+  scaling?: 'party_level' | 'scene_tier' | 'fixed';
+  duration_rounds?: number;
+  rewards?: EncounterReward;
+  description?: string;
+}
+
+export const RANDOM_ENCOUNTERS: RandomEncounter[] = [
+  {
+    id: 'wandering_merchant',
+    chance: 0.05,
+    requirements: { min_scene: '2.1' },
+    rewards: { shop_discount: 20, rare_items: true },
+    description: 'A merchant drifting through the ledger corridors offers rare wares in exchange for harmony tokens.'
+  },
+  {
+    id: 'gremlin_ambush',
+    chance: 0.1,
+    combat: true,
+    scaling: 'party_level',
+    description: 'A band of gremlins leaps from the rafters demanding proof of strength before letting the party proceed.'
+  },
+  {
+    id: 'lost_archivist',
+    chance: 0.08,
+    requirements: { tags_any: ['lorehunter'] },
+    rewards: { items: ['archival_key'], xp: 45 },
+    description: 'An archivist trapped between shelves needs help finding the exit, rewarding the party with a spare key.'
+  },
+  {
+    id: 'consensus_echo',
+    chance: 0.06,
+    requirements: { min_scene: '3.4', tags_all: ['ritualist'] },
+    scaling: 'scene_tier',
+    rewards: { buffs: ['echo_of_precision'], xp: 60 },
+    description: 'A lingering echo of consensus offers a ritual challenge that grants a precision buff when solved.'
+  },
+  {
+    id: 'ledger_glitch',
+    chance: 0.03,
+    combat: false,
+    scaling: 'fixed',
+    rewards: { coins: 120 },
+    description: 'A ledger glitch spills coins into the corridor. Recover as much as possible before the auditors arrive.'
+  },
+  {
+    id: 'custodian_probe',
+    chance: 0.02,
+    combat: true,
+    scaling: 'scene_tier',
+    requirements: { min_scene: 'boss.custodian' },
+    rewards: { items: ['custodian_relic'], xp: 120 },
+    description: 'A fragment of the Stone Custodian scans the area, challenging the party to prove they deserve its relic.'
+  }
+];
+
+export function rollEncounter(available: RandomEncounter[], rng: () => number): RandomEncounter | null {
+  const roll = rng();
+  let cumulative = 0;
+  for (const encounter of available) {
+    cumulative += encounter.chance;
+    if (roll <= cumulative) {
+      return encounter;
+    }
+  }
+  return null;
+}
+
+export function filterEncounters(options: {
+  encounters?: RandomEncounter[];
+  scene?: string;
+  tags?: string[];
+}): RandomEncounter[] {
+  const { encounters = RANDOM_ENCOUNTERS, scene, tags = [] } = options;
+  return encounters.filter((encounter) => {
+    const req = encounter.requirements;
+    if (!req) return true;
+    if (req.min_scene && scene && scene < req.min_scene) return false;
+    if (req.max_scene && scene && scene > req.max_scene) return false;
+    if (req.tags_all && !req.tags_all.every((tag) => tags.includes(tag))) return false;
+    if (req.tags_any && !req.tags_any.some((tag) => tags.includes(tag))) return false;
+    return true;
+  });
+}

--- a/src/systems/stateRecovery.ts
+++ b/src/systems/stateRecovery.ts
@@ -1,0 +1,67 @@
+import type { Checkpoint, RunId } from '../models.js';
+
+export interface ValidationResult {
+  ok: boolean;
+  issues: string[];
+}
+
+export interface CheckpointRecord {
+  checkpoint: Checkpoint;
+  storedAt: number;
+}
+
+export class StateRecoverySystem {
+  private checkpoints = new Map<string, CheckpointRecord>();
+
+  createCheckpoint(runId: string, checkpoint: Partial<Checkpoint> = {}): Checkpoint {
+    const nextCheckpoint: Checkpoint = {
+      run_id: runId as RunId,
+      guild_id: checkpoint.guild_id ?? 'unknown',
+      channel_id: checkpoint.channel_id ?? 'unknown',
+      party_id: checkpoint.party_id ?? 'unknown',
+      content_id: checkpoint.content_id ?? 'genesis',
+      content_version: checkpoint.content_version ?? '1.0',
+      scene_id: checkpoint.scene_id ?? '1.1',
+      round_id: checkpoint.round_id ?? 'R1',
+      micro_ix: checkpoint.micro_ix ?? 0,
+      rng_seed: checkpoint.rng_seed ?? 'seed',
+      flags_json: checkpoint.flags_json ?? {},
+      sleight_score: checkpoint.sleight_score ?? 0,
+      updated_at: Date.now()
+    };
+    const record: CheckpointRecord = {
+      checkpoint: nextCheckpoint,
+      storedAt: Date.now()
+    };
+    this.checkpoints.set(nextCheckpoint.run_id, record);
+    return record.checkpoint;
+  }
+
+  rollbackToCheckpoint(checkpointId: string): Checkpoint | null {
+    const record = this.checkpoints.get(checkpointId as RunId);
+    if (!record) return null;
+    return { ...record.checkpoint, updated_at: Date.now() };
+  }
+
+  validateStateIntegrity(runId: string): ValidationResult {
+    const record = this.checkpoints.get(runId);
+    if (!record) {
+      return { ok: false, issues: ['missing_checkpoint'] };
+    }
+
+    const issues: string[] = [];
+    const { checkpoint } = record;
+
+    if (!checkpoint.flags_json) {
+      issues.push('missing_flags');
+    }
+    if (checkpoint.sleight_score < 0) {
+      issues.push('invalid_sleight_score');
+    }
+    if (!checkpoint.scene_id) {
+      issues.push('missing_scene');
+    }
+
+    return { ok: issues.length === 0, issues };
+  }
+}

--- a/src/systems/territory.ts
+++ b/src/systems/territory.ts
@@ -1,0 +1,114 @@
+export type ResourceNodeType = 'ore' | 'essence' | 'ledger' | 'flora' | 'artifice';
+
+export interface ResourceNode {
+  id: string;
+  type: ResourceNodeType;
+  yield_per_hour: number;
+  capacity: number;
+  contested?: boolean;
+}
+
+export interface Defense {
+  id: string;
+  name: string;
+  level: number;
+  modifiers: {
+    hp_bonus?: number;
+    focus_bonus?: number;
+    damage_reduction?: number;
+    trap_difficulty?: number;
+  };
+  upkeep_cost: number;
+}
+
+export interface Territory {
+  id: string;
+  owner_guild: string;
+  resources: ResourceNode[];
+  defenses: Defense[];
+  conquest_points: number;
+  morale: number;
+  contested_by?: string[];
+}
+
+export class TerritoryManager {
+  private territories = new Map<string, Territory>();
+
+  registerTerritory(territory: Territory): void {
+    this.territories.set(territory.id, territory);
+  }
+
+  listTerritories(): Territory[] {
+    return Array.from(this.territories.values());
+  }
+
+  claimTerritory(territoryId: string, guildId: string): Territory | null {
+    const territory = this.territories.get(territoryId);
+    if (!territory) return null;
+    territory.owner_guild = guildId;
+    territory.conquest_points = 0;
+    territory.morale = 50;
+    territory.contested_by = [];
+    this.territories.set(territoryId, territory);
+    return territory;
+  }
+
+  adjustConquest(territoryId: string, points: number): Territory | null {
+    const territory = this.territories.get(territoryId);
+    if (!territory) return null;
+    territory.conquest_points = Math.max(0, territory.conquest_points + points);
+    territory.morale = Math.min(100, Math.max(0, territory.morale + Math.sign(points) * 5));
+    this.territories.set(territoryId, territory);
+    return territory;
+  }
+
+  addContestant(territoryId: string, guildId: string): void {
+    const territory = this.territories.get(territoryId);
+    if (!territory) return;
+    if (!territory.contested_by) territory.contested_by = [];
+    if (!territory.contested_by.includes(guildId)) {
+      territory.contested_by.push(guildId);
+    }
+  }
+}
+
+export const DEFAULT_TERRITORIES: Territory[] = [
+  {
+    id: 'ledger_bastion',
+    owner_guild: 'neutral',
+    conquest_points: 0,
+    morale: 50,
+    resources: [
+      { id: 'ancient_ore', type: 'ore', yield_per_hour: 24, capacity: 480 },
+      { id: 'ledger_bloom', type: 'flora', yield_per_hour: 12, capacity: 240 }
+    ],
+    defenses: [
+      {
+        id: 'resonant_barrier',
+        name: 'Resonant Barrier',
+        level: 1,
+        modifiers: { damage_reduction: 0.1 },
+        upkeep_cost: 50
+      }
+    ]
+  },
+  {
+    id: 'custodian_watch',
+    owner_guild: 'neutral',
+    conquest_points: 0,
+    morale: 55,
+    resources: [
+      { id: 'custodian_stone', type: 'artifice', yield_per_hour: 6, capacity: 90, contested: true },
+      { id: 'gremlin_essence', type: 'essence', yield_per_hour: 18, capacity: 300 }
+    ],
+    defenses: [
+      {
+        id: 'stone_sentinels',
+        name: 'Stone Sentinels',
+        level: 2,
+        modifiers: { hp_bonus: 150, trap_difficulty: 5 },
+        upkeep_cost: 80
+      }
+    ]
+  }
+];

--- a/src/systems/tournament/tournamentManager.ts
+++ b/src/systems/tournament/tournamentManager.ts
@@ -898,6 +898,18 @@ export class TournamentManager {
        VALUES (?,?,?,?,?)`
     ).run(tournamentId, userId, placement, JSON.stringify(prizes), Date.now());
   }
+
+  getTournament(tournamentId: string) {
+    return this.activeTournaments.get(tournamentId) ?? null;
+  }
+
+  getBrackets(tournamentId: string) {
+    return this.brackets.get(tournamentId) ?? [];
+  }
+
+  getRegistrations(tournamentId: string): Set<string> {
+    return new Set(this.registrations.get(tournamentId) ?? []);
+  }
 }
 
 export const tournamentManager = new TournamentManager();

--- a/src/systems/vault/vaultrooms.ts
+++ b/src/systems/vault/vaultrooms.ts
@@ -1,4 +1,4 @@
-{
+export default {
   "schema_version": "1.0",
   "content_id": "genesis",
   "book_id": "book_1",
@@ -203,4 +203,4 @@
     { "when": "flags.gremlin_whisperer", "goto": "3.3.gremlin_alliance" },
     { "when": "else", "goto": "3.1" }
   ]
-}
+} as const;

--- a/src/testing/contentValidator.ts
+++ b/src/testing/contentValidator.ts
@@ -1,0 +1,62 @@
+import type { SceneDef } from '../models.js';
+
+export interface ValidationIssue {
+  path: string;
+  message: string;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  issues: ValidationIssue[];
+}
+
+export class ContentValidator {
+  validateScene(scene: SceneDef): ValidationResult {
+    const issues: ValidationIssue[] = [];
+
+    scene.rounds.forEach((round, roundIndex) => {
+      if (!round.actions || round.actions.length === 0) {
+        issues.push({ path: `${scene.scene_id}.rounds[${roundIndex}]`, message: 'round has no actions' });
+      }
+
+      round.actions.forEach((action, actionIndex) => {
+        const requiredOutcomes: Array<keyof typeof action.outcomes> = ['success', 'fail'];
+        for (const key of requiredOutcomes) {
+          if (!action.outcomes[key]) {
+            issues.push({
+              path: `${scene.scene_id}.rounds[${roundIndex}].actions[${actionIndex}].outcomes.${String(key)}`,
+              message: 'missing outcome definition'
+            });
+          }
+        }
+
+        for (const [outcomeKey, outcome] of Object.entries(action.outcomes)) {
+          if (!outcome?.effects || outcome.effects.length === 0) {
+            issues.push({
+              path: `${scene.scene_id}.rounds[${roundIndex}].actions[${actionIndex}].outcomes.${outcomeKey}`,
+              message: 'outcome has no effects'
+            });
+          }
+        }
+      });
+    });
+
+    if (scene.arrivals) {
+      scene.arrivals.forEach((arrival, index) => {
+        if (!arrival.goto) {
+          issues.push({ path: `${scene.scene_id}.arrivals[${index}]`, message: 'arrival missing goto reference' });
+        }
+      });
+    }
+
+    if (scene.threshold_rewards) {
+      scene.threshold_rewards.forEach((reward, index) => {
+        if (!reward.rewards || reward.rewards.length === 0) {
+          issues.push({ path: `${scene.scene_id}.threshold_rewards[${index}]`, message: 'reward has no effects' });
+        }
+      });
+    }
+
+    return { ok: issues.length === 0, issues };
+  }
+}

--- a/src/ui/shop.ts
+++ b/src/ui/shop.ts
@@ -112,13 +112,6 @@ function purchasePack(user_id: string, pack: ShopPack) {
   if (pack.cost.coins && coins < pack.cost.coins) throw new Error(`Need ${pack.cost.coins.toLocaleString()} coins.`);
   if (pack.cost.gems && gems < pack.cost.gems) throw new Error(`Need ${pack.cost.gems} gems.`);
 
-
-  const coins = profile.coins ?? 0;
-  const gems = profile.gems ?? 0;
-
-  if (pack.cost.coins && coins < pack.cost.coins) throw new Error(`Need ${pack.cost.coins.toLocaleString()} coins.`);
-  if (pack.cost.gems && gems < pack.cost.gems) throw new Error(`Need ${pack.cost.gems} gems.`);
-
   if (pack.cost.coins) {
     db.prepare('UPDATE profiles SET coins=coins-? WHERE user_id=?').run(pack.cost.coins, user_id);
     db.prepare(

--- a/src/voice/voiceRPG.ts
+++ b/src/voice/voiceRPG.ts
@@ -1,0 +1,45 @@
+import type { SceneDef } from '../models.js';
+
+export interface VoiceChannelLike {
+  id: string;
+}
+
+export interface VoiceChannelAdapter {
+  playNarration(text: string): Promise<void>;
+  playSoundEffect(effect: string): Promise<void>;
+  playMusic(track: string, loop?: boolean): Promise<void>;
+  stopMusic(): Promise<void>;
+}
+
+export class VoiceRPGSession {
+  private soundEffectsEnabled = true;
+  private currentTrack: string | null = null;
+
+  constructor(private readonly adapter: VoiceChannelAdapter) {}
+
+  async startNarration(channel: VoiceChannelLike, scene: SceneDef): Promise<void> {
+    const intro = `Entering scene ${scene.scene_id}: ${scene.title}`;
+    await this.adapter.playNarration(intro);
+    await this.adapter.playNarration(scene.narration);
+    if (this.soundEffectsEnabled) {
+      await this.adapter.playSoundEffect('scene_transition');
+    }
+    void channel; // touch parameter to satisfy lint/tsconfig even if adapter handles audio only
+  }
+
+  enableSoundEffects(enabled: boolean): void {
+    this.soundEffectsEnabled = enabled;
+  }
+
+  async playAmbientMusic(track: string, loop = true): Promise<void> {
+    if (this.currentTrack === track) return;
+    if (this.currentTrack) {
+      await this.adapter.stopMusic();
+    }
+    this.currentTrack = track;
+    await this.adapter.playMusic(track, loop);
+    if (this.soundEffectsEnabled) {
+      await this.adapter.playSoundEffect('music_fade_in');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Stone Custodian raid scene, quest chapter, seasonal scenes, and crafting recipes
- expand registries with hundreds of items/cards and add supporting systems for achievements, encounters, guild territory, companions, analytics, recovery, voice, and validation
- refresh tournament and vault logic to surface brackets, eligibility, and public vault metadata while fixing shop calculations
- bump the genesis manifest version for the new raid content and switch world event timers to environment-safe typings
- rename the Stone Custodian scene JSON to follow scene_* naming so content loaders can access it

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5b61f6944833083030f66a2e518f9