### PR TITLE
Restore synchronous database writes

### DIFF
--- a/src/persistence/db.ts
+++ b/src/persistence/db.ts
@@ -6,128 +6,33 @@ import { CFG } from '../config.js';
 const dir = path.dirname(CFG.dbPath);
 if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
 
-class PerformanceMonitor {
-  private writeCount = 0;
-  private startTime = Date.now();
-  private readonly interval: NodeJS.Timer;
-
-  constructor(intervalMs = 30_000) {
-    this.interval = setInterval(() => this.logStats(), intervalMs);
-    if (typeof this.interval.unref === 'function') {
-      this.interval.unref();
-    }
-  }
-
-  recordWrite() {
-    this.writeCount++;
-  }
-
-  private logStats() {
-    const elapsed = Math.max((Date.now() - this.startTime) / 1000, 1);
-    const writesPerSecond = this.writeCount / elapsed;
-    console.log(`Database: ${writesPerSecond.toFixed(1)} writes/sec`);
-    this.writeCount = 0;
-    this.startTime = Date.now();
-  }
-}
-
-type WriteOperation = () => void;
-
 class DatabaseManager {
-  private db: Database;
-  private writeQueue: WriteOperation[] = [];
-  private processing = false;
-  private readonly monitor: PerformanceMonitor;
-  private readonly interval: NodeJS.Timer;
+  private readonly db: Database;
+  private closed = false;
 
   constructor(dbPath: string) {
     this.db = new Database(dbPath);
     this.db.pragma('journal_mode = WAL');
     this.db.pragma('synchronous = NORMAL');
     this.db.pragma('foreign_keys = ON');
-
-    this.monitor = new PerformanceMonitor();
-    this.interval = setInterval(() => this.processWrites(), 50);
-    if (typeof this.interval.unref === 'function') {
-      this.interval.unref();
-    }
   }
 
   prepare(query: string) {
-    const stmt = this.db.prepare(query);
-    return {
-      get: (...params: any[]) => stmt.get(...params),
-      all: (...params: any[]) => stmt.all(...params),
-      run: (...params: any[]) =>
-        this.queueWrite(() => {
-          stmt.run(...params);
-          this.monitor.recordWrite();
-        }),
-    };
+    return this.db.prepare(query);
   }
 
   exec(sql: string) {
     return this.db.exec(sql);
   }
 
-  private queueWrite(operation: WriteOperation) {
-    this.writeQueue.push(operation);
-    if (this.writeQueue.length >= 100) {
-      this.processWrites();
-    }
+  close() {
+    if (this.closed) return;
+    this.closed = true;
+    this.db.close();
   }
 
-  private processWrites(force = false) {
-    if (this.processing) return;
-    if (!force && this.writeQueue.length === 0) return;
-
-    this.processing = true;
-
-    try {
-      while (this.writeQueue.length > 0) {
-        const operations = this.writeQueue.splice(0, 100);
-        const transaction = this.db.transaction((ops: WriteOperation[]) => {
-          for (const op of ops) {
-            op();
-          }
-        });
-        transaction(operations);
-      }
-    } catch (error) {
-      console.error('Batch write failed:', error);
-    } finally {
-      this.processing = false;
-
-      if (force && this.writeQueue.length > 0) {
-        this.processWrites(true);
-      }
-    }
-  }
-
-  async flush(): Promise<void> {
-    return new Promise((resolve) => {
-      const check = () => {
-        if (this.processing) {
-          setTimeout(check, 10);
-          return;
-        }
-
-        if (this.writeQueue.length === 0) {
-          resolve();
-          return;
-        }
-
-        this.processWrites(true);
-
-        if (this.writeQueue.length === 0) {
-          resolve();
-        } else {
-          setTimeout(check, 10);
-        }
-      };
-
-      check();
-    });
+  get connection() {
+    return this.db;
   }
 }
 
@@ -241,17 +146,16 @@ if (process.argv.includes('--reset')) {
 
 const handleShutdown = (signal: NodeJS.Signals) => {
   console.log(`Graceful shutdown (${signal})...`);
-  db
-    .flush()
-    .catch((error) => {
-      console.error('Error flushing database queue during shutdown:', error);
-    })
-    .finally(() => {
-      const timer = setTimeout(() => process.exit(0), 1000);
-      if (typeof timer.unref === 'function') {
-        timer.unref();
-      }
-    });
+  try {
+    db.close();
+  } catch (error) {
+    console.error('Error closing database during shutdown:', error);
+  } finally {
+    const timer = setTimeout(() => process.exit(0), 1000);
+    if (typeof timer.unref === 'function') {
+      timer.unref();
+    }
+  }
 };
 
 process.once('SIGTERM', () => handleShutdown('SIGTERM'));

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -10,6 +10,7 @@ declare module 'better-sqlite3' {
     transaction<T extends (...args: any[]) => any>(fn: T): T;
     pragma(statement: string): any;
     exec(sql: string): void;
+    close(): void;
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the asynchronous batching queue from the database manager so writes execute immediately and return native results
- expose the underlying better-sqlite3 connection and add a close() helper for graceful shutdown
- extend the ambient typings to include Database.close so shutdown handling can compile

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d747fdebd483309ff7c6997f67655d